### PR TITLE
Migrate playbooks to new kubeconfig path (PLAN-005)

### DIFF
--- a/ansible/playbooks/020-remove-nginx.yml
+++ b/ansible/playbooks/020-remove-nginx.yml
@@ -22,7 +22,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     nginx_ingressroute_manifest: "{{ manifests_folder }}/020-nginx-root-ingress.yaml"
     nginx_config_manifest: "{{ manifests_folder }}/020-nginx-config.yaml"
     remove_pvc_flag: "{{ remove_pvc | default(false) | bool }}"

--- a/ansible/playbooks/020-setup-nginx.yml
+++ b/ansible/playbooks/020-setup-nginx.yml
@@ -23,7 +23,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     nginx_content_filename: "urbalurba-test.html"
     nginx_ingressroute_manifest: "{{ manifests_folder }}/020-nginx-root-ingress.yaml"
     nginx_config_manifest: "{{ manifests_folder }}/020-nginx-config.yaml"

--- a/ansible/playbooks/020-setup-tstweb-nginx.yml
+++ b/ansible/playbooks/020-setup-tstweb-nginx.yml
@@ -8,7 +8,7 @@
   gather_facts: no
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     source_tst_nginx: "/mnt/urbalurbadisk/tst/nginx"
     storage_manifest: "020-tstweb-storage-nginx.yaml"
     ingress_manifest: "021-tstweb-ingress-nginx.yaml"

--- a/ansible/playbooks/020-setup-web-files.yml
+++ b/ansible/playbooks/020-setup-web-files.yml
@@ -25,7 +25,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     website_source: "/mnt/urbalurbadisk/testdata/website"
     docs_source: "/mnt/urbalurbadisk/testdata/docs"
     nginx_content_title: "Welcome to Nginx"

--- a/ansible/playbooks/025-setup-whoami-testpod.yml
+++ b/ansible/playbooks/025-setup-whoami-testpod.yml
@@ -21,7 +21,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     whoami_test_app_file: "{{ manifests_folder }}/990-whoami-test-app.yaml"
     test_timeout: 120  # 2 minutes timeout for tests
     # operation variable is passed as external parameter, defaults handled in tasks

--- a/ansible/playbooks/04-merge-kubeconf.yml
+++ b/ansible/playbooks/04-merge-kubeconf.yml
@@ -20,7 +20,7 @@
 # Note: This playbook is designed to run on provision-host
 #
 # Variables:
-# - kubernetes_files_path: Directory containing the kubeconfig files (default: "/mnt/urbalurbadisk/kubeconfig/")
+# - kubernetes_files_path: Directory containing the kubeconfig files (default: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/")
 # - merged_kubeconf_file: Path and name of the merged kubeconfig file (default: "{kubernetes_files_path}kubeconf-all")
 #
 

--- a/ansible/playbooks/040-database-mysql.yml
+++ b/ansible/playbooks/040-database-mysql.yml
@@ -16,7 +16,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     mysql_manifest_file: "{{ manifests_folder }}/043-database-mysql-config.yaml"
     mysql_namespace: "default"
     mysql_pod_label: "app.kubernetes.io/name=mysql"

--- a/ansible/playbooks/040-database-postgresql.yml
+++ b/ansible/playbooks/040-database-postgresql.yml
@@ -20,7 +20,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     postgres_config_file: "{{ manifests_folder }}/042-database-postgresql-config.yaml"
     # Use _target internally to provide default value
     _target: "{{ target_host | default('rancher-desktop') }}"

--- a/ansible/playbooks/040-remove-database-mongodb.yml
+++ b/ansible/playbooks/040-remove-database-mongodb.yml
@@ -13,7 +13,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     mongodb_namespace: "default"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     mongodb_config_path: "{{ manifests_folder }}/040-mongodb-config.yaml"

--- a/ansible/playbooks/040-remove-database-mysql.yml
+++ b/ansible/playbooks/040-remove-database-mysql.yml
@@ -14,7 +14,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     mysql_manifest_file: "{{ manifests_folder }}/043-database-mysql-config.yaml"
     mysql_namespace: "default"
     deletion_timeout: 120

--- a/ansible/playbooks/040-remove-database-postgresql.yml
+++ b/ansible/playbooks/040-remove-database-postgresql.yml
@@ -18,7 +18,7 @@
     _target: "{{ target_host | default('rancher-desktop') }}"
     # Use _remove_pvc internally to avoid recursive template issues
     _remove_pvc: "{{ remove_pvc | default(false) }}"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     postgresql_namespace: "default"
     postgresql_helm_release: "postgresql"
     deletion_timeout: 120

--- a/ansible/playbooks/040-setup-mongodb.yml
+++ b/ansible/playbooks/040-setup-mongodb.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     mongodb_config_path: "{{ manifests_folder }}/040-mongodb-config.yaml"
     mongodb_namespace: "default"  # Using default namespace for simplicity
 

--- a/ansible/playbooks/044-remove-qdrant.yml
+++ b/ansible/playbooks/044-remove-qdrant.yml
@@ -26,7 +26,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     qdrant_namespace: "default"
     removal_timeout: 180  # 3 minutes timeout for removal operations
     cleanup_wait_timeout: 120  # 2 minutes timeout for cleanup verification

--- a/ansible/playbooks/044-setup-qdrant.yml
+++ b/ansible/playbooks/044-setup-qdrant.yml
@@ -31,7 +31,7 @@
     # Use _include_verification internally to avoid recursive template issues
     _include_verification: "{{ include_verification | default(false) }}"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     qdrant_namespace: "default"
     installation_timeout: 300  # 5 minutes timeout for installations
     pod_readiness_timeout: 180  # 3 minutes timeout for pod readiness

--- a/ansible/playbooks/050-remove-redis.yml
+++ b/ansible/playbooks/050-remove-redis.yml
@@ -13,7 +13,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     redis_namespace: "default"
     redis_release_name: "redis"
     deletion_timeout: 120

--- a/ansible/playbooks/050-setup-redis.yml
+++ b/ansible/playbooks/050-setup-redis.yml
@@ -8,7 +8,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
 
   tasks:
     - name: Check if target_host is provided

--- a/ansible/playbooks/060-remove-elasticsearch.yml
+++ b/ansible/playbooks/060-remove-elasticsearch.yml
@@ -11,7 +11,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     elasticsearch_namespace: "default"
     # Labels for both Elastic official and Bitnami charts
     elasticsearch_pod_label_elastic: "app=elasticsearch-master"

--- a/ansible/playbooks/060-setup-elasticsearch.yml
+++ b/ansible/playbooks/060-setup-elasticsearch.yml
@@ -17,7 +17,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     elasticsearch_config_file: "{{ manifests_folder }}/060-elasticsearch-config.yaml"
     elasticsearch_namespace: "default"
     elasticsearch_pod_label: "app=elasticsearch-master"

--- a/ansible/playbooks/070-remove-authentik.yml
+++ b/ansible/playbooks/070-remove-authentik.yml
@@ -21,7 +21,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     authentik_namespace: "authentik"
     default_namespace: "default"
 

--- a/ansible/playbooks/070-setup-authentik.yml
+++ b/ansible/playbooks/070-setup-authentik.yml
@@ -29,7 +29,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     authentik_namespace: "authentik"
     default_namespace: "default"
     installation_timeout: 900  # 15 minutes timeout for installations

--- a/ansible/playbooks/070-test-authentik-auth.yml
+++ b/ansible/playbooks/070-test-authentik-auth.yml
@@ -20,7 +20,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     authentik_namespace: "authentik"
     default_namespace: "default"
 

--- a/ansible/playbooks/070-verify-authentik.yml
+++ b/ansible/playbooks/070-verify-authentik.yml
@@ -23,7 +23,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     authentik_namespace: "authentik"
 
   tasks:

--- a/ansible/playbooks/080-remove-rabbitmq.yml
+++ b/ansible/playbooks/080-remove-rabbitmq.yml
@@ -13,7 +13,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     rabbitmq_namespace: "default"
     rabbitmq_release_name: "rabbitmq"
     deletion_timeout: 120

--- a/ansible/playbooks/080-setup-rabbitmq.yml
+++ b/ansible/playbooks/080-setup-rabbitmq.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     namespace: "default"
     service_name: "rabbitmq"
 

--- a/ansible/playbooks/090-setup-gravitee.yml
+++ b/ansible/playbooks/090-setup-gravitee.yml
@@ -9,7 +9,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     elasticsearch_password_secret: "urbalurba-secrets"
     elasticsearch_password_key: "ELASTICSEARCH_PASSWORD"
     gravitee_config_file: "{{ manifests_folder }}/090-gravitee-config.yaml"

--- a/ansible/playbooks/200-remove-open-webui.yml
+++ b/ansible/playbooks/200-remove-open-webui.yml
@@ -18,7 +18,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     ai_namespace: "ai"
     storage_config_file: "{{ manifests_folder }}/200-ai-persistent-storage.yaml"
     openwebui_ingress_file: "{{ manifests_folder }}/210-openwebui-ingress.yaml"

--- a/ansible/playbooks/200-setup-open-webui.yml
+++ b/ansible/playbooks/200-setup-open-webui.yml
@@ -24,7 +24,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     ai_namespace: "ai"
     installation_timeout: 900  # 15 minutes timeout for installations
     pod_readiness_timeout: 600  # 10 minutes timeout for pod readiness

--- a/ansible/playbooks/200-setup-openwebui-litellm.yml
+++ b/ansible/playbooks/200-setup-openwebui-litellm.yml
@@ -23,7 +23,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     ai_namespace: "ai"
     installation_timeout: 600  # 10 minutes
     pod_readiness_timeout: 300 # 5 minutes

--- a/ansible/playbooks/210-remove-litellm.yml
+++ b/ansible/playbooks/210-remove-litellm.yml
@@ -17,7 +17,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     ai_namespace: "ai"
     litellm_ingress_file: "{{ manifests_folder }}/221-litellm-ingress.yaml"
 

--- a/ansible/playbooks/210-setup-litellm.yml
+++ b/ansible/playbooks/210-setup-litellm.yml
@@ -18,7 +18,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     ai_namespace: "ai"
     installation_timeout: 600  # 10 minutes
     pod_readiness_timeout: 300 # 5 minutes

--- a/ansible/playbooks/220-remove-argocd.yml
+++ b/ansible/playbooks/220-remove-argocd.yml
@@ -15,7 +15,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     argocd_namespace: "argocd"
     argocd_helm_release: "argocd"

--- a/ansible/playbooks/220-setup-argocd.yml
+++ b/ansible/playbooks/220-setup-argocd.yml
@@ -13,7 +13,7 @@
   gather_facts: true
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     argocd_namespace: "argocd"
     installation_timeout: 600  # 10 minutes timeout for installations
     pod_readiness_timeout: 300  # 5 minutes timeout for pod readiness

--- a/ansible/playbooks/220-test-argocd.yml
+++ b/ansible/playbooks/220-test-argocd.yml
@@ -19,7 +19,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     argocd_namespace: "argocd"
 
   tasks:

--- a/ansible/playbooks/320-remove-unity-catalog.yml
+++ b/ansible/playbooks/320-remove-unity-catalog.yml
@@ -10,7 +10,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     unity_catalog_namespace: "unity-catalog"
 
   tasks:

--- a/ansible/playbooks/320-setup-unity-catalog.yml
+++ b/ansible/playbooks/320-setup-unity-catalog.yml
@@ -29,7 +29,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     unity_catalog_namespace: "unity-catalog"
     installation_timeout: 300  # 5 minutes timeout for installations
     pod_readiness_timeout: 180  # 3 minutes timeout for pod readiness

--- a/ansible/playbooks/330-remove-spark.yml
+++ b/ansible/playbooks/330-remove-spark.yml
@@ -13,7 +13,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     spark_namespace: "spark-operator"
     spark_helm_release: "spark-kubernetes-operator"
     deletion_timeout: 180

--- a/ansible/playbooks/330-setup-spark.yml
+++ b/ansible/playbooks/330-setup-spark.yml
@@ -28,7 +28,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     spark_namespace: "spark-operator"
     installation_timeout: 300  # 5 minutes timeout for installations
     pod_readiness_timeout: 180  # 3 minutes timeout for pod readiness

--- a/ansible/playbooks/350-remove-jupyterhub.yml
+++ b/ansible/playbooks/350-remove-jupyterhub.yml
@@ -14,7 +14,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     jupyterhub_namespace: "jupyterhub"
     jupyterhub_helm_release: "jupyterhub"

--- a/ansible/playbooks/350-setup-jupyterhub.yml
+++ b/ansible/playbooks/350-setup-jupyterhub.yml
@@ -29,7 +29,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     jupyterhub_namespace: "jupyterhub"
     installation_timeout: 300  # 5 minutes timeout for installations
     pod_readiness_timeout: 180  # 3 minutes timeout for pod readiness

--- a/ansible/playbooks/641-adm-pgadmin.yml
+++ b/ansible/playbooks/641-adm-pgadmin.yml
@@ -8,7 +8,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     pgadmin_namespace: "default"
     pgadmin_pod_label: "app.kubernetes.io/name=pgadmin4"
     pgadmin_service_name: "pgadmin-pgadmin4"

--- a/ansible/playbooks/641-remove-pgadmin.yml
+++ b/ansible/playbooks/641-remove-pgadmin.yml
@@ -14,7 +14,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     pgadmin_namespace: "default"
     pgadmin_release_name: "pgadmin"

--- a/ansible/playbooks/651-adm-redisinsight.yml
+++ b/ansible/playbooks/651-adm-redisinsight.yml
@@ -8,7 +8,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     redisinsight_namespace: "default"
     redisinsight_pod_label: "app.kubernetes.io/name=redisinsight"
     redisinsight_service_name: "redisinsight"

--- a/ansible/playbooks/651-remove-redisinsight.yml
+++ b/ansible/playbooks/651-remove-redisinsight.yml
@@ -14,7 +14,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     redisinsight_namespace: "default"
     redisinsight_release_name: "redisinsight"

--- a/ansible/playbooks/802-deploy-network-tailscale-tunnel.yml
+++ b/ansible/playbooks/802-deploy-network-tailscale-tunnel.yml
@@ -20,7 +20,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    kubeconfig_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    kubeconfig_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     operator_config: "800-tailscale-operator-config.yaml"
     ingress_manifest: "803-tailscale-cluster-ingress.yaml.j2"
     TAILSCALE_CLUSTER_HOSTNAME: "{{ TAILSCALE_CLUSTER_HOSTNAME | default('k8s') }}"

--- a/ansible/playbooks/802-tailscale-tunnel-addhost.yml
+++ b/ansible/playbooks/802-tailscale-tunnel-addhost.yml
@@ -23,7 +23,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    kubeconfig_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    kubeconfig_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     SERVICE_NAME: "{{ SERVICE_NAME | default('') }}"
     ingress_namespace: "kube-system"
     TAILSCALE_DOMAIN: "{{ TAILSCALE_DOMAIN | default('') }}"

--- a/ansible/playbooks/805-deploy-tailscale-internal-ingress.yml
+++ b/ansible/playbooks/805-deploy-tailscale-internal-ingress.yml
@@ -22,7 +22,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    kubeconfig_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    kubeconfig_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     operator_config_template: "800-tailscale-operator-config.yaml.j2"
     internal_ingress_manifest: "805-tailscale-internal-ingress.yaml.j2"
     # Default hostname if not provided via -e or K8s secret

--- a/ansible/playbooks/806-remove-tailscale-internal-ingress.yml
+++ b/ansible/playbooks/806-remove-tailscale-internal-ingress.yml
@@ -16,7 +16,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    kubeconfig_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    kubeconfig_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     operator_namespace: "tailscale"
     operator_release_name: "tailscale-operator"
     remove_operator: false

--- a/ansible/playbooks/820-setup-network-cloudflare-tunnel.yml
+++ b/ansible/playbooks/820-setup-network-cloudflare-tunnel.yml
@@ -15,7 +15,7 @@
     cloudflare_certificate_file: "{{ cloudflarefolder }}cloudflare-certificate.pem"
     cloudflare_credentials_file: "{{ cloudflarefolder }}cloudflare-tunnel.json"
     cloudflare_config_file: "{{ cloudflarefolder }}cloudflare-tunnel-config.yml"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
 
   tasks:
     - name: 1. Check if required variables are provided

--- a/ansible/playbooks/821-deploy-network-cloudflare-tunnel.yml
+++ b/ansible/playbooks/821-deploy-network-cloudflare-tunnel.yml
@@ -19,7 +19,7 @@
   collections:
     - kubernetes.core
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
   tasks:
     - name: Check if cloudflared-credentials secret exists
       kubernetes.core.k8s_info:
@@ -54,7 +54,7 @@
     domain: "{{ domain }}"
     full_tunnel_name: "cloudflare-tunnel"
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     cloudflare_kubernetes_template_file: "{{ manifests_folder }}/820-cloudflare-tunnel-base.yaml.j2"
 
   tasks:

--- a/ansible/playbooks/argocd-register-app.yml
+++ b/ansible/playbooks/argocd-register-app.yml
@@ -25,7 +25,7 @@
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     argocd_namespace: "argocd"
     github_secret_name: "github-{{ repo_name }}"
     github_secret_username_key: "username"

--- a/ansible/playbooks/argocd-remove-app.yml
+++ b/ansible/playbooks/argocd-remove-app.yml
@@ -17,7 +17,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     argocd_namespace: "argocd"
     github_secret_name: "github-{{ repo_name }}"
     retry_delay: 8

--- a/ansible/playbooks/utility/u01-add-domains-to-tunnel.yml
+++ b/ansible/playbooks/utility/u01-add-domains-to-tunnel.yml
@@ -13,7 +13,7 @@
     tunnel_name: "{{ tunnel_name }}"
     domain: "{{ domain }}"
     cloudflarefolder: "/mnt/urbalurbadisk/cloudflare/"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
 
   tasks:
     - name: 1. Validate input parameters

--- a/ansible/playbooks/utility/u02-verify-postgres.yml
+++ b/ansible/playbooks/utility/u02-verify-postgres.yml
@@ -12,7 +12,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     test_db_name: "test_verify_db"
     test_table_name: "test_table"
 

--- a/ansible/playbooks/utility/u03-extract-cluster-config.yml
+++ b/ansible/playbooks/utility/u03-extract-cluster-config.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   vars:
     config_extract_folder: "/mnt/urbalurbadisk/troubleshooting/output"
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     timestamp: "{{ lookup('pipe', 'date') }}"
 
   tasks:

--- a/ansible/playbooks/utility/u06-openwebui-create-postgres.yml
+++ b/ansible/playbooks/utility/u06-openwebui-create-postgres.yml
@@ -46,7 +46,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
 
   tasks:
     - name: 1. Get urbalurba-secrets from ai namespace

--- a/ansible/playbooks/utility/u07-setup-unity-catalog-database.yml
+++ b/ansible/playbooks/utility/u07-setup-unity-catalog-database.yml
@@ -21,7 +21,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     unity_catalog_db_name: "unity_catalog"
     unity_catalog_user: "unity_catalog_user"
     unity_catalog_password: "unity_catalog_password"

--- a/ansible/playbooks/utility/u07-verify-qdrant.yml
+++ b/ansible/playbooks/utility/u07-verify-qdrant.yml
@@ -12,7 +12,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     qdrant_namespace: "default"
     test_collection_name: "verification_test_collection"
 

--- a/ansible/playbooks/utility/u08-verify-mysql.yml
+++ b/ansible/playbooks/utility/u08-verify-mysql.yml
@@ -10,7 +10,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     test_db_name: "test_verify_db"
     test_table_name: "test_table"
 

--- a/ansible/playbooks/utility/u09-authentik-create-postgres.yml
+++ b/ansible/playbooks/utility/u09-authentik-create-postgres.yml
@@ -59,7 +59,7 @@
 - hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     # operation variable is passed as parameter, defaults to 'create' if not specified
   
   tasks:

--- a/ansible/playbooks/utility/u10-litellm-create-postgres.yml
+++ b/ansible/playbooks/utility/u10-litellm-create-postgres.yml
@@ -32,7 +32,7 @@
 - hosts: localhost
   gather_facts: false
   vars:
-    merged_kubeconf_file: "/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     # operation variable is passed as parameter, defaults to 'create' if not specified
 
   tasks:

--- a/provision-host-rancher/docker-compose.yml
+++ b/provision-host-rancher/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - TZ=Europe/Oslo
       - USER=ansible
       # Updated KUBECONFIG to use the consolidated config file
-      - KUBECONFIG=/mnt/urbalurbadisk/kubeconfig/kubeconf-all
+      - KUBECONFIG=/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all
     # Use host network to access Kubernetes and for Tailscale
     network_mode: "host"
     # Enable privileged mode for Tailscale and other operations

--- a/provision-host-rancher/entrypoint-copy-kubeconf.sh
+++ b/provision-host-rancher/entrypoint-copy-kubeconf.sh
@@ -19,7 +19,7 @@
 set -e
 
 # Target kubeconfig path on the volume
-TARGET_KUBECONFIG="/mnt/urbalurbadisk/kubeconfig/kubeconf-all"
+TARGET_KUBECONFIG="/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
 # Host-mounted kubeconfig path
 HOST_KUBECONFIG="/tmp/host-kube/config"
 
@@ -33,7 +33,7 @@ if [ ! -f "$TARGET_KUBECONFIG" ] && [ -f "$HOST_KUBECONFIG" ]; then
   
   # Create target directory structure on the volume
   echo "* Creating target directory structure"
-  mkdir -p /mnt/urbalurbadisk/kubeconfig
+  mkdir -p /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig
   
   # Copy kubeconfig from host to the specified location on volume
   echo "* Copying initial kubeconfig to $TARGET_KUBECONFIG"
@@ -41,7 +41,7 @@ if [ ! -f "$TARGET_KUBECONFIG" ] && [ -f "$HOST_KUBECONFIG" ]; then
   
   # Ensure ansible user can access the file
   echo "* Setting appropriate permissions for ansible user"
-  chown -R ansible:ansible /mnt/urbalurbadisk/kubeconfig
+  chown -R ansible:ansible /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig
   
   echo "* Successfully set up initial kubeconfig on volume"
 else

--- a/provision-host-rancher/prepare-rancher-environment.sh
+++ b/provision-host-rancher/prepare-rancher-environment.sh
@@ -8,12 +8,12 @@ echo "Setting up Rancher Desktop environment..."
 
 #TODO: this is not needed as we can copied the kubeconfig from the host to the container in the entrypoint script
 # Create the kubeconfig directory
-#mkdir -p /mnt/urbalurbadisk/kubeconfig
+#mkdir -p /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig
 
 # Copy the Rancher Desktop kubeconfig to the expected location
 echo "Copying Rancher Desktop kubeconfig so that it can be merged with the other kubeconfigs..."
 # The line below seems crazy. But what we do is to copy the kubeconfig that came from the host to the place where we normally woul put kubekonf files that are going to be merged
-cp /mnt/urbalurbadisk/kubeconfig/kubeconf-all /mnt/urbalurbadisk/kubeconfig/rancher-desktop-kubeconf
+cp /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/rancher-desktop-kubeconf
 
 # Create Ansible inventory for Rancher Desktop
 echo "Setting up Ansible inventory for Rancher Desktop..."
@@ -37,7 +37,7 @@ echo "Environment setup complete."
 
 # Test the configuration
 echo "Testing Kubernetes configuration..."
-KUBECONFIG=/mnt/urbalurbadisk/kubeconfig/kubeconf-all kubectl get nodes
+KUBECONFIG=/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all kubectl get nodes
 if [ $? -eq 0 ]; then
     echo "Kubernetes configuration test successful!"
 else

--- a/uis
+++ b/uis
@@ -137,15 +137,12 @@ start_container() {
     # Wait for container to be ready
     sleep 2
 
-    # Create kubeconfig symlinks to host kubeconfig
+    # Create kubeconfig symlink to host kubeconfig
     docker exec "$CONTAINER_NAME" bash -c '
         if [ -d /mnt/urbalurbadisk/.uis.secrets ]; then
             mkdir -p /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig
             ln -sf /home/ansible/.kube/config /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all
         fi
-        # Legacy path — 59 playbooks still reference this; remove after PLAN-005 migration
-        mkdir -p /mnt/urbalurbadisk/kubeconfig
-        ln -sf /home/ansible/.kube/config /mnt/urbalurbadisk/kubeconfig/kubeconf-all
     ' 2>/dev/null || true
 
     log_info "Container started"


### PR DESCRIPTION
## Summary

- Migrate 64 files from legacy kubeconfig path (`/mnt/urbalurbadisk/kubeconfig/kubeconf-all`) to new path (`/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all`)
- Remove the legacy kubeconfig bridge symlink from the `uis` wrapper (added in PR #36 as a temporary fix)
- All Ansible playbooks, provision-host-rancher scripts, and docker-compose.yml updated

## Test plan

- [x] Container builds successfully
- [x] All 192 unit tests pass (6/6 test suites)
- [x] Zero references to `/mnt/urbalurbadisk/kubeconfig/` in playbooks
- [x] Legacy symlink confirmed gone in container
- [x] New symlink confirmed present in container
- [x] Tester verified: whoami deploy/undeploy works with new path (no bridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)