### PR TITLE
Fix cloud provider selection passthrough, document feature

### DIFF
--- a/docs/provision-host-tools.md
+++ b/docs/provision-host-tools.md
@@ -38,7 +38,45 @@ After the container is created, it's provisioned with additional tools through a
 
 ### 2. Cloud Provider Tools (`provision-host-01-cloudproviders.sh`)
 
-The container supports ALL major cloud providers with their official CLIs:
+The container supports ALL major cloud providers with their official CLIs. You can select which cloud provider tools to install during setup:
+
+#### Cloud Provider Selection
+
+When running `./install-rancher.sh` or the container creation script, you can specify which cloud provider tools to install:
+
+```bash
+# Install Azure CLI only (default)
+./install-rancher.sh
+./install-rancher.sh az
+
+# Install AWS CLI only
+./install-rancher.sh aws
+
+# Install Google Cloud SDK only
+./install-rancher.sh gcp
+
+# Install Oracle Cloud CLI only
+./install-rancher.sh oci
+
+# Install Terraform only
+./install-rancher.sh tf
+
+# Install ALL cloud provider tools
+./install-rancher.sh all
+```
+
+#### Tools Installed Per Selection
+
+| Selection | Tools Installed |
+|-----------|-----------------|
+| `az` / `azure` (default) | Azure CLI |
+| `aws` | AWS CLI v2 |
+| `gcp` / `google` | Google Cloud SDK (gcloud, bq, gsutil) |
+| `oci` / `oracle` | Oracle Cloud Infrastructure CLI |
+| `tf` / `terraform` | Terraform |
+| `all` | All of the above |
+
+#### Available Cloud Provider Tools
 
 #### Azure CLI
 - **Resource Management**: VMs, Storage, Networking, AKS
@@ -222,8 +260,18 @@ docker run -d \
 ```bash
 # Inside the container or via docker exec
 cd /mnt/urbalurbadisk/provision-host/
+
+# Run all provisioning scripts with Azure CLI (default)
+./provision-host-provision.sh
+
+# Or specify a different cloud provider
+./provision-host-provision.sh aws    # AWS only
+./provision-host-provision.sh gcp    # Google Cloud only
+./provision-host-provision.sh all    # All cloud providers
+
+# Or run individual scripts manually
 ./provision-host-00-coresw.sh
-./provision-host-01-cloudproviders.sh all
+./provision-host-01-cloudproviders.sh aws  # Specify cloud provider
 ./provision-host-02-kubetools.sh
 ./provision-host-03-net.sh
 ./provision-host-04-helmrepo.sh


### PR DESCRIPTION
## Summary
- **Bug fix**: `provision-host-provision.sh` was not passing the cloud provider argument to `provision-host-01-cloudproviders.sh`, so the selection parameter from `install-rancher.sh` was being ignored
- Add usage documentation to script header
- Update `docs/provision-host-tools.md` with cloud provider selection guide
- Document tools installed per selection in a table format

## Cloud Provider Selection
Users can now properly select which cloud CLI tools to install:
```bash
./install-rancher.sh aws     # AWS CLI only
./install-rancher.sh gcp     # Google Cloud SDK only
./install-rancher.sh all     # All cloud tools
```

| Selection | Tools Installed |
|-----------|-----------------|
| `az` / `azure` (default) | Azure CLI |
| `aws` | AWS CLI v2 |
| `gcp` / `google` | Google Cloud SDK |
| `oci` / `oracle` | Oracle Cloud Infrastructure CLI |
| `tf` / `terraform` | Terraform |
| `all` | All of the above |

## Test plan
- [x] Tested on imac - verified `./provision-host-01-cloudproviders.sh aws` correctly shows "Cloud Provider Selection: aws"

🤖 Generated with [Claude Code](https://claude.com/claude-code)