### PR TITLE
docs: rewrite landing page with cloud comparison and container install

### DIFF
--- a/uis.ps1
+++ b/uis.ps1
@@ -1,0 +1,225 @@
+# UIS - Urbalurba Infrastructure Stack CLI wrapper (PowerShell)
+# This script manages the UIS provision-host container
+#
+# Usage: .\uis.ps1 <command> [args]
+# Run .\uis.ps1 help for available commands
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ContainerName = "uis-provision-host"
+$Image = if ($env:UIS_IMAGE) { $env:UIS_IMAGE } else { "ghcr.io/terchris/uis-provision-host:latest" }
+$KubeconfigDir = if ($env:UIS_KUBECONFIG_DIR) { $env:UIS_KUBECONFIG_DIR } else { Join-Path $HOME ".kube" }
+
+# Detect if we have an interactive terminal
+$DockerIT = if ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) { "-it" } else { "" }
+
+function Log-Info { param([string]$Message) Write-Host "[UIS] $Message" -ForegroundColor Green }
+function Log-Warn { param([string]$Message) Write-Host "[UIS] $Message" -ForegroundColor Yellow }
+function Log-Error { param([string]$Message) Write-Host "[UIS] $Message" -ForegroundColor Red }
+
+function Check-Image {
+    $null = docker image inspect $Image 2>&1
+    if ($LASTEXITCODE -eq 0) { return }
+
+    if ($Image -match "/") {
+        Log-Info "Image '$Image' not found locally, pulling from registry..."
+        docker pull $Image
+        if ($LASTEXITCODE -eq 0) {
+            Log-Info "Image pulled successfully"
+            return
+        }
+        Log-Error "Failed to pull image '$Image'"
+    } else {
+        Log-Error "Image '$Image' not found!"
+    }
+
+    Log-Info "Build it with: docker build -f Dockerfile.uis-provision-host -t uis-provision-host:local ."
+    Log-Info "Or pull from registry: `$env:UIS_IMAGE = 'ghcr.io/terchris/uis-provision-host:latest'"
+    exit 1
+}
+
+function Init-ConfigDirs {
+    $firstRun = $false
+
+    $extendDir = Join-Path $ScriptDir ".uis.extend"
+    if (-not (Test-Path $extendDir)) {
+        Log-Info "Creating .uis.extend/ configuration directory..."
+        New-Item -ItemType Directory -Path $extendDir -Force | Out-Null
+        $firstRun = $true
+    }
+
+    $secretsDir = Join-Path $ScriptDir ".uis.secrets"
+    if (-not (Test-Path $secretsDir)) {
+        Log-Info "Creating .uis.secrets/ directory..."
+        New-Item -ItemType Directory -Path $secretsDir -Force | Out-Null
+        $firstRun = $true
+    }
+
+    $gitignore = Join-Path $ScriptDir ".gitignore"
+    if (-not (Test-Path $gitignore)) {
+        @("# UIS secrets - do not commit", ".uis.secrets/") | Set-Content $gitignore
+        Log-Info "Created .gitignore with .uis.secrets/"
+    } elseif (-not (Select-String -Path $gitignore -Pattern "^\.uis\.secrets" -Quiet)) {
+        @("", "# UIS secrets (auto-added)", ".uis.secrets/") | Add-Content $gitignore
+        Log-Info "Added .uis.secrets/ to .gitignore"
+    }
+
+    return $firstRun
+}
+
+function Show-Welcome {
+    docker exec $ContainerName bash -c 'if [ -f /mnt/urbalurbadisk/provision-host/uis/templates/welcome.txt ]; then cat /mnt/urbalurbadisk/provision-host/uis/templates/welcome.txt; fi' 2>$null
+}
+
+function Start-UISContainer {
+    $running = docker ps --format '{{.Names}}' 2>$null | Where-Object { $_ -eq $ContainerName }
+    if ($running) { return }
+
+    Check-Image
+    $firstRun = Init-ConfigDirs
+
+    Log-Info "Starting UIS container..."
+
+    docker rm -f $ContainerName 2>$null | Out-Null
+
+    $volumeArgs = @(
+        "-v", "${ScriptDir}/.uis.extend:/mnt/urbalurbadisk/.uis.extend"
+        "-v", "${ScriptDir}/.uis.secrets:/mnt/urbalurbadisk/.uis.secrets"
+    )
+
+    if (Test-Path $KubeconfigDir) {
+        $volumeArgs += "-v", "${KubeconfigDir}:/home/ansible/.kube:ro"
+    } else {
+        Log-Warn "Kubeconfig directory not found: $KubeconfigDir"
+        Log-Warn "Kubernetes commands will not work until kubeconfig is configured"
+    }
+
+    docker run -d --name $ContainerName --network host --privileged @volumeArgs $Image
+    if ($LASTEXITCODE -ne 0) {
+        Log-Error "Failed to start container"
+        exit 1
+    }
+
+    Start-Sleep -Seconds 2
+
+    docker exec $ContainerName bash -c 'if [ -d /mnt/urbalurbadisk/.uis.secrets ]; then mkdir -p /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig; ln -sf /home/ansible/.kube/config /mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all; fi' 2>$null
+
+    Log-Info "Container started"
+
+    if ($firstRun) {
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh init 2>$null
+        Show-Welcome
+    }
+}
+
+function Stop-UISContainer {
+    $running = docker ps --format '{{.Names}}' 2>$null | Where-Object { $_ -eq $ContainerName }
+    if ($running) {
+        Log-Info "Stopping UIS container..."
+        docker stop $ContainerName | Out-Null
+        Log-Info "Container stopped"
+    } else {
+        Log-Warn "Container is not running"
+    }
+}
+
+# Main command handler
+$command = if ($args.Count -gt 0) { $args[0] } else { "help" }
+$remaining = if ($args.Count -gt 1) { $args[1..($args.Count - 1)] } else { @() }
+
+switch ($command) {
+    "start" {
+        Start-UISContainer
+        Log-Info "UIS container is ready"
+    }
+    "stop" {
+        Stop-UISContainer
+    }
+    "restart" {
+        Stop-UISContainer
+        Start-UISContainer
+        Log-Info "UIS container restarted"
+    }
+    "container" {
+        $running = docker ps --format '{{.Names}}' 2>$null | Where-Object { $_ -eq $ContainerName }
+        if ($running) {
+            Log-Info "Container is running"
+            docker ps --filter "name=$ContainerName" --format "table {{.Names}}`t{{.Status}}`t{{.Ports}}"
+        } else {
+            Log-Warn "Container is not running"
+        }
+    }
+    "shell" {
+        Start-UISContainer
+        docker exec -it $ContainerName bash
+    }
+    "provision" {
+        Start-UISContainer
+        Log-Info "Running kubernetes provisioning..."
+        docker exec -it $ContainerName bash -c "cd /mnt/urbalurbadisk/provision-host/kubernetes && ./provision-kubernetes.sh rancher-desktop"
+    }
+    "exec" {
+        if ($remaining.Count -eq 0) {
+            Log-Error "No command specified"
+            exit 1
+        }
+        Start-UISContainer
+        docker exec $DockerIT $ContainerName @remaining
+    }
+    "logs" {
+        $tail = if ($remaining.Count -gt 0) { $remaining[0] } else { "--tail 50" }
+        docker logs $ContainerName $tail
+    }
+    "build" {
+        Log-Info "Building UIS container image..."
+        docker build -f (Join-Path $ScriptDir "Dockerfile.uis-provision-host") -t uis-provision-host:local $ScriptDir
+        Log-Info "Build complete"
+    }
+    "test" {
+        Log-Info "Running UIS container validation tests..."
+        Start-UISContainer
+
+        docker exec $ContainerName rm -rf /mnt/urbalurbadisk/.temp /mnt/urbalurbadisk/generate 2>$null
+
+        Log-Info "Test 1: uis-cli version"
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh version
+
+        Log-Info "Test 2: uis-cli list"
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh list
+
+        Log-Info "Test 3: uis-cli stack list"
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh stack list
+
+        Log-Info "Test 4: JSON generation"
+        docker exec $ContainerName bash -c "cd /mnt/urbalurbadisk && ./provision-host/uis/manage/uis-docs.sh"
+
+        Log-Info "Test 5: Schema validation"
+        docker exec $ContainerName bash -c "cd /mnt/urbalurbadisk && ./provision-host/uis/tests/validate-schemas.sh"
+
+        Log-Info "Test 6: Enable/disable service"
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh enable prometheus
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh list-enabled
+        docker exec $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh disable prometheus
+
+        Log-Info "All tests passed!"
+    }
+    { $_ -in "help", "--help", "-h" } {
+        Start-UISContainer
+        docker exec $DockerIT $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh help
+        Write-Host ""
+        Write-Host "Container management:"
+        Write-Host "  start       Start the UIS container"
+        Write-Host "  stop        Stop the UIS container"
+        Write-Host "  restart     Restart the UIS container"
+        Write-Host "  container   Show container status"
+        Write-Host "  shell       Open a shell in the container"
+        Write-Host "  logs        Show container logs"
+        Write-Host "  build       Build the container image locally"
+        Write-Host "  test        Run container validation tests"
+    }
+    default {
+        Start-UISContainer
+        docker exec $DockerIT $ContainerName /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh @args
+    }
+}

--- a/website/docs/getting-started/overview.md
+++ b/website/docs/getting-started/overview.md
@@ -1,119 +1,107 @@
 # Getting Started
 
-**File**: `docs/overview-getting-started.md`
-**Purpose**: Quick start guide for first-time users to get Urbalurba running immediately
-**Target Audience**: New users and developers trying Urbalurba for the first time
-**Last Updated**: September 22, 2024
+Get UIS running on your machine in a few minutes.
 
-## 🚀 First Test - 5 Minutes to Running
+## Prerequisites
 
-Get Urbalurba Infrastructure running on your computer in just 5 minutes:
+- macOS, Linux, or Windows with WSL2
+- [Rancher Desktop](https://rancherdesktop.io/) installed and running (Kubernetes enabled)
+- 16GB RAM minimum (32GB recommended)
 
-### Step 1: Install Rancher Desktop (2 minutes)
-
-1. **Download Rancher Desktop**: Go to https://rancherdesktop.io/
-2. **Install**: Run the installer for your operating system
-3. **Start Rancher Desktop**: Launch the application
-4. **Wait for Kubernetes**: The Kubernetes cluster will start automatically
-
-### Step 2: Download and Start Urbalurba (3 minutes)
-
-1. **Download**: Go to https://github.com/terchris/urbalurba-infrastructure/releases
-2. **Download the latest**: Click on `urbalurba-infrastructure.zip`
-3. **Extract**: Unzip the file to your desired folder
-4. **Start**: Double-click `start-urbalurba.sh` (macOS/Linux) or `start-urbalurba.bat` (Windows)
-
-### Step 3: Open Your Browser
-
-Once the startup completes (you'll see "All services ready!"), open your browser to:
-
-**http://localhost**
-
-You'll see the Urbalurba welcome page "Hello world"
-
-## 🌐 Starting services
-
-By default you get a catch-all web page that says "Hello world". 
-
-
-There are two ways of doing this. Starting manually or defining what service should start when the cluster is built.
-
-
-We will do the simplest way first. Starting sevices manually.
-
-All management is done in the provision-host container. Log in with `./uis shell`.
-
-This takes you into the provision-host and ou should see a prompt like this:
-```plaintext
-[INFO] Logging into provision-host container...
-[INFO] Type 'exit' to return to your local machine
-
-ansible@lima-rancher-desktop:/mnt/urbalurbadisk$
-```
-
-### Deploy Your First Service
-
-Let's deploy a simple test service you can see in your browser:
+Verify Rancher Desktop is ready:
 
 ```bash
-# Run the simple setup script
-./provision-host/kubernetes/99-test/not-in-use/01-setup-whoami-public.sh
+kubectl get nodes
 ```
 
-The script will:
-- Test your Kubernetes connection
-- Deploy the whoami service and ingress
-- Wait for the pod to be ready
-- Test that the service responds
+You should see one node in `Ready` state.
 
-The output will be:
+## Install UIS
 
-```plaintext
-.. many lines ...
+Download the `uis` CLI script — this is the only file you need:
 
-PLAY RECAP *************************************************************************************************************************************
-localhost                  : ok=17   changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
-
-✅ whoami deployment complete
-🎉 Open your browser to: http://whoami.localhost
-```
-
-When it completes successfully, open your browser to:
-**http://whoami.localhost**
-
-You'll see a page showing your request details - this proves your Kubernetes cluster and ingress are working perfectly!
-
-### Monitor Your Cluster with k9s
-
-k9s is a terminal-based Kubernetes dashboard that's already installed in the provision-host:
+**macOS / Linux:**
 
 ```bash
-# Start k9s to see your cluster
+curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+chmod +x uis
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
+```
+
+## Start the Provision Host
+
+```bash
+./uis start
+```
+
+On first run this will:
+1. Pull the `uis-provision-host` container image from the registry
+2. Create local configuration directories
+3. Initialize default secrets and config files
+4. Start the provision host container
+
+Your directory now looks like this:
+
+```
+my-project/
+├── uis                   # UIS CLI (the only file you downloaded)
+├── .uis.extend/          # Service configuration overrides (yours to edit)
+├── .uis.secrets/         # Passwords, API keys, certificates (gitignored)
+└── .gitignore            # Auto-created, excludes .uis.secrets/
+```
+
+- **`.uis.extend/`** — Controls which services are enabled, cluster settings, and tool preferences. Edit these files to tailor UIS to your environment.
+- **`.uis.secrets/`** — All credentials and sensitive config. Generated with safe defaults on first run. Never committed to git.
+
+Everything else — manifests, playbooks, tools — lives inside the container image.
+
+## Deploy Your First Service
+
+```bash
+./uis deploy whoami
+```
+
+Once it completes, open your browser to **http://whoami-public.localhost** — you should see a page showing your request details. This proves your Kubernetes cluster and ingress are working.
+
+Remove it when done:
+
+```bash
+./uis undeploy whoami
+```
+
+## Common Commands
+
+```bash
+./uis list                  # Show all services and their status
+./uis deploy postgresql     # Deploy a service
+./uis undeploy postgresql   # Remove a service
+./uis stack install observability  # Deploy a full package
+./uis shell                 # Open a shell in the provision host
+./uis help                  # Show all available commands
+```
+
+## Monitor Your Cluster
+
+k9s is a terminal-based Kubernetes dashboard available inside the provision host:
+
+```bash
+./uis shell
 k9s
 ```
 
 **k9s Navigation Tips**:
-- **0** - Show all namespaces
-- **:pods** - List all pods
-- **:svc** - List all services
-- **:deploy** - List all deployments
-- **Enter** - View details of selected item
-- **l** - View logs of selected pod
-- **q** - Quit/go back
+- **0** — Show all namespaces
+- **:pods** — List all pods
+- **:svc** — List all services
+- **l** — View logs of selected pod
+- **q** — Quit/go back
 
-**What You'll See**:
-
-A line like this:
-```plaintext
-default      whoami-76575d99b4-t6q42      1/1   Running
-```
-
-- And several system pods keeping Kubernetes running
-
-
-
-
-## 🔧 What's Happening Behind the Scenes
+## How it Works
 
 ```
 ┌─────────────────────────────────────────────┐
@@ -123,42 +111,25 @@ default      whoami-76575d99b4-t6q42      1/1   Running
 │  │ Provision Host   │  │ Kubernetes      │  │
 │  │ Container        │─►│ Cluster         │  │
 │  │                  │  │                 │  │
-│  │ • Installing...  │  │ • Starting...   │  │
-│  │ • Configuring... │  │ • Services...   │  │
-│  │ • Deploying...   │  │ • Ready!        │  │
+│  │ • Ansible        │  │ • PostgreSQL    │  │
+│  │ • Helm           │  │ • Grafana       │  │
+│  │ • kubectl        │  │ • Authentik     │  │
 │  └──────────────────┘  └─────────────────┘  │
 │                            ▲                │
 │  ┌─────────────────────────┴──────────────┐ │
 │  │        Web Browser                     │ │
-│  │  http://whoami.localhost               │ │
+│  │  http://grafana.localhost              │ │
 │  └────────────────────────────────────────┘ │
 └─────────────────────────────────────────────┘
 ```
 
+1. The **Provision Host** container contains all deployment tools (Ansible, Helm, kubectl)
+2. The `./uis` CLI sends commands to the provision host
+3. The provision host deploys services to your **Kubernetes cluster**
+4. You access services through `*.localhost` URLs in your browser
 
+## Next Steps
 
-1. **Provision Host** downloads and configures all tools
-2. **Kubernetes** starts your local services
-3. **Browser** connects to the whoami-public and displays its parameters
-
-
-### How to remove the whoami test
-
-```bash
-# Run the simple setup script
-./provision-host/kubernetes/99-test/not-in-use/01-remove-whoami-public.sh
-```
-
-The service will be removed and you can verify it by using the `k9s`
-
-
-## 🎯 Next Steps
-
-Once you have the basic system running:
-
-**Explore Services**: Read the [services overview](./services.md) to understand what's available
-
-
----
-
-**💡 Goal**: Get you from zero to a running local datacenter in 5 minutes with just a browser and two downloads!
+- **[Services Overview](./services.md)** — See all available services and their cloud equivalents
+- **[Architecture](./architecture.md)** — Understand the full system design
+- **[Installation Details](./installation.md)** — Platform-specific setup guides

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,17 +1,47 @@
-# Urbalurba Infrastructure
+# Urbalurba Infrastructure Stack
 
-**Complete datacenter on your laptop** - A zero-friction developer platform that provides production-grade infrastructure locally.
+**Your cloud services, on your laptop.**
 
-## What is This?
+## What is UIS?
 
-Urbalurba Infrastructure is a comprehensive Kubernetes-based platform that runs the same configuration in development and production:
+UIS gives you the same services you use from cloud providers — databases, monitoring, AI, authentication — running on your own machine. No cloud account needed. Same configuration works on your laptop and in production.
 
-- **Local Development**: Run everything on your laptop with Rancher Desktop
-- **Production Ready**: Deploy the exact same configuration to Azure AKS or any Kubernetes cluster
-- **Zero Cloud Dependencies**: Develop and test without internet connectivity
-- **Privacy-First AI**: Run LLMs locally on your own data
+## How it Works
 
-## Run Anywhere
+A management container (the **Provision Host**) uses standard tools — Ansible, Helm, kubectl — to deploy services onto any Kubernetes cluster. You interact with it through the `./uis` CLI.
+
+```mermaid
+graph LR
+    subgraph ph["UIS Provision Host (container)"]
+        cli["./uis CLI"]
+        tools["Ansible · Helm · kubectl"]
+    end
+    subgraph k8s["Any Kubernetes Cluster"]
+        svc["PostgreSQL · Grafana · Authentik · OpenWebUI · ..."]
+    end
+    ph -- "manages & deploys" --> k8s
+```
+
+> The same provision host targets your laptop, a cloud cluster, or a Raspberry Pi — only the Kubernetes endpoint changes.
+
+## Cloud Services Comparison
+
+UIS replaces cloud-managed services with open-source equivalents you control:
+
+| What you need | Cloud service you know | UIS gives you |
+|---|---|---|
+| **Monitoring & Observability** | Azure Monitor, CloudWatch | Prometheus, Grafana, Loki, Tempo |
+| **Relational Database** | Azure Database for PostgreSQL | PostgreSQL, MySQL |
+| **AI & LLM Services** | Azure OpenAI, AWS Bedrock | OpenWebUI, LiteLLM, Ollama |
+| **Identity & SSO** | Azure AD, AWS IAM | Authentik |
+| **Data Science & Analytics** | Azure Databricks | Spark, JupyterHub, Unity Catalog |
+| **GitOps & Deployment** | Azure DevOps, GitHub Actions | ArgoCD |
+| **Message Queues** | Azure Service Bus, SQS | RabbitMQ |
+| **API Gateway** | Azure API Management | Gravitee |
+
+[See the full services comparison →](./getting-started/services.md)
+
+## Runs Anywhere
 
 | Platform | Architecture | Use Case |
 |----------|--------------|----------|
@@ -24,49 +54,6 @@ Urbalurba Infrastructure is a comprehensive Kubernetes-based platform that runs 
 Once your Kubernetes cluster is running, everything else is identical regardless of where it runs. Same manifests, same Ansible playbooks, same services, same URLs.
 :::
 
-## Services Included
-
-### Core Infrastructure
-- **Kubernetes** - Container orchestration via Rancher Desktop
-- **Traefik** - Ingress controller with automatic TLS
-- **Nginx** - Web server
-
-### Observability Stack
-- **Prometheus** - Metrics collection
-- **Grafana** - Visualization and dashboards
-- **Loki** - Log aggregation
-- **Tempo** - Distributed tracing
-- **OpenTelemetry Collector** - Telemetry pipeline
-
-### Databases
-- **PostgreSQL** - Primary relational database
-- **MySQL** - Alternative SQL database
-- **MongoDB** - Document database
-- **Qdrant** - Vector database for AI
-- **Redis** - Cache and message broker
-- **Elasticsearch** - Search engine
-
-### AI & Machine Learning
-- **OpenWebUI** - ChatGPT-like interface
-- **LiteLLM** - LLM proxy for multiple providers
-- **Ollama** - Local LLM runtime
-- **Tika** - Document extraction
-
-### Authentication
-- **Authentik** - SSO and identity provider with blueprints
-
-### Message Queues
-- **RabbitMQ** - Message broker
-
-### Development Tools
-- **ArgoCD** - GitOps continuous deployment
-- **pgAdmin** - PostgreSQL administration
-- **RedisInsight** - Redis administration
-
-### Networking
-- **Tailscale** - Secure mesh VPN
-- **Cloudflare Tunnels** - Public access without port forwarding
-
 ## Quick Start
 
 ### Prerequisites
@@ -78,22 +65,39 @@ Once your Kubernetes cluster is running, everything else is identical regardless
 
 ### Installation
 
-```bash
-# Clone the repository
-git clone https://github.com/terchris/urbalurba-infrastructure.git
-cd urbalurba-infrastructure
+Download the `uis` script and start — the container image is pulled automatically:
 
-# Start the UIS container
+**macOS / Linux:**
+
+```bash
+# Download the UIS CLI
+curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+chmod +x uis
+
+# Start the UIS provision host (pulls the container image automatically)
 ./uis start
 
-# Deploy all services to kubernetes
-./uis provision
+# Deploy a single service
+./uis deploy postgresql
 
-# Access the provision host shell
-./uis shell
+# Or install a full package
+./uis stack install observability
+```
 
-# Or deploy individual services
-./uis deploy grafana
+**Windows (PowerShell):**
+
+```powershell
+# Download the UIS CLI
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
+
+# Start the UIS provision host (pulls the container image automatically)
+.\uis.ps1 start
+
+# Deploy a single service
+.\uis.ps1 deploy postgresql
+
+# Or install a full package
+.\uis.ps1 stack install observability
 ```
 
 ### Access Your Services
@@ -102,7 +106,6 @@ After deployment, access services at:
 
 | Service | URL |
 |---------|-----|
-| Nginx | [http://localhost](http://localhost) |
 | Grafana | [http://grafana.localhost](http://grafana.localhost) |
 | Prometheus | [http://prometheus.localhost](http://prometheus.localhost) |
 | Authentik | [http://authentik.localhost](http://authentik.localhost) |
@@ -110,27 +113,31 @@ After deployment, access services at:
 | pgAdmin | [http://pgadmin.localhost](http://pgadmin.localhost) |
 | ArgoCD | [http://argocd.localhost](http://argocd.localhost) |
 
-## Documentation Structure
+## Documentation
 
-- **[Getting Started](./getting-started/overview.md)** - First steps and quick start guide
-- **[Hosts & Platforms](./hosts/index.md)** - Supported platforms and setup guides
-- **[Packages](./packages/ai/index.md)** - Service documentation by category
-- **[Networking](./networking/index.md)** - External access via Tailscale and Cloudflare
-- **[Rules & Standards](./rules/index.md)** - Development conventions and patterns
-- **[Troubleshooting](./reference/troubleshooting.md)** - Common issues and solutions
+- **[Getting Started](./getting-started/overview.md)** — First steps and quick start guide
+- **[Hosts & Platforms](./hosts/index.md)** — Supported platforms and setup guides
+- **[Packages](./packages/ai/index.md)** — Service documentation by category
+- **[Networking](./networking/index.md)** — External access via Tailscale and Cloudflare
+- **[Rules & Standards](./rules/index.md)** — Development conventions and patterns
+- **[Troubleshooting](./reference/troubleshooting.md)** — Common issues and solutions
 
-## Repository Structure
+## Your Working Directory
+
+After running `./uis start`, your directory looks like this:
 
 ```
-urbalurba-infrastructure/
-├── ansible/              # Ansible playbooks for deployment
-├── docs/                 # Documentation (this site)
-├── manifests/            # Kubernetes manifests (numbered by category)
-├── provision-host/       # Provision host container scripts
-├── .uis.secrets/         # Secrets management (gitignored)
-├── uis                   # UIS CLI wrapper (main entry point)
-└── mkdocs.yml            # Documentation site configuration
+my-project/
+├── uis                   # UIS CLI (the only file you download)
+├── .uis.extend/          # Service configuration overrides (yours to edit)
+├── .uis.secrets/         # Passwords, API keys, certificates (gitignored)
+└── .gitignore            # Auto-created, excludes .uis.secrets/
 ```
+
+- **`.uis.extend/`** — Customize which services are enabled, cluster settings, and tool preferences. Edit these files to tailor UIS to your environment.
+- **`.uis.secrets/`** — All credentials and sensitive config. Generated with safe defaults on first run. Never committed to git.
+
+Everything else lives inside the container image — manifests, playbooks, and tools are all baked in.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Rewrites the landing page (`index.md`) with cloud services comparison table, Mermaid architecture diagram, and container-based quick start
- Rewrites getting started page (`overview.md`) with current `./uis` CLI workflow — no more zip downloads or raw script paths
- Adds `uis.ps1` PowerShell equivalent for Windows users
- Both install sections show macOS/Linux and Windows instructions
- Explains `.uis.extend/` and `.uis.secrets/` directories

## Test plan
- [ ] Verify Docusaurus build passes (`npm run build` in `website/`)
- [ ] Check landing page renders correctly at https://uis.sovereignsky.no/docs
- [ ] Verify Mermaid architecture diagram renders
- [ ] Check cloud comparison table and "See full services comparison" link works
- [ ] Verify getting-started/overview page at https://uis.sovereignsky.no/docs/getting-started/overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)