### PR TITLE
Fix Prometheus remote write receiver for OTLP metrics pipeline

### DIFF
--- a/manifests/030-prometheus-config.yaml
+++ b/manifests/030-prometheus-config.yaml
@@ -46,6 +46,11 @@ server:
     limits:
       cpu: 500m
       memory: 1Gi
+  # Enable remote write receiver for OTLP Collector metrics ingestion
+  # This flag allows Prometheus to accept metrics via the /api/v1/write endpoint
+  # Required for: OpenTelemetry Collector → Prometheus metrics pipeline
+  extraArgs:
+    web.enable-remote-write-receiver: ""
 
 # Alertmanager configuration
 alertmanager:


### PR DESCRIPTION
## Summary
Fixes critical missing configuration in Prometheus that prevented metrics from being accepted via the OTLP Collector's remote write API.

## Problem
Prometheus was returning 404 errors with message "remote write receiver needs to be enabled" when the OTLP Collector attempted to send metrics. The `--web.enable-remote-write-receiver` flag was missing from Prometheus configuration.

## Solution
Added `extraArgs.web.enable-remote-write-receiver` to Prometheus server configuration in `manifests/030-prometheus-config.yaml`.

## Changes
- **manifests/030-prometheus-config.yaml**: Added `extraArgs` section with `web.enable-remote-write-receiver` flag
- **doc/package-monitoring-prometheus.md**: Updated documentation with correct configuration and troubleshooting guidance

## Testing
✅ Prometheus upgraded successfully (revision 5)
✅ Remote write endpoint responding with 204 (success)
✅ OTLP Collector logs show successful metric exports
✅ Prometheus query API confirms metrics are stored
✅ All monitoring pods running healthy

## Impact
- Fixes the complete observability pipeline: Applications → OTLP Collector → Prometheus → Grafana
- Metrics from OTLP instrumented applications now properly stored in Prometheus
- Enables full observability stack functionality for metrics, logs, and traces

## Verification Commands
```bash
# Verify flag is enabled
kubectl get pod -n monitoring -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server \
  -o jsonpath='{.items[0].spec.containers[?(@.name=="prometheus-server")].args}' | jq -r '.[]' | grep "remote-write"

# Test remote write endpoint
kubectl run curl-test --image=curlimages/curl --rm -i --restart=Never -n monitoring -- \
  curl -v -X POST http://prometheus-server.monitoring.svc.cluster.local:80/api/v1/write

# Check OTLP Collector logs
kubectl logs -n monitoring -l app.kubernetes.io/name=opentelemetry-collector --tail=50 | grep prometheus
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Prometheus remote write receiver for OTLP metrics and update documentation with configuration and troubleshooting steps.
> 
> - **Prometheus Configuration**:
>   - Add `server.extraArgs` with `web.enable-remote-write-receiver: ""` in `manifests/030-prometheus-config.yaml` to accept metrics at `/api/v1/write`.
> - **Documentation** (`doc/package-monitoring-prometheus.md`):
>   - Include the `server.extraArgs.web.enable-remote-write-receiver` setting in the config example.
>   - Add troubleshooting guidance and commands to verify the flag and remote write endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81f43900017d3ca95f6de7ece5b98376bc984637. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->