### PR TITLE
docs: restore kubeconfig backup script reference

### DIFF
--- a/website/docs/hosts/rancher-kubernetes.md
+++ b/website/docs/hosts/rancher-kubernetes.md
@@ -103,7 +103,7 @@ kubectl config current-context               # Verify current
 To completely reset and start fresh:
 
 :::warning
-All data, configurations, and certificates will be permanently lost. If you manage multiple clusters, back up your kubeconfig first.
+All data, configurations, and certificates will be permanently lost. If you manage multiple clusters, back up your kubeconfig first with `kubeconf-copy2local.sh`.
 :::
 
 1. Open Rancher Desktop


### PR DESCRIPTION
## Summary
- Restores `kubeconf-copy2local.sh` reference in the factory reset warning that was accidentally removed in #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)