### PR TITLE
Fix old path references in playbooks and config

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 inventory = /mnt/urbalurbadisk/ansible/inventory.yml
-private_key_file = secrets/id_rsa_ansible.secret-key
+private_key_file = /mnt/urbalurbadisk/.uis.secrets/ssh/id_rsa_ansible
 remote_user = ansible
 host_key_checking = False
 roles_path = /mnt/urbalurbadisk/ansible/roles

--- a/ansible/playbooks/01-configure_provision-host.yml
+++ b/ansible/playbooks/01-configure_provision-host.yml
@@ -27,7 +27,7 @@
     ansible_collections_path: '/mnt/urbalurbadisk/ansible/collections'
     ansible_inventory: '/mnt/urbalurbadisk/ansible/inventory.yml'
     ansible_config: '/mnt/urbalurbadisk/ansible/ansible.cfg'
-    ansible_private_key_file: '/mnt/urbalurbadisk/ansible/secrets/id_rsa_ansible.secret-key'
+    ansible_private_key_file: '/mnt/urbalurbadisk/.uis.secrets/ssh/id_rsa_ansible'
     ansible_library: '/usr/share/ansible'
     ansible_host_key_checking: false
     ansible_remote_user: 'ansible'

--- a/ansible/playbooks/350-setup-jupyterhub.yml
+++ b/ansible/playbooks/350-setup-jupyterhub.yml
@@ -38,6 +38,9 @@
     jupyterhub_chart: "jupyterhub/jupyterhub"
     jupyterhub_repo_url: "https://hub.jupyter.org/helm-chart/"
 
+    # Secrets file (auto-applied at start to create namespace and credentials)
+    secrets_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubernetes/kubernetes-secrets.yml"
+
     # Config files
     jupyterhub_config_file: "{{ manifests_folder }}/310-jupyterhub-config.yaml"
     jupyterhub_ingress_file: "{{ manifests_folder }}/311-jupyterhub-ingress.yaml"
@@ -61,8 +64,8 @@
         kubeconfig: "{{ merged_kubeconf_file }}"
 
     - name: 3. Apply urbalurba-secrets to cluster (includes jupyterhub namespace)
-      ansible.builtin.shell: |
-        kubectl apply -f /mnt/urbalurbadisk/topsecret/kubernetes/kubernetes-secrets.yml
+      ansible.builtin.command: >
+        kubectl apply -f {{ secrets_file }}
       environment:
         KUBECONFIG: "{{ merged_kubeconf_file }}"
       register: secrets_apply_result

--- a/ansible/playbooks/802-deploy-network-tailscale-tunnel.yml
+++ b/ansible/playbooks/802-deploy-network-tailscale-tunnel.yml
@@ -190,8 +190,8 @@
           - "To fix auth issues:"
           - "1. Go to https://login.tailscale.com/admin/settings/keys"
           - "2. Generate new auth key with 'tag:k8s' permission"
-          - "3. Update topsecret/kubernetes/kubernetes-secrets.yml"
-          - "4. Run: kubectl apply -f topsecret/kubernetes/kubernetes-secrets.yml"
+          - "3. Update .uis.secrets/service-keys/tailscale.env"
+          - "4. Run: ./uis deploy tailscale-tunnel"
       when: 
         - operator_pods.resources | length > 0
         - operator_pods_status.resources[0].status.phase != 'Running'

--- a/provision-host/provision-host-vm-create.sh
+++ b/provision-host/provision-host-vm-create.sh
@@ -87,22 +87,21 @@ check_command_success "Mounting host directory"
 multipass info $VM_NAME
 check_command_success "Get VM info"
 
-# Copy ansible secret key (check both new and legacy paths)
+# Copy ansible secret key to VM
 SSH_KEY_FILE=""
 if [ -f "../.uis.secrets/ssh/id_rsa_ansible" ]; then
     SSH_KEY_FILE="../.uis.secrets/ssh/id_rsa_ansible"
-elif [ -f "../secrets/id_rsa_ansible" ]; then
-    SSH_KEY_FILE="../secrets/id_rsa_ansible"
 fi
 
 if [ -n "$SSH_KEY_FILE" ]; then
-    echo "Now copying ansible secret key to /mnt/urbalurbadisk/ansible/secrets/id_rsa_ansible.secret-key"
-    multipass exec $VM_NAME -- sudo mkdir -p /mnt/urbalurbadisk/ansible/secrets
-    multipass transfer "$SSH_KEY_FILE" $VM_NAME:/mnt/urbalurbadisk/ansible/secrets/id_rsa_ansible.secret-key
+    echo "Now copying ansible secret key to /mnt/urbalurbadisk/.uis.secrets/ssh/id_rsa_ansible"
+    multipass exec $VM_NAME -- sudo mkdir -p /mnt/urbalurbadisk/.uis.secrets/ssh
+    multipass transfer "$SSH_KEY_FILE" $VM_NAME:/mnt/urbalurbadisk/.uis.secrets/ssh/id_rsa_ansible
     check_command_success "Transferring ansible secret key"
 else
     echo "Warning: ansible secret key does not exist. Skipping transfer."
-    echo "Looked for: ../.uis.secrets/ssh/id_rsa_ansible or ../secrets/id_rsa_ansible"
+    echo "Looked for: ../.uis.secrets/ssh/id_rsa_ansible"
+    echo "Run './uis' first to generate SSH keys."
     STATUS+=("Transferring ansible secret key: Skipped")
     ERROR=1
 fi


### PR DESCRIPTION
## Summary
- Update 3 ansible playbooks, `ansible.cfg`, and `provision-host-vm-create.sh` to use new `.uis.secrets/` paths instead of deprecated `topsecret/` and `secrets/` paths
- Phase 2 of service migration — prerequisite for removing backwards compatibility code (PLAN-004)
- Fixes: JupyterHub hardcoded `topsecret/` path, Tailscale error message references, provision-host SSH key paths

## Test plan
- [ ] Verify `350-setup-jupyterhub.yml` uses `secrets_file` variable instead of hardcoded path
- [ ] Verify `802-deploy-network-tailscale-tunnel.yml` error messages reference new paths
- [ ] Verify `01-configure_provision-host.yml` and `ansible.cfg` use `.uis.secrets/ssh/` path
- [ ] Verify `provision-host-vm-create.sh` copies SSH key to new location without legacy fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)