### PR TITLE
docs: update rules documentation for UIS deployment system

### DIFF
--- a/website/docs/provision-host/kubernetes.md
+++ b/website/docs/provision-host/kubernetes.md
@@ -92,7 +92,7 @@ Each category has a `not-in-use/` folder containing optional services. You contr
 - **📁 Active Services**: Scripts in the category folder (e.g., `07-ai/01-setup-litellm-openwebui.sh`)
 - **📁 Inactive Services**: Scripts in `not-in-use/` folder (e.g., `07-ai/not-in-use/02-setup-open-webui.sh`)
 
-**Technical Details**: See [Active vs Inactive Management](../rules/kubernetes-deployment.md#active-vs-inactive-management) in the rules documentation.
+**Technical Details**: See [Legacy System](../rules/kubernetes-deployment.md#legacy-system) in the rules documentation. The current system uses `./uis enable`/`./uis disable` — see [Autostart Configuration](../rules/kubernetes-deployment.md#autostart-configuration).
 
 ## Quick Start Guide
 

--- a/website/docs/rules/kubernetes-deployment.md
+++ b/website/docs/rules/kubernetes-deployment.md
@@ -1,180 +1,359 @@
-# Rules for Automated Kubernetes Deployment
+# Rules for UIS Deployment System
 
 **File**: `docs/rules-automated-kubernetes-deployment.md`
-**Purpose**: Define the **ORCHESTRATION LAYER** - how deployment scripts are organized, discovered, and executed automatically when cluster is built
-**Target Audience**: Developers, DevOps engineers, and LLMs working with the automated deployment system
-**Scope**: Directory structure, naming conventions, execution order, and automation flow
+**Purpose**: Define the **ORCHESTRATION LAYER** — how services are discovered, configured, and deployed through the UIS CLI
+**Target Audience**: Developers, DevOps engineers, and LLMs working with the UIS deployment system
+**Scope**: CLI commands, service metadata, deploy flow, stacks, autostart configuration
 
 ## Relationship to Other Rules
 
 This document covers the **orchestration and automation framework**:
-- How scripts are organized in numbered directories
-- How `provision-kubernetes.sh` discovers and executes scripts
-- Alphabetic ordering and dependency management
-- Active/inactive script management
+- How the UIS CLI discovers and deploys services
+- Service metadata files and the deploy/undeploy lifecycle
+- Stacks (pre-defined service bundles)
+- Autostart configuration via `enabled-services.conf`
 
-For **how to write individual deployment scripts**, see:
-→ [Rules for Provisioning](./provisioning.md) - Implementation patterns for scripts and playbooks
+For **how to write individual Ansible playbooks**, see:
+> [Rules for Provisioning](./provisioning.md) - Implementation patterns for playbooks
+
+For **file and resource naming patterns**, see:
+> [Naming Conventions](./naming-conventions.md)
 
 ## Core Principles
 
-1. **Automated Orchestration**: The `provision-kubernetes.sh` script is the master orchestrator that executes all deployment scripts
-2. **Alphabetic Execution Order**: Directories and scripts are executed in strict alphabetic order based on their names
-3. **Sequential Dependency Management**: Applications MUST be deployed in order based on their dependencies via alphabetic naming
-4. **Idempotency**: All deployment scripts MUST be safe to run multiple times
-5. **Error Resilience**: Deployment process MUST continue even if individual scripts fail, with errors tracked
-6. **Parameterization**: All scripts MUST accept target host as a parameter
+1. **Declarative Service Metadata**: Each service is defined by a metadata file (`service-*.sh`) that declares its properties, deployment method, dependencies, and health check
+2. **CLI-Driven Deployment**: All deployments are performed through `./uis deploy` and `./uis undeploy` commands
+3. **Dependency Management**: Services declare their requirements via `SCRIPT_REQUIRES` and the system verifies dependencies before deploying
+4. **Ansible for Heavy Lifting**: Metadata files delegate actual deployment to Ansible playbooks — no business logic in metadata
+5. **Idempotency**: All deployments MUST be safe to run multiple times
+6. **Health Verification**: Services define a `SCRIPT_CHECK_COMMAND` for post-deploy health checks
 
-## Automated Orchestration System
+## UIS CLI Commands
 
-### Master Script: provision-kubernetes.sh
-
-The **`provision-kubernetes.sh`** is the central automation controller that orchestrates all deployments:
-
-**Repository Path**: `provision-host/kubernetes/provision-kubernetes.sh`
-**Container Path**: `/mnt/urbalurbadisk/provision-host/kubernetes/provision-kubernetes.sh` (when running inside provision-host)
-
-**Key Functions**:
-- Automatically discovers all numbered directories (e.g., `01-core`, `02-databases`)
-- Executes directories in **strict alphabetic order** (not numeric - this is critical!)
-- Within each directory, executes all `*.sh` scripts in **alphabetic order**
-- Ignores scripts in `not-in-use/` folders
-- Passes target host parameter to every script
-- Continues execution even if individual scripts fail
-- Generates comprehensive summary report
-
-**CRITICAL**: The system uses **alphabetic sorting**, not numeric sorting:
-- `01` comes before `02` (correct)
-- `10` comes before `2` (would be wrong - always use leading zeros!)
-- This is why `05-setup-postgres.sh` comes before `10-setup-mysql.sh`
-
-### Automated Execution
-
-**IMPORTANT**: This script is called **automatically** by `./uis provision` during cluster build:
+### Service Deployment
 
 ```bash
-# Automatically executed by ./uis provision:
+# Deploy a single service (also enables it for autostart)
+./uis deploy postgresql
+
+# Deploy all enabled services (from enabled-services.conf)
+./uis deploy
+
+# Undeploy a single service
+./uis undeploy postgresql
+```
+
+### Service Management
+
+```bash
+# List all available services (grouped by category)
+./uis list
+./uis list --all            # Include disabled services
+./uis list --category AI    # Filter by category
+
+# Show deployed services with health status
+./uis status
+
+# Enable/disable autostart (does not deploy/undeploy)
+./uis enable postgresql
+./uis disable postgresql
+
+# List enabled services
+./uis list-enabled
+```
+
+### Stack Operations
+
+```bash
+# List available stacks
+./uis stack list
+
+# Show stack details (services, descriptions)
+./uis stack info observability
+
+# Install a stack (deploys all services in order)
+./uis stack install observability
+
+# Install stack without optional services
+./uis stack install observability --skip-optional
+
+# Remove a stack (undeploys in reverse order)
+./uis stack remove observability
+```
+
+### Other Commands
+
+```bash
+# Show version
+./uis version
+
+# Interactive setup menu
+./uis setup
+
+# First-time initialization
+./uis init
+
+# Sync enabled list with what's actually running in cluster
+./uis sync
+
+# Legacy: run old provision-kubernetes.sh system
 ./uis provision
 ```
 
-The complete cluster setup flow:
-1. User runs `./uis start` in the repo on their host machine (Windows, Mac, Linux)
-2. UIS pulls the pre-built container image and mounts volumes
-3. User runs `./uis provision` which calls provision-kubernetes.sh inside the container
-4. provision-kubernetes.sh deploys all services in alphabetic order
+## Service Architecture
 
-### Manual Usage (for testing/debugging)
+### Service Metadata Files
+
+Every service is defined by a metadata file in `provision-host/uis/services/<category>/`:
+
+```
+provision-host/uis/services/
+├── ai/
+│   ├── service-litellm.sh
+│   └── service-openwebui.sh
+├── analytics/
+│   ├── service-jupyterhub.sh
+│   ├── service-spark.sh
+│   └── service-unity-catalog.sh
+├── databases/
+│   ├── service-elasticsearch.sh
+│   ├── service-mongodb.sh
+│   ├── service-mysql.sh
+│   ├── service-postgresql.sh
+│   └── service-redis.sh
+├── identity/
+│   └── service-authentik.sh
+├── integration/
+│   └── service-rabbitmq.sh
+├── management/
+│   ├── service-argocd.sh
+│   ├── service-pgadmin.sh
+│   ├── service-redisinsight.sh
+│   └── service-whoami.sh
+├── networking/
+│   ├── service-cloudflare-tunnel.sh
+│   └── service-tailscale-tunnel.sh
+└── observability/
+    ├── service-grafana.sh
+    ├── service-loki.sh
+    ├── service-otel-collector.sh
+    ├── service-prometheus.sh
+    └── service-tempo.sh
+```
+
+### Metadata File Structure
+
+Each metadata file declares service properties as shell variables. The scanner reads these by parsing the file line-by-line (it does NOT `source` the file during discovery, for safety).
 
 ```bash
-# From within provision-host container:
-cd /mnt/urbalurbadisk
-./provision-host/kubernetes/provision-kubernetes.sh [target-host]
+#!/bin/bash
+# service-postgresql.sh - PostgreSQL service metadata
+
+# === Service Metadata (Required) ===
+SCRIPT_ID="postgresql"                    # Unique ID used in CLI commands
+SCRIPT_NAME="PostgreSQL"                  # Human-readable display name
+SCRIPT_DESCRIPTION="Open-source relational database"
+SCRIPT_CATEGORY="DATABASES"               # Must match a category ID
+
+# === Deployment Configuration (Optional) ===
+SCRIPT_PLAYBOOK="040-database-postgresql.yml"   # Ansible playbook (preferred)
+SCRIPT_MANIFEST=""                              # Direct kubectl manifest (alternative)
+SCRIPT_REMOVE_PLAYBOOK="040-remove-database-postgresql.yml"
+SCRIPT_CHECK_COMMAND="kubectl get pods -n default -l app.kubernetes.io/name=postgresql --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REQUIRES=""                        # Space-separated service IDs
+SCRIPT_PRIORITY="30"                      # Deploy order (lower = earlier, default: 50)
+
+# === Deployment Details (Optional) ===
+SCRIPT_HELM_CHART="bitnami/postgresql"
+SCRIPT_NAMESPACE="default"
+
+# === Website Metadata (Optional) ===
+SCRIPT_ABSTRACT="World's most advanced open-source relational database"
+SCRIPT_LOGO="postgresql-logo.webp"
+SCRIPT_WEBSITE="https://www.postgresql.org"
+SCRIPT_TAGS="database,sql,relational,postgres,rdbms"
+SCRIPT_SUMMARY="PostgreSQL is a powerful, open-source object-relational database system..."
+SCRIPT_DOCS="/docs/packages/databases/postgresql"
 ```
 
-Default target-host is `rancher-desktop` if not specified.
+**Three metadata groups:**
 
-## Directory Structure Rules
+| Group | Fields | Purpose |
+|-------|--------|---------|
+| Required | `SCRIPT_ID`, `SCRIPT_NAME`, `SCRIPT_DESCRIPTION`, `SCRIPT_CATEGORY` | Service identity and discovery |
+| Deployment | `SCRIPT_PLAYBOOK`, `SCRIPT_MANIFEST`, `SCRIPT_CHECK_COMMAND`, `SCRIPT_REMOVE_PLAYBOOK`, `SCRIPT_REQUIRES`, `SCRIPT_PRIORITY`, `SCRIPT_NAMESPACE` | How to deploy, verify, and remove |
+| Website | `SCRIPT_ABSTRACT`, `SCRIPT_LOGO`, `SCRIPT_WEBSITE`, `SCRIPT_TAGS`, `SCRIPT_SUMMARY`, `SCRIPT_DOCS` | Documentation generation |
 
-### Category Numbering Standards
+**Important constraints:**
+- `SCRIPT_PLAYBOOK` and `SCRIPT_MANIFEST` are mutually exclusive — if both are set, playbook takes precedence
+- `SCRIPT_REMOVE_PLAYBOOK` can include extra Ansible parameters after the filename (space-separated)
+- Files starting with `_` (e.g., `_helper.sh`) are skipped by the scanner
+- Each variable must be on its own line in `KEY="value"` format for the line-by-line parser
 
-Deployment scripts MUST be organized in numbered categories:
+### Categories
 
-**Repository Structure**:
+Services are organized into 9 categories (defined in `provision-host/uis/lib/categories.sh`):
+
+| Category ID | Display Name | Description | Manifest Range |
+|------------|--------------|-------------|----------------|
+| `OBSERVABILITY` | Observability | Metrics, logs, and tracing | 030-039 |
+| `AI` | AI & ML | AI and machine learning services | 200-229 |
+| `ANALYTICS` | Analytics | Data science and analytics platforms | 300-399 |
+| `IDENTITY` | Identity | Identity and access management | 070-079 |
+| `DATABASES` | Databases | Data storage and caching services | 040-099 |
+| `MANAGEMENT` | Management | Admin tools, GitOps, and test services | 600-799 |
+| `NETWORKING` | Networking | VPN tunnels and network access | — |
+| `STORAGE` | Storage | Platform storage infrastructure | 000-009 |
+| `INTEGRATION` | Integration | Messaging, API gateways, and event streams | — |
+
+**Note**: `STORAGE` and `NETWORKING` are platform-dependent — Traefik and storage provisioners are managed by Rancher Desktop, not by `./uis deploy`.
+
+### Service Discovery
+
+The service scanner (`provision-host/uis/lib/service-scanner.sh`) discovers services by:
+
+1. Walking `provision-host/uis/services/` recursively for `*.sh` files
+2. Skipping files starting with `_` (helper scripts)
+3. Parsing each file line-by-line for `SCRIPT_ID=`, `SCRIPT_NAME=`, etc.
+4. Caching results for performance (cache is an in-memory indexed array)
+
+The scanner never `source`s scripts during discovery — this is a safety measure. Only `deploy_single_service` in `service-deployment.sh` actually sources a metadata file (to load all variables for deployment).
+
+## Deploy Flow
+
+When you run `./uis deploy <service>`, the system follows this sequence:
+
 ```
-provision-host/kubernetes/
-├── 01-core/             # Storage, ingress, DNS, basic infrastructure
-├── 02-databases/        # PostgreSQL, MySQL, MongoDB, etc.
-├── 03-queues/          # Redis, RabbitMQ, message brokers
-├── 04-search/          # Elasticsearch, Solr, search engines
-├── 05-apim/            # API management platforms
-├── 06-management/      # Admin tools (pgAdmin, phpMyAdmin, etc.)
-├── 07-ai/              # AI/ML services (OpenWebUI, LiteLLM, etc.)
-├── 08-development/     # CI/CD tools (ArgoCD, Jenkins, etc.)
-├── 09-network/         # VPN, tunnels, network tools
-├── 10-datascience/    # Jupyter, Unity Catalog, analytics
-├── 11-monitoring/      # Prometheus, Grafana, observability
-└── 12-auth/            # Authentication services (Authentik, Keycloak)
+./uis deploy postgresql
+    │
+    ├─ 1. Find service script via service scanner
+    │     └─ Locates provision-host/uis/services/databases/service-postgresql.sh
+    │
+    ├─ 2. Source metadata file (loads all SCRIPT_* variables)
+    │
+    ├─ 3. Check dependencies (SCRIPT_REQUIRES)
+    │     └─ For each required service, verify it's deployed via SCRIPT_CHECK_COMMAND
+    │     └─ Fail fast if any dependency is missing
+    │
+    ├─ 4. Execute deployment (mutually exclusive methods):
+    │     ├─ If SCRIPT_PLAYBOOK: ansible-playbook <playbook> -e "target_host=<host>"
+    │     └─ If SCRIPT_MANIFEST: kubectl apply -f <manifest>
+    │
+    ├─ 5. Post-deploy health check (if SCRIPT_CHECK_COMMAND is set)
+    │     └─ Wait 2 seconds, then run health check
+    │     └─ Failure is a warning, not an error
+    │
+    └─ 6. Auto-enable service in enabled-services.conf
 ```
 
-**Container Path**: `/mnt/urbalurbadisk/provision-host/kubernetes/` (when mounted in provision-host)
+**`./uis deploy` (no argument)** deploys all services listed in `enabled-services.conf`, in order. Stops on first failure.
 
-### Script Naming Convention
+**`./uis undeploy <service>`** uses a three-tier removal strategy:
+1. If `SCRIPT_REMOVE_PLAYBOOK` is set: run the removal playbook
+2. Else if `SCRIPT_MANIFEST` is set: `kubectl delete -f <manifest> --ignore-not-found`
+3. Else: warn "no removal method found"
 
-**⚠️ See [doc/rules-naming-conventions.md](./naming-conventions.md) for complete naming patterns.**
+### Target Host
 
-Scripts must follow standard naming patterns. For **implementation details** (script structure, error handling), see:
-→ [Rules for Provisioning](./provisioning.md) - Script Template Pattern section
+The target host (default: `rancher-desktop`) is read from `cluster-config.sh`. This determines which Kubernetes context Ansible uses. Supported cluster types:
+- `rancher-desktop` (default, local development)
+- `azure-aks`
+- `azure-microk8s`
+- `multipass-microk8s`
+- `raspberry-microk8s`
 
-### Active vs Inactive Management
+## Stacks
 
-**Purpose**: Control what gets deployed during **automated cluster build** by `./uis provision`
+Stacks are pre-defined bundles of services that work together. They are defined in `provision-host/uis/lib/stacks.sh`.
 
-- **Active scripts**: Placed directly in the category folder - will be deployed automatically
-- **Inactive scripts**: Placed in `not-in-use/` subfolder - skipped during automated build
-- **Activation**: Move script from `not-in-use/` to parent directory for next cluster build
-- **Deactivation**: Move script to `not-in-use/` to exclude from automated deployment
+### Available Stacks
 
-**IMPORTANT**: Scripts in `not-in-use/` can still be run manually anytime:
+| Stack | Services | Optional |
+|-------|----------|----------|
+| **observability** | prometheus, tempo, loki, otel-collector, grafana | otel-collector |
+| **ai-local** | litellm, openwebui | — |
+| **analytics** | spark, jupyterhub, unity-catalog | unity-catalog |
+
+### Stack Behavior
+
+- **Install**: Services are deployed left-to-right in the defined order (dependencies first)
+- **Remove**: Services are removed in **reverse** order (dependents first)
+- **`--skip-optional`**: Skips services listed as optional for the stack
+- Each service installed via a stack is automatically added to `enabled-services.conf`
+
+## Autostart Configuration
+
+The file `.uis.extend/enabled-services.conf` controls which services are deployed when running `./uis deploy` without arguments.
+
 ```bash
-# Manual execution of inactive script (from provision-host container):
-cd /mnt/urbalurbadisk/provision-host/kubernetes/02-databases/not-in-use/
-./04-setup-mongodb.sh rancher-desktop
+# Enable a service (adds to enabled-services.conf)
+./uis enable postgresql
+
+# Disable a service (removes from enabled-services.conf)
+./uis disable postgresql
+
+# List what's enabled
+./uis list-enabled
+
+# Sync enabled list with cluster state
+./uis sync
 ```
 
-**Note**: The path above uses the container mount point (`/mnt/urbalurbadisk/`).
+The `sync` command scans the cluster for running services and adds them to the enabled list — useful after manual deployments or when the enabled list gets out of sync.
 
-This allows you to:
-- Keep optional services ready but not auto-deployed
-- Test services before adding to automated build
-- Maintain different cluster configurations
+## Adding a New Service
 
-## Script Requirements for Orchestration
+To add a new service to UIS:
 
-### Compatibility with Automation
+1. **Create a metadata file** in the appropriate category directory:
+   ```
+   provision-host/uis/services/<category>/service-<name>.sh
+   ```
+   Include at minimum: `SCRIPT_ID`, `SCRIPT_NAME`, `SCRIPT_DESCRIPTION`, `SCRIPT_CATEGORY`
 
-For scripts to work with the automated orchestration system, they MUST:
+2. **Create an Ansible playbook** in `ansible/playbooks/`:
+   ```
+   ansible/playbooks/NNN-setup-<name>.yml
+   ```
+   Follow the patterns in [Rules for Provisioning](./provisioning.md)
 
-1. **Be executable**: File permissions must be 755 (`chmod +x script.sh`)
-2. **Accept target host as first parameter**: The orchestrator passes this automatically
-3. **Follow naming convention**: `[NN]-setup-[service].sh` for proper alphabetic ordering
-4. **Be placed in correct directory**: Active scripts in category folder, inactive in `not-in-use/`
+3. **Create a removal playbook** (if using Ansible deployment):
+   ```
+   ansible/playbooks/NNN-remove-<name>.yml
+   ```
 
-For **implementation details** (how to write the scripts), see:
-→ [Rules for Provisioning](./provisioning.md)
+4. **Create manifest configs** in `manifests/` (if needed):
+   ```
+   manifests/NNN-<name>-config.yaml
+   ```
 
+5. **Set deployment fields** in the metadata file:
+   - `SCRIPT_PLAYBOOK` or `SCRIPT_MANIFEST`
+   - `SCRIPT_REMOVE_PLAYBOOK`
+   - `SCRIPT_CHECK_COMMAND` (health check)
+   - `SCRIPT_REQUIRES` (dependencies)
+   - `SCRIPT_PRIORITY` (deploy order)
 
-## Dependency Management Rules
+6. **Test**: `./uis deploy <name>` then `./uis status`
 
-### Execution Order (Alphabetic!)
+## Legacy System
 
-1. Categories are processed in **alphabetic order** (01 before 02, 10 before 11, etc.)
-2. Scripts within categories execute in **alphabetic order**
-3. Dependencies MUST be satisfied by proper alphabetic ordering:
-   - Databases (02) before applications that use them
-   - Authentication (12) after databases it depends on
-   - Monitoring (11) after services to monitor
+The old deployment system (`provision-host/kubernetes/` with numbered directories and `provision-kubernetes.sh`) still exists for backward compatibility:
 
+```bash
+# Run the old orchestration system
+./uis provision
+```
 
+This executes `provision-host/kubernetes/provision-kubernetes.sh`, which discovers numbered directories (e.g., `01-core/`, `02-databases/`) and runs scripts within them in alphabetic order. The old system uses `not-in-use/` subdirectories to control which scripts execute.
 
-## Automation Integration
-
-The **`provision-kubernetes.sh`** master script implements these orchestration requirements:
-
-1. **Discover all category directories** in alphabetic order
-2. **Execute scripts within each directory** in alphabetic order
-3. **Skip scripts** in `not-in-use/` folders
-4. **Pass target host parameter** to every script
-5. **Continue execution** even if individual scripts fail
-6. **Track successes and failures** for summary report
-7. **Generate comprehensive summary** of all deployment results
-8. **Return appropriate exit code** based on overall success/failure
-
-
-**Key Point**: This discovery pattern ensures **strict alphabetic execution order** for both directories and scripts.
+**The old system is not actively maintained.** New services should use the UIS metadata + Ansible pattern described above.
 
 ---
 
 **Related Documentation:**
-- [Provision Host Kubernetes Guide](../provision-host/kubernetes.md)
+- [Rules for Provisioning](./provisioning.md) - Ansible playbook patterns
+- [Naming Conventions](./naming-conventions.md) - File and resource naming
 - [Rules Overview](./index.md)
 - [Secrets Management](./secrets-management.md)
+- [Ingress and Traefik](./ingress-traefik.md)

--- a/website/docs/rules/naming-conventions.md
+++ b/website/docs/rules/naming-conventions.md
@@ -99,78 +99,86 @@
 
 ---
 
-### Shell Scripts (provision-host/kubernetes/*/*)
+### Service Metadata Files (provision-host/uis/services/)
 
-**Pattern:** `NN-action-component.sh`
+**Pattern:** `service-[name].sh`
 
-**Script Number:** Sequential within directory (01, 02, 03...)
-
-**Actions:** Same as playbooks (`setup-`, `remove-`, `update-`, `test-`)
+**Location:** `provision-host/uis/services/<category>/`
 
 **Relationship to Playbooks:**
-- Script number is independent of playbook number
-- Script wraps Ansible playbook call
-- Script provides proper context and parameters
+- Metadata file declares which Ansible playbook to run (`SCRIPT_PLAYBOOK`)
+- The UIS CLI reads the metadata and calls the playbook automatically
+- No imperative code — metadata files are declarative variable assignments
+- Files starting with `_` are skipped by the scanner (used for helper scripts)
 
 **Examples:**
 ```
-provision-host/kubernetes/11-monitoring/not-in-use/
-├── 00-setup-all-monitoring.sh      # Orchestrates all setup scripts
-├── 00-remove-all-monitoring.sh     # Orchestrates all remove scripts
-├── 01-setup-prometheus.sh          # Calls ansible/playbooks/030-setup-prometheus.yml
-├── 01-remove-prometheus.sh         # Calls ansible/playbooks/030-remove-prometheus.yml
-├── 02-setup-tempo.sh               # Calls ansible/playbooks/031-setup-tempo.yml
-├── 02-remove-tempo.sh              # Calls ansible/playbooks/031-remove-tempo.yml
-├── 03-setup-loki.sh                # Calls ansible/playbooks/032-setup-loki.yml
-├── 03-remove-loki.sh               # Calls ansible/playbooks/032-remove-loki.yml
-├── 04-setup-otel-collector.sh      # Calls ansible/playbooks/033-setup-otel-collector.yml
-├── 04-remove-otel-collector.sh     # Calls ansible/playbooks/033-remove-otel-collector.yml
-├── 05-setup-grafana.sh             # Calls ansible/playbooks/034-setup-grafana.yml
-└── 05-remove-grafana.sh            # Calls ansible/playbooks/034-remove-grafana.yml
+provision-host/uis/services/
+├── observability/
+│   ├── service-prometheus.sh        # SCRIPT_PLAYBOOK="030-setup-prometheus.yml"
+│   ├── service-tempo.sh             # SCRIPT_PLAYBOOK="031-setup-tempo.yml"
+│   ├── service-loki.sh              # SCRIPT_PLAYBOOK="032-setup-loki.yml"
+│   ├── service-otel-collector.sh    # SCRIPT_PLAYBOOK="033-setup-otel-collector.yml"
+│   └── service-grafana.sh           # SCRIPT_PLAYBOOK="034-setup-grafana.yml"
+├── databases/
+│   ├── service-postgresql.sh        # SCRIPT_PLAYBOOK="040-database-postgresql.yml"
+│   ├── service-mysql.sh             # SCRIPT_PLAYBOOK="041-database-mysql.yml"
+│   └── service-redis.sh             # SCRIPT_PLAYBOOK="043-setup-redis.yml"
+└── ai/
+    ├── service-litellm.sh           # SCRIPT_PLAYBOOK="210-setup-litellm.yml"
+    └── service-openwebui.sh         # SCRIPT_PLAYBOOK="208-setup-openwebui.yml"
 ```
 
-**Script Content Pattern:**
+**Metadata File Structure:**
 ```bash
 #!/bin/bash
-# Description of what this script does
+# service-[name].sh - [Service] service metadata
 
-# Check if target host provided
-if [ -z "$1" ]; then
-    echo "Usage: $0 <target_host>"
-    exit 1
-fi
+# === Required ===
+SCRIPT_ID="name"                        # Unique CLI identifier
+SCRIPT_NAME="Display Name"              # Human-readable name
+SCRIPT_DESCRIPTION="Brief description"
+SCRIPT_CATEGORY="CATEGORY_ID"           # One of the 9 categories
 
-TARGET_HOST="$1"
-
-# Call Ansible playbook
-ansible-playbook /mnt/urbalurbadisk/ansible/playbooks/030-setup-prometheus.yml \
-    -e "target_host=${TARGET_HOST}"
+# === Deployment (Optional) ===
+SCRIPT_PLAYBOOK="NNN-setup-name.yml"    # Ansible playbook
+SCRIPT_REMOVE_PLAYBOOK="NNN-remove-name.yml"
+SCRIPT_CHECK_COMMAND="kubectl get pods ..."
+SCRIPT_REQUIRES=""                      # Space-separated service IDs
+SCRIPT_PRIORITY="50"                    # Deploy order (lower = earlier)
 ```
 
 ---
 
 ### Directory Structure
 
-**Pattern:** Numbered directories for deployment order
-
-**Examples:**
+**UIS Service Directory** — services organized by category:
 ```
-provision-host/kubernetes/
-├── 00-system/                      # Core system setup
-├── 01-storage/                     # Storage provisioners
-├── 02-ingress/                     # Traefik ingress
-├── 03-dns/                         # DNS services
-├── 11-monitoring/                  # Monitoring stack
-│   └── not-in-use/                # Testing/development area
-├── 12-databases/                   # Database services
-├── 13-auth/                        # Authentication services
-└── 20-applications/                # Application deployments
+provision-host/uis/services/
+├── ai/                             # AI & ML services
+├── analytics/                      # Data science and analytics
+├── databases/                      # Data storage and caching
+├── identity/                       # Identity and access management
+├── integration/                    # Messaging and API gateways
+├── management/                     # Admin tools and GitOps
+├── networking/                     # VPN tunnels and network access
+├── observability/                  # Metrics, logs, and tracing
+└── storage/                        # Platform storage infrastructure
+```
+
+**Supporting Directories:**
+```
+provision-host/uis/
+├── lib/                            # Core libraries (categories, stacks, deployment logic)
+├── manage/                         # CLI entry point (uis-cli.sh)
+├── services/                       # Service metadata files (see above)
+└── templates/                      # Config templates and defaults
 ```
 
 **Rules:**
-1. Two-digit prefix for ordering
-2. Descriptive name after number
-3. `not-in-use/` subdirectory for scripts under development
+1. Category directories match the 9 UIS categories (lowercase)
+2. Service files use `service-[name].sh` naming pattern
+3. Helper files use `_` prefix (skipped by scanner)
 
 ---
 
@@ -180,20 +188,21 @@ provision-host/kubernetes/
 
 **Pattern:** `lowercase-descriptive`
 
+Most services deploy to the `default` namespace. Dedicated namespaces are used when a service requires isolation or when the Helm chart creates its own namespace.
+
 **Examples:**
 ```
-monitoring          # Monitoring stack (Prometheus, Grafana, Loki, Tempo, OTEL)
-databases          # Database services
+default            # Most services (PostgreSQL, MySQL, Redis, pgAdmin, whoami, LiteLLM, etc.)
+monitoring         # Observability stack (Prometheus, Grafana, Loki, Tempo, OTEL)
 authentik          # Authentik SSO
-openwebui          # OpenWebUI and AI services
-kube-system        # Kubernetes system (default)
+kube-system        # Kubernetes system
 traefik            # Traefik ingress controller
 ```
 
 **Rules:**
 1. Single word or hyphenated
 2. All lowercase
-3. Descriptive of purpose
+3. Prefer `default` namespace unless isolation is needed
 4. No version numbers
 
 ---
@@ -357,14 +366,15 @@ Claude Code vs manual workflows and path conventions.
 8. ✅ Consistent patterns across all file types
 
 **When adding new components:**
-1. Choose appropriate number range
-2. Create manifest file with proper suffix
-3. Create matching Ansible playbooks (setup + remove)
-4. Create shell script wrappers
-5. Follow established patterns
-6. Leave room for related components
+1. Create a service metadata file in `provision-host/uis/services/<category>/service-<name>.sh`
+2. Choose appropriate manifest number range for the category
+3. Create manifest config file(s) in `manifests/`
+4. Create matching Ansible playbooks (setup + remove) in `ansible/playbooks/`
+5. Set `SCRIPT_PLAYBOOK`, `SCRIPT_REMOVE_PLAYBOOK`, and `SCRIPT_CHECK_COMMAND` in metadata
+6. Declare dependencies with `SCRIPT_REQUIRES` if needed
+7. Test with `./uis deploy <name>` and `./uis status`
 
 **Reference:**
 - [doc/rules-development-workflow.md](./development-workflow.md) - Workflow and command execution
-- [doc/rules-automated-kubernetes-deployment.md](./kubernetes-deployment.md) - Ansible patterns *(to be created)*
-- [doc/rules-ingress-traefik.md](./ingress-traefik.md) - IngressRoute patterns *(to be created)*
+- [doc/rules-automated-kubernetes-deployment.md](./kubernetes-deployment.md) - UIS deployment system
+- [doc/rules-ingress-traefik.md](./ingress-traefik.md) - IngressRoute patterns

--- a/website/docs/rules/provisioning.md
+++ b/website/docs/rules/provisioning.md
@@ -22,20 +22,20 @@ This document establishes mandatory patterns for writing deployment scripts and 
 
 ## 🎯 **Core Deployment Architecture**
 
-### **Rule 1: Script + Ansible Pattern**
-All deployments MUST follow the **Script + Ansible** pattern:
+### **Rule 1: Metadata + Ansible Pattern**
+All deployments MUST follow the **Metadata + Ansible** pattern:
 
 ```
-scripts/packages/[service].sh  →  ansible/playbooks/[nnn]-setup-[service].yml
-     ↑ Minimal orchestration      ↑ Heavy lifting implementation
+service-*.sh metadata  →  ansible/playbooks/[nnn]-setup-[service].yml
+   ↑ Declarative config      ↑ Heavy lifting implementation
 ```
 
-#### **Script Responsibilities** (Keep Minimal):
-- ✅ Check prerequisites (kubectl access, basic dependencies)
-- ✅ Call Ansible playbook with proper parameters
-- ✅ Display final success/failure message
-- ❌ **NO business logic** - delegate to Ansible
-- ❌ **NO complex operations** - keep scripts simple
+#### **Service Metadata Responsibilities** (Declarative Only):
+- ✅ Declare service identity (`SCRIPT_ID`, `SCRIPT_NAME`, `SCRIPT_CATEGORY`)
+- ✅ Point to Ansible playbook (`SCRIPT_PLAYBOOK`) or manifest (`SCRIPT_MANIFEST`)
+- ✅ Declare dependencies (`SCRIPT_REQUIRES`) and health check (`SCRIPT_CHECK_COMMAND`)
+- ❌ **NO business logic** — delegate to Ansible
+- ❌ **NO imperative code** — metadata files are declarative variable assignments
 
 #### **Ansible Playbook Responsibilities** (Heavy Lifting):
 - ✅ All deployment logic and verification
@@ -44,14 +44,15 @@ scripts/packages/[service].sh  →  ansible/playbooks/[nnn]-setup-[service].yml
 - ✅ Error handling with proper retry mechanisms
 - ✅ Status reporting and troubleshooting information
 
-### **Example Structure**:
+#### **How it works**:
+The UIS CLI reads the metadata file, resolves dependencies, then calls the Ansible playbook:
+
 ```bash
-# scripts/packages/litellm.sh
-#!/bin/bash
-set -e
-echo "🚀 Deploying LiteLLM AI Gateway..."
-ansible-playbook ansible/playbooks/210-setup-litellm.yml
-echo "✅ LiteLLM deployment complete"
+# Service metadata declares the playbook:
+# provision-host/uis/services/ai/service-litellm.sh
+SCRIPT_ID="litellm"
+SCRIPT_PLAYBOOK="210-setup-litellm.yml"
+SCRIPT_REQUIRES="postgresql"
 ```
 
 ```yaml
@@ -60,17 +61,21 @@ echo "✅ LiteLLM deployment complete"
   # ... all the actual deployment logic
 ```
 
+For details on the UIS CLI and service metadata format, see:
+> [Rules for UIS Deployment System](./kubernetes-deployment.md)
+
 ## 📝 **Script Template Pattern**
 
-### **Rule 1B: Script Naming Convention**
+### **Rule 1B: Naming Convention**
 
 **⚠️ See [doc/rules-naming-conventions.md](./naming-conventions.md) for complete naming patterns.**
 
 **Quick Reference:**
-- **Setup Script**: `[NN]-setup-[service-name].sh` (e.g., `05-setup-postgres.sh`)
-- **Remove Script**: `[NN]-remove-[service-name].sh` (same number prefix)
+- **Service Metadata**: `service-[name].sh` in `provision-host/uis/services/<category>/`
+- **Setup Playbook**: `[NNN]-setup-[service-name].yml` (e.g., `040-database-postgresql.yml`)
+- **Remove Playbook**: `[NNN]-remove-[service-name].yml` (same number prefix)
 
-**MANDATORY**: Every setup script MUST have a corresponding remove script for clean uninstallation.
+**MANDATORY**: Every service with a `SCRIPT_PLAYBOOK` SHOULD have a corresponding `SCRIPT_REMOVE_PLAYBOOK` for clean uninstallation.
 
 ### **Rule 1C: Check Existing Playbooks First**
 
@@ -656,14 +661,12 @@ When calling utility playbooks from main playbooks, MUST implement "quiet succes
 
 ### **Rule 13: Consistent File Naming and Numbering**
 
-TODO: we need to revise numbering (someday)
-
 ```
-scripts/packages/[service-name].sh
-ansible/playbooks/[nnn]-setup-[service-name].yml
-ansible/playbooks/utility/[unn]-[purpose].yml
-manifests/[nnn]-[service-name]-[component].yaml
-provision-host/kubernetes/[nn]-[category]/[nn]-setup-[service].sh
+provision-host/uis/services/[category]/service-[name].sh   # Service metadata
+ansible/playbooks/[nnn]-setup-[service-name].yml            # Deploy playbook
+ansible/playbooks/[nnn]-remove-[service-name].yml           # Remove playbook
+ansible/playbooks/utility/[unn]-[purpose].yml               # Utility playbook
+manifests/[nnn]-[service-name]-[component].yaml             # Kubernetes manifests
 ```
 
 ### **Rule 14: Retry and Timeout Patterns**
@@ -897,7 +900,7 @@ See `docs/rules-ingress-traefik.md` for complete IngressRoute examples and patte
 - Always follow the Script + Ansible pattern
 
 ### **Validation Checklist**:
-- [ ] Uses Script + Ansible pattern
+- [ ] Uses Metadata + Ansible pattern (service metadata declares playbook)
 - [ ] Tests using kubectl run (not .localhost from host)
 - [ ] Includes comprehensive verification steps
 - [ ] Does not ignore errors for critical dependencies
@@ -905,7 +908,7 @@ See `docs/rules-ingress-traefik.md` for complete IngressRoute examples and patte
 - [ ] Uses sequential task numbering (1, 2, 3...)
 - [ ] Utility files are complete playbooks (not task lists)
 - [ ] Manages required Helm repositories within playbook
-- [ ] Understands auto-execution system (active vs not-in-use placement)
+- [ ] Service metadata file placed in correct category directory
 - [ ] Uses Traefik IngressRoute (not standard Ingress)
 - [ ] Follows file naming conventions
 - [ ] Includes proper status reporting


### PR DESCRIPTION
## Summary
- **Rewrote** `kubernetes-deployment.md` — replaced old `provision-kubernetes.sh` orchestration docs with UIS CLI system (`./uis deploy`, service metadata, stacks, categories, deploy flow, autostart config)
- **Updated** `provisioning.md` — "Script + Ansible" → "Metadata + Ansible" pattern, updated file paths and validation checklist
- **Updated** `naming-conventions.md` — replaced shell scripts/directory sections with UIS service metadata patterns, fixed namespace examples (most use `default`)

## Test plan
- [x] `npm run build` passes with no new warnings or broken links
- [ ] Visual check of rules pages on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)