### PR TITLE
docs: fix kubeconfig backup to use real command

### DIFF
--- a/website/docs/hosts/rancher-kubernetes.md
+++ b/website/docs/hosts/rancher-kubernetes.md
@@ -103,7 +103,7 @@ kubectl config current-context               # Verify current
 To completely reset and start fresh:
 
 :::warning
-All data, configurations, and certificates will be permanently lost. If you manage multiple clusters, back up your kubeconfig first with `kubeconf-copy2local.sh`.
+All data, configurations, and certificates will be permanently lost. If you manage multiple clusters, back up your kubeconfig first: `cp ~/.kube/config ~/.kube/config.backup`
 :::
 
 1. Open Rancher Desktop


### PR DESCRIPTION
## Summary
- `kubeconf-copy2local.sh` doesn't exist — replaced with `cp ~/.kube/config ~/.kube/config.backup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)