### PR TITLE
Add MkDocs with Material theme for documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+# GitHub Actions workflow to build and deploy MkDocs to GitHub Pages
+# Triggers on pushes to main branch when docs/ or mkdocs.yml changes
+
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git info
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-mkdocs-material
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install MkDocs and Material theme
+        run: |
+          pip install mkdocs-material
+          pip install mkdocs-tags-plugin
+
+      - name: Build and deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,145 @@
+# Urbalurba Infrastructure
+
+**Complete datacenter on your laptop** - A zero-friction developer platform that provides production-grade infrastructure locally.
+
+## What is This?
+
+Urbalurba Infrastructure is a comprehensive Kubernetes-based platform that runs the same configuration in development and production:
+
+- **Local Development**: Run everything on your laptop with Rancher Desktop
+- **Production Ready**: Deploy the exact same configuration to Azure AKS or any Kubernetes cluster
+- **Zero Cloud Dependencies**: Develop and test without internet connectivity
+- **Privacy-First AI**: Run LLMs locally on your own data
+
+## Run Anywhere
+
+| Platform | Architecture | Use Case |
+|----------|--------------|----------|
+| **Laptop** (Rancher Desktop) | ARM64 / x86_64 | Local development |
+| **Azure AKS** | x86_64 | Production cloud |
+| **Ubuntu Server** | ARM64 / x86_64 | Self-hosted production |
+| **Raspberry Pi** | ARM64 | Edge computing, home lab |
+
+!!! tip "One codebase. Any platform. Same result."
+    Once your Kubernetes cluster is running, everything else is identical regardless of where it runs. Same manifests, same Ansible playbooks, same services, same URLs.
+
+## Services Included
+
+### Core Infrastructure
+- **Kubernetes** - Container orchestration via Rancher Desktop
+- **Traefik** - Ingress controller with automatic TLS
+- **Nginx** - Web server
+
+### Observability Stack
+- **Prometheus** - Metrics collection
+- **Grafana** - Visualization and dashboards
+- **Loki** - Log aggregation
+- **Tempo** - Distributed tracing
+- **OpenTelemetry Collector** - Telemetry pipeline
+
+### Databases
+- **PostgreSQL** - Primary relational database
+- **MySQL** - Alternative SQL database
+- **MongoDB** - Document database
+- **Qdrant** - Vector database for AI
+- **Redis** - Cache and message broker
+- **Elasticsearch** - Search engine
+
+### AI & Machine Learning
+- **OpenWebUI** - ChatGPT-like interface
+- **LiteLLM** - LLM proxy for multiple providers
+- **Ollama** - Local LLM runtime
+- **Tika** - Document extraction
+
+### Authentication
+- **Authentik** - SSO and identity provider with blueprints
+
+### Message Queues
+- **RabbitMQ** - Message broker
+
+### Development Tools
+- **ArgoCD** - GitOps continuous deployment
+- **pgAdmin** - PostgreSQL administration
+- **RedisInsight** - Redis administration
+
+### Networking
+- **Tailscale** - Secure mesh VPN
+- **Cloudflare Tunnels** - Public access without port forwarding
+
+## Quick Start
+
+### Prerequisites
+
+- macOS, Linux, or Windows with WSL2
+- 16GB RAM minimum (32GB recommended)
+- 50GB free disk space
+- [Rancher Desktop](https://rancherdesktop.io/) installed
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/terchris/urbalurba-infrastructure.git
+cd urbalurba-infrastructure
+
+# Run the installer
+./install-rancher.sh
+
+# Access the provision host
+./login-provision-host.sh
+
+# Configure secrets
+cd topsecret
+./create-kubernetes-secrets.sh
+# Edit your values in secrets-config/
+./create-kubernetes-secrets.sh
+kubectl apply -f kubernetes/kubernetes-secrets.yml
+
+# Deploy services using Ansible
+cd /mnt/urbalurbadisk/ansible
+ansible-playbook playbooks/034-setup-grafana.yml
+```
+
+### Access Your Services
+
+After deployment, access services at:
+
+| Service | URL |
+|---------|-----|
+| Nginx | [http://localhost](http://localhost) |
+| Grafana | [http://grafana.localhost](http://grafana.localhost) |
+| Prometheus | [http://prometheus.localhost](http://prometheus.localhost) |
+| Authentik | [http://authentik.localhost](http://authentik.localhost) |
+| OpenWebUI | [http://openwebui.localhost](http://openwebui.localhost) |
+| pgAdmin | [http://pgadmin.localhost](http://pgadmin.localhost) |
+| ArgoCD | [http://argocd.localhost](http://argocd.localhost) |
+
+## Documentation Structure
+
+- **[Getting Started](overview-getting-started.md)** - First steps and quick start guide
+- **[Hosts & Platforms](hosts-readme.md)** - Supported platforms and setup guides
+- **[Packages](package-ai-readme.md)** - Service documentation by category
+- **[Networking](networking-readme.md)** - External access via Tailscale and Cloudflare
+- **[Rules & Standards](rules-readme.md)** - Development conventions and patterns
+- **[Troubleshooting](troubleshooting-readme.md)** - Common issues and solutions
+
+## Repository Structure
+
+```
+urbalurba-infrastructure/
+├── ansible/              # Ansible playbooks for deployment
+├── docs/                 # Documentation (this site)
+├── manifests/            # Kubernetes manifests (numbered by category)
+├── provision-host/       # Provision host container scripts
+├── topsecret/            # Secrets management (gitignored)
+├── install-rancher.sh    # Main installer script
+└── mkdocs.yml            # Documentation site configuration
+```
+
+## Contributing
+
+Contributions are welcome! Please read the [development workflow](rules-development-workflow.md) and [git workflow](rules-git-workflow.md) guides before submitting changes.
+
+## License
+
+This project is maintained by the Norwegian Red Cross development team.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,159 @@
+# MkDocs configuration for Urbalurba Infrastructure
+# Run locally: mkdocs serve
+# Build: mkdocs build
+# Deploy: mkdocs gh-deploy
+
+site_name: Urbalurba Infrastructure
+site_description: Complete datacenter on your laptop - Kubernetes infrastructure for local development and production
+site_url: https://terchris.github.io/urbalurba-infrastructure/
+repo_url: https://github.com/terchris/urbalurba-infrastructure
+repo_name: terchris/urbalurba-infrastructure
+
+theme:
+  name: material
+  palette:
+    # Light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - tags
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Overview: overview-getting-started.md
+    - Installation: overview-installation.md
+    - Infrastructure: overview-infrastructure.md
+    - Services: overview-services.md
+    - System Architecture: overview-system-architecture.md
+  - Hosts & Platforms:
+    - Overview: hosts-readme.md
+    - Rancher Desktop: hosts-rancher-kubernetes.md
+    - Azure AKS: hosts-azure-aks.md
+    - Azure MicroK8s: hosts-azure-microk8s.md
+    - Multipass MicroK8s: hosts-multipass-microk8s.md
+    - Raspberry Pi: hosts-raspberry-microk8s.md
+    - Cloud Init: hosts-cloud-init-readme.md
+    - Cloud Init Secrets: hosts-cloud-init-secrets.md
+  - Packages:
+    - AI & ML:
+      - Overview: package-ai-readme.md
+      - LiteLLM: package-ai-litellm.md
+      - LiteLLM Client Keys: package-ai-litellm-client-key-setup.md
+      - OpenWebUI Model Access: package-ai-openwebui-model-access-setup.md
+      - Environment Management: package-ai-environment-management.md
+    - Authentication:
+      - Overview: package-auth-authentik-readme.md
+      - Auth10 Configuration: package-auth-authentik-auth10.md
+      - Developer Guide: package-auth-authentik-auth10-developer-guide.md
+      - Blueprints Syntax: package-auth-authentik-blueprints-syntax.md
+      - Technical Implementation: package-auth-authentik-technical-implementation.md
+      - Test Users: package-auth-authentik-testusers.md
+    - Core:
+      - Overview: package-core-readme.md
+      - Nginx: package-core-nginx.md
+    - Databases:
+      - Overview: package-databases-readme.md
+      - PostgreSQL: package-databases-postgresql.md
+      - PostgreSQL Container: package-databases-postgresql-container.md
+      - MySQL: package-databases-mysql.md
+      - MongoDB: package-databases-mongodb.md
+      - Qdrant: package-databases-qdrant.md
+    - Data Science:
+      - Overview: package-datascience.md
+      - JupyterHub: package-datascience-jupyterhub.md
+      - Spark: package-datascience-spark.md
+      - Unity Catalog: package-datascience-unitycatalog.md
+    - Development:
+      - Overview: package-development-readme.md
+      - ArgoCD: package-development-argocd.md
+      - Templates: package-development-templates.md
+    - Management:
+      - Overview: package-management-readme.md
+      - pgAdmin: package-management-pgadmin.md
+      - RabbitMQ Admin: package-management-rabbitmq.md
+      - RedisInsight: package-management-redisinsight.md
+    - Monitoring:
+      - Overview: package-monitoring-readme.md
+      - Prometheus: package-monitoring-prometheus.md
+      - Grafana: package-monitoring-grafana.md
+      - Loki: package-monitoring-loki.md
+      - Tempo: package-monitoring-tempo.md
+      - OpenTelemetry: package-monitoring-otel.md
+      - SovDev Logger: package-monitoring-sovdev-logger.md
+    - Message Queues:
+      - Overview: package-queues-readme.md
+      - RabbitMQ: package-queues-rabbitmq.md
+      - Redis: package-queues-redis.md
+    - Search:
+      - Overview: package-search-readme.md
+      - Elasticsearch: package-search-elasticsearch.md
+  - Networking:
+    - Overview: networking-readme.md
+    - Tailscale Setup: networking-tailscale-setup.md
+    - Tailscale Network Isolation: networking-tailscale-networkisolation.md
+    - Cloudflare Setup: networking-cloudflare-setup.md
+  - Provision Host:
+    - Overview: provision-host-readme.md
+    - Rancher Integration: provision-host-rancher.md
+    - Kubernetes Operations: provision-host-kubernetes.md
+    - Tools: provision-host-tools.md
+  - Rules & Standards:
+    - Overview: rules-readme.md
+    - Kubernetes Deployment: rules-automated-kubernetes-deployment.md
+    - Ingress & Traefik: rules-ingress-traefik.md
+    - Secrets Management: rules-secrets-management.md
+    - Provisioning: rules-provisioning.md
+    - Naming Conventions: rules-naming-conventions.md
+    - Git Workflow: rules-git-workflow.md
+    - Development Workflow: rules-development-workflow.md
+    - Documentation: rules-howtodoc.md
+  - Reference:
+    - Documentation Index: README.md
+    - Manifests: manifests-readme.md
+    - Secrets Management: secrets-management-readme.md
+    - Troubleshooting: troubleshooting-readme.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/terchris/urbalurba-infrastructure


### PR DESCRIPTION
## Summary
Phase 2 of documentation restructure - Add MkDocs Material for a professional documentation website.

## Files Added
- `mkdocs.yml` - Full configuration with organized navigation for all 76 docs
- `docs/index.md` - Homepage with overview, services list, and quick start guide
- `.github/workflows/docs.yml` - GitHub Actions workflow for auto-deployment

## Features
- Light/dark mode toggle
- Full-text search with suggestions and highlighting
- Code syntax highlighting with copy button
- Navigation sections with instant loading
- Admonitions (note/warning/tip boxes)
- Mobile responsive design
- Automatic deployment to GitHub Pages on push to main

## After Merge
Documentation will be available at: https://terchris.github.io/urbalurba-infrastructure/

## Local Development
```bash
pip install mkdocs-material
mkdocs serve
# Open http://localhost:8000
```

## Note
You may need to enable GitHub Pages in the repository settings:
1. Go to Settings → Pages
2. Set source to "Deploy from a branch"
3. Select "gh-pages" branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)