### PR TITLE
Add in-cluster documentation serving via nginx

### DIFF
--- a/ansible/playbooks/020-setup-web-files.yml
+++ b/ansible/playbooks/020-setup-web-files.yml
@@ -27,6 +27,7 @@
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
     website_source: "/mnt/urbalurbadisk/testdata/website"
+    docs_source: "/mnt/urbalurbadisk/testdata/docs"
     nginx_content_title: "Welcome to Nginx"
     nginx_content_message: "Your Nginx server is running successfully!"
     nginx_content_filename: "urbalurba-test.html"
@@ -190,7 +191,43 @@
         KUBECONFIG: "{{ merged_kubeconf_file }}"
       changed_when: true
       when: copy_result.rc != 0
-      
+
+    - name: 17a. Check if docs source folder exists
+      ansible.builtin.stat:
+        path: "{{ docs_source }}"
+      register: docs_folder
+
+    - name: 17b. Create docs directory in pod
+      ansible.builtin.shell: |
+        kubectl exec web-files-pod --context {{ kube_context }} -- \
+        sh -c "mkdir -p /content/docs"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      when: docs_folder.stat.exists and docs_folder.stat.isdir
+
+    - name: 17c. Copy docs content to pod using tar
+      ansible.builtin.shell: |
+        cd {{ docs_source }} && \
+        tar cf - . | kubectl exec -i web-files-pod --context {{ kube_context }} -- \
+        sh -c "cd /content/docs && tar xf -"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      when: docs_folder.stat.exists and docs_folder.stat.isdir
+      register: docs_copy_result
+      ignore_errors: true
+
+    - name: 17d. Display docs copy status
+      ansible.builtin.debug:
+        msg: "Documentation copied to /content/docs/ - will be available at /docs/ path"
+      when: docs_folder.stat.exists and docs_folder.stat.isdir and docs_copy_result.rc == 0
+
+    - name: 17e. Display docs skip message
+      ansible.builtin.debug:
+        msg: "Documentation source not found at {{ docs_source }} - skipping docs deployment"
+      when: not docs_folder.stat.exists or not docs_folder.stat.isdir
+
     - name: 18. Verify files in pod
       ansible.builtin.shell: |
         kubectl exec web-files-pod --context {{ kube_context }} -- \
@@ -216,14 +253,18 @@
       ansible.builtin.debug:
         msg: |
           WEB FILES SETUP COMPLETE
-          
+
           The website content from {{ website_source }} has been copied to the persistent volume.
           A test file named "{{ nginx_content_filename }}" has been created in the storage.
-          
+          {% if docs_folder.stat.exists and docs_folder.stat.isdir %}
+          Documentation from {{ docs_source }} has been copied to /docs/ subdirectory.
+          Access documentation at: http://localhost/docs/ (after nginx deployment)
+          {% endif %}
+
           PVC Status: {{ pvc_status_after_pod.stdout | default(pvc_status.stdout) }}
-          
+
           The files are stored in the persistent volume claim "nginx-content-pvc"
-          
+
           This playbook can be run again at any time to refresh the content from the source location.
           
 

--- a/provision-host-rancher/provision-host-container-create.sh
+++ b/provision-host-rancher/provision-host-container-create.sh
@@ -163,6 +163,17 @@ main() {
     create_and_copy "../topsecret" "/mnt/urbalurbadisk/topsecret" "topsecret directory"
     create_and_copy "../testdata" "/mnt/urbalurbadisk/testdata" "testdata directory"
     create_and_copy "../scripts" "/mnt/urbalurbadisk/scripts" "scripts directory"
+    create_and_copy "../docs" "/mnt/urbalurbadisk/docs" "docs directory"
+
+    # Copy mkdocs.yml configuration file
+    if [ -f "../mkdocs.yml" ]; then
+        echo "Copying mkdocs.yml to container"
+        docker cp "../mkdocs.yml" "provision-host:/mnt/urbalurbadisk/mkdocs.yml"
+        add_status "Transferring mkdocs.yml" "OK"
+    else
+        echo "Warning: mkdocs.yml does not exist. Skipping transfer."
+        add_status "Transferring mkdocs.yml" "Skipped"
+    fi
 
     # Fix ownership
     docker exec -u root provision-host chown -R ansible:ansible /mnt/urbalurbadisk

--- a/provision-host/provision-host-00-coresw.sh
+++ b/provision-host/provision-host-00-coresw.sh
@@ -117,6 +117,10 @@ main() {
     sudo pip3 install --upgrade pip
     sudo pip3 install psycopg2-binary
 
+    # Install MkDocs with Material theme for documentation generation
+    echo "Installing MkDocs and Material theme for documentation"
+    sudo pip3 install mkdocs-material mkdocs-tags-plugin
+
     install_github_cli || return 1
 
     print_summary

--- a/provision-host/provision-host-05-builddocs.sh
+++ b/provision-host/provision-host-05-builddocs.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# filename: provision-host-05-builddocs.sh
+# description: Builds MkDocs documentation and places it in testdata/docs for nginx serving
+
+set -e
+
+# Directories
+URBALURBA_ROOT="/mnt/urbalurbadisk"
+DOCS_SOURCE="${URBALURBA_ROOT}/docs"
+MKDOCS_CONFIG="${URBALURBA_ROOT}/mkdocs.yml"
+DOCS_OUTPUT="${URBALURBA_ROOT}/testdata/docs"
+
+# Initialize status tracking
+declare -A STATUS
+declare -A ERRORS
+
+# Function to add status
+add_status() {
+    local step=$1
+    local status=$2
+    STATUS["$step"]=$status
+}
+
+# Function to add error
+add_error() {
+    local step=$1
+    local error=$2
+    ERRORS["$step"]="${ERRORS[$step]}${ERRORS[$step]:+$'\n'}$error"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    echo "Checking prerequisites for documentation build..."
+
+    if ! command -v mkdocs &> /dev/null; then
+        add_error "Prerequisites" "mkdocs not found. Run provision-host-00-coresw.sh first."
+        return 1
+    fi
+
+    if [ ! -f "${MKDOCS_CONFIG}" ]; then
+        add_error "Prerequisites" "mkdocs.yml not found at ${MKDOCS_CONFIG}"
+        return 1
+    fi
+
+    if [ ! -d "${DOCS_SOURCE}" ]; then
+        add_error "Prerequisites" "docs directory not found at ${DOCS_SOURCE}"
+        return 1
+    fi
+
+    add_status "Prerequisites" "OK"
+    return 0
+}
+
+# Build documentation
+build_docs() {
+    echo "Building MkDocs documentation..."
+
+    # Create output directory if it doesn't exist
+    mkdir -p "${DOCS_OUTPUT}"
+
+    # Change to project root for mkdocs build
+    cd "${URBALURBA_ROOT}"
+
+    # Build documentation to testdata/docs
+    if mkdocs build --site-dir "${DOCS_OUTPUT}" --clean; then
+        add_status "Build" "OK"
+        echo "Documentation built successfully to ${DOCS_OUTPUT}"
+        return 0
+    else
+        add_error "Build" "mkdocs build failed"
+        return 1
+    fi
+}
+
+# Verify build output
+verify_build() {
+    echo "Verifying documentation build..."
+
+    if [ -f "${DOCS_OUTPUT}/index.html" ]; then
+        local file_count
+        file_count=$(find "${DOCS_OUTPUT}" -type f | wc -l)
+        add_status "Verification" "OK (${file_count} files)"
+        echo "Documentation verified: ${file_count} files generated"
+        return 0
+    else
+        add_error "Verification" "index.html not found in output directory"
+        return 1
+    fi
+}
+
+# Print summary
+print_summary() {
+    echo "---------- Documentation Build Summary ----------"
+    echo "Source: ${DOCS_SOURCE}"
+    echo "Config: ${MKDOCS_CONFIG}"
+    echo "Output: ${DOCS_OUTPUT}"
+    echo "-------------------------------------------------"
+
+    for step in "Prerequisites" "Build" "Verification"; do
+        if [ -n "${STATUS[$step]}" ]; then
+            echo "$step: ${STATUS[$step]}"
+        fi
+    done
+
+    if [ ${#ERRORS[@]} -eq 0 ]; then
+        echo "Documentation build completed successfully."
+        echo ""
+        echo "The documentation will be available at /docs/ after nginx deployment."
+        echo "Run the 020-setup-nginx.yml playbook to deploy to the cluster."
+    else
+        echo "Errors occurred during documentation build:"
+        for step in "${!ERRORS[@]}"; do
+            echo "  $step: ${ERRORS[$step]}"
+        done
+        return 1
+    fi
+}
+
+# Main execution
+main() {
+    echo "Starting documentation build on $(hostname)"
+    echo "---------------------------------------------------"
+
+    local overall_exit_code=0
+
+    check_prerequisites || overall_exit_code=1
+
+    if [ $overall_exit_code -eq 0 ]; then
+        build_docs || overall_exit_code=1
+    fi
+
+    if [ $overall_exit_code -eq 0 ]; then
+        verify_build || overall_exit_code=1
+    fi
+
+    print_summary
+
+    return $overall_exit_code
+}
+
+# Run the main function and exit with its return code
+main
+exit $?

--- a/provision-host/provision-host-provision.sh
+++ b/provision-host/provision-host-provision.sh
@@ -15,6 +15,7 @@ PROVISION_SCRIPTS=(
     "provision-host-02-kubetools.sh"
     "provision-host-03-net.sh"
     "provision-host-04-helmrepo.sh"
+    "provision-host-05-builddocs.sh"
 )
 
 # Check if running in a container


### PR DESCRIPTION
## Summary

- Install mkdocs-material and mkdocs-tags-plugin in provision-host during provisioning
- Add `provision-host-05-builddocs.sh` script to build documentation to `testdata/docs/`
- Copy `docs/` directory and `mkdocs.yml` into provision-host container
- Update `020-setup-web-files.yml` playbook to copy docs to nginx PVC at `/docs/` path

## Three-Tier Documentation Deployment

This completes the documentation deployment architecture:

| Tier | Use Case | Method |
|------|----------|--------|
| **Local dev** | Live editing while writing docs | `mkdocs serve` |
| **GitHub Pages** | Public documentation | GitHub Actions on push to main |
| **In-cluster** | Documentation in K8s cluster | Built during provisioning, served by nginx at `/docs/` |

## Test plan

- [ ] Run `provision-host-container-create.sh` to verify docs and mkdocs.yml are copied
- [ ] Verify `provision-host-05-builddocs.sh` builds docs to `testdata/docs/`
- [ ] Run `020-setup-nginx.yml` and verify docs are accessible at `http://localhost/docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)