### PR TITLE
Upgrade Elasticsearch to 9.3.0

### DIFF
--- a/manifests/060-elasticsearch-config.yaml
+++ b/manifests/060-elasticsearch-config.yaml
@@ -14,6 +14,9 @@
 # Uninstall:
 # helm uninstall elasticsearch -n search
 
+# Pin Elasticsearch version explicitly (chart is archived at 8.5.1, image overrides independently)
+imageTag: "9.3.0"
+
 # Single node configuration
 # NOTE: Do NOT set discovery.type: single-node in esConfig - the chart handles
 # single-node mode automatically when replicas: 1, and setting it explicitly

--- a/website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-service-version-metadata.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-service-version-metadata.md
@@ -1,0 +1,106 @@
+# Investigate: Version Metadata in Service Scripts
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Decide how service scripts should expose version information for docs generation and CLI display
+
+**Last Updated**: 2026-03-09
+
+**Related**:
+- [INVESTIGATE-version-pinning.md](INVESTIGATE-version-pinning.md) — Tracks which services are pinned
+- [adding-a-service.md](../../../contributors/guides/adding-a-service.md) — Service definition guide (must be updated with the decision)
+
+---
+
+## Problem
+
+The docs generator (`uis-docs-markdown.sh`) hardcodes "(unpinned)" for every service with a `SCRIPT_HELM_CHART` field — even for services that ARE pinned (ArgoCD `7.8.26`, Gravitee `4.8.4`, Authentik `2025.8.1`). There is no metadata field for version information.
+
+Versions currently live in different places depending on the service:
+
+| Service | Where version lives | Service script knows? |
+|---------|--------------------|-----------------------|
+| ArgoCD | Playbook var `argocd_chart_version: "7.8.26"` | No |
+| Gravitee | Hardcoded `--version 4.8.4` in playbook | No |
+| Authentik | Playbook var `authentik_chart_version` | No |
+| Elasticsearch | `imageTag: "9.3.0"` in Helm values yaml | No |
+| MongoDB | `SCRIPT_IMAGE="mongo:8.0.5"` | Yes (baked into image tag) |
+| MySQL | `SCRIPT_IMAGE="mysql:8.0"` | Yes (baked into image tag) |
+| Whoami | `SCRIPT_IMAGE="traefik/whoami:v1.10.2"` | Yes (baked into image tag) |
+
+Services using `SCRIPT_IMAGE` already have version info in the script. Helm-based services do not.
+
+---
+
+## Questions to Answer
+
+1. Should we add a version field to service scripts (e.g. `SCRIPT_HELM_CHART_VERSION`)?
+2. If yes, is it acceptable to maintain the version in two places (script + playbook/config)?
+3. Should the field be required or optional?
+4. Should the docs generator show "(unpinned)" or nothing when no version is set?
+5. Could the version be extracted automatically from the playbook or config file instead of duplicating it?
+
+---
+
+## Options
+
+### Option A: Add optional `SCRIPT_HELM_CHART_VERSION` field
+
+Add a new metadata field. Services that want their version shown in docs set it. Others leave it blank.
+
+**Pros:**
+- Simple to implement
+- Service script remains the single source of truth for docs
+- Optional — no obligation to set for all services
+
+**Cons:**
+- Dual maintenance — version must be updated in both the script and the playbook/config
+- Risk of version drift between script metadata and actual deployed version
+
+### Option B: Extract version automatically from playbooks/configs
+
+The docs generator reads the actual playbook or config file to find the version.
+
+**Pros:**
+- Single source of truth — no dual maintenance
+- Always accurate
+
+**Cons:**
+- Complex parsing — different services store versions differently (playbook vars, `--version` flags, `imageTag` in yaml)
+- Fragile — tightly couples docs generator to playbook/config format
+- May not work for all services
+
+### Option C: Keep it manual — edit docs pages directly
+
+Don't add a metadata field. When a version is pinned, manually update the generated docs page.
+
+**Pros:**
+- No new metadata fields or generator changes
+- Works now for Elasticsearch (just edit the `.md` file)
+
+**Cons:**
+- Generated pages can overwrite manual edits (if `--force` is used)
+- No programmatic way to list versions (e.g. `./uis list --versions`)
+- Inconsistent — some info comes from metadata, some is manually maintained
+
+---
+
+## Current State
+
+- 19 metadata fields exist in service scripts (none for versions)
+- `uis-docs-markdown.sh` line 184 hardcodes "(unpinned)" for all Helm charts
+- `uis-docs.sh` (JSON generator) outputs `helmChart` but no version field
+- The docs pages are generated once (skip if exists), so manual edits survive unless `--force` is used
+- 3 of 21 Helm charts are pinned, 18 are unpinned
+
+---
+
+## Next Steps
+
+- [ ] Decide on an approach
+- [ ] Create PLAN to implement the chosen approach
+- [ ] Update `adding-a-service.md` with the new convention

--- a/website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-version-pinning.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-version-pinning.md
@@ -30,7 +30,7 @@ Everything works today, but 18 of 21 Helm charts and several container images ha
 | **postgresql** | `bitnami/postgresql` | — | UNPINNED |
 | **redis** | `bitnami/redis` | — | UNPINNED |
 | **rabbitmq** | `bitnami/rabbitmq` | — | UNPINNED |
-| **elasticsearch** | `elastic/elasticsearch` | — | UNPINNED |
+| **elasticsearch** | `elastic/elasticsearch` | `9.3.0` | PINNED |
 | **qdrant** | `qdrant/qdrant` | — | UNPINNED |
 | **tika** | `tika/tika` | — | UNPINNED |
 | **open-webui** | `open-webui/open-webui` | — | UNPINNED |
@@ -41,7 +41,7 @@ Everything works today, but 18 of 21 Helm charts and several container images ha
 | **redisinsight** | `redisinsight/redisinsight` | — | UNPINNED |
 | **mysql** | (manifest, no helm) | — | N/A |
 
-**Summary: 3 pinned, 18 unpinned out of 21 Helm charts.**
+**Summary: 4 pinned, 17 unpinned out of 21 Helm charts.**
 
 ### Container Images — Version Pinning Status
 
@@ -53,6 +53,7 @@ Images explicitly set in manifests or config files:
 | **mongodb** | `mongo` | `8.0.5` | PINNED |
 | **rabbitmq** | `bitnamilegacy/rabbitmq` | `3.13.7-debian-12-r5` | PINNED |
 | **tika** | `apache/tika` | `3.0.0.0` | PINNED |
+| **elasticsearch** | `docker.elastic.co/elasticsearch/elasticsearch` | `9.3.0` | PINNED |
 | **redis** | `redis` | `7.4` | FLOATING (minor) |
 | **mysql** | `mysql` | `8.0` | FLOATING (minor) |
 | **postgresql** | `ghcr.io/terchris/urbalurba-postgresql` | `latest` | UNPINNED |
@@ -61,7 +62,7 @@ Images explicitly set in manifests or config files:
 | **pgadmin init** | `busybox` | `latest` | UNPINNED |
 
 Images controlled by Helm chart (not explicitly set in our config — chart decides):
-- prometheus, grafana, tempo, loki, otel-collector, elasticsearch, qdrant, open-webui, litellm, spark, jupyterhub, pgadmin, redisinsight, authentik, argocd
+- prometheus, grafana, tempo, loki, otel-collector, qdrant, open-webui, litellm, spark, jupyterhub, pgadmin, redisinsight, authentik, argocd
 
 ---
 

--- a/website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md
@@ -18,8 +18,9 @@ These items reduce risk, fix broken services, and unblock new service deployment
 
 | # | Investigation | Status | Blocks | Summary |
 |---|--------------|--------|--------|---------|
-| 1 | [Elasticsearch upgrade](INVESTIGATE-elasticsearch-upgrade.md) | Ready for PLAN | OpenMetadata | Upgrade ES 8.5.1 → 9.3.0. One-line change. Only Gravitee depends on ES, and it supports 9.x. |
+| 1 | [Elasticsearch upgrade](INVESTIGATE-elasticsearch-upgrade.md) | Complete | OpenMetadata | Upgrade ES 8.5.1 → 9.3.0. Pinned `imageTag: "9.3.0"`. Verified by tester. |
 | 2 | [Version pinning](INVESTIGATE-version-pinning.md) | Backlog | — | 18 of 21 Helm charts unpinned. Should happen alongside ES upgrade. |
+| 2b | [Service version metadata](INVESTIGATE-service-version-metadata.md) | Backlog | — | Decide how service scripts expose version info for docs generation. Docs generator hardcodes "(unpinned)" even for pinned services. |
 | 3 | [Gravitee fix](INVESTIGATE-gravitee-fix.md) | Backlog | — | Only unverified service. Hardcoded credentials, no remove playbook, wrong namespace, `Host()` instead of `HostRegexp()`. |
 
 ---
@@ -69,6 +70,7 @@ Investigations where the work has been implemented. The INVESTIGATE files have b
 | Documentation generation | 2026-03-02 | [PLAN-015](../completed/PLAN-015-documentation-generation.md) |
 | Dev template ingress cleanup | 2026-03-04 | [PLAN-dev-template-ingress-cleanup](../completed/PLAN-dev-template-ingress-cleanup.md) |
 | PowerShell ErrorActionPreference | 2026-03-04 | [PLAN-uis-ps1-erroractionpreference](../completed/PLAN-uis-ps1-erroractionpreference.md) |
+| Elasticsearch upgrade | 2026-03-09 | [PLAN-elasticsearch-upgrade](../completed/PLAN-elasticsearch-upgrade.md) |
 
 ---
 

--- a/website/docs/ai-development/ai-developer/plans/completed/INVESTIGATE-elasticsearch-upgrade.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/INVESTIGATE-elasticsearch-upgrade.md
@@ -126,5 +126,5 @@ This is a low-risk change: only one service (Gravitee) depends on ES, and Gravit
 
 ## Next Steps
 
-- [ ] Create PLAN to upgrade and pin Elasticsearch version
-- [ ] After upgrade: update `INVESTIGATE-version-pinning.md` — change Elasticsearch row from UNPINNED to PINNED with version `9.3.0`
+- [x] Create PLAN to upgrade and pin Elasticsearch version ✓
+- [x] After upgrade: update `INVESTIGATE-version-pinning.md` — change Elasticsearch row from UNPINNED to PINNED with version `9.3.0` ✓

--- a/website/docs/ai-development/ai-developer/plans/completed/PLAN-elasticsearch-upgrade.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/PLAN-elasticsearch-upgrade.md
@@ -1,0 +1,104 @@
+# Upgrade Elasticsearch to 9.3.0
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Completed
+
+**Completed**: 2026-03-09
+
+**Goal**: Pin Elasticsearch to version 9.3.0, upgrading from the unpinned 8.5.1 default to unblock OpenMetadata deployment and eliminate version drift risk.
+
+**Last Updated**: 2026-03-09
+
+**Priority**: High
+
+**Blocks**: [OpenMetadata deployment](INVESTIGATE-openmetadata-deployment.md) (requires ES 9.x)
+
+**Related**: [INVESTIGATE-elasticsearch-upgrade.md](INVESTIGATE-elasticsearch-upgrade.md), [INVESTIGATE-version-pinning.md](INVESTIGATE-version-pinning.md)
+
+---
+
+## Problem
+
+Elasticsearch is deployed via the `elastic/elasticsearch` Helm chart with no explicit image tag. The chart defaults to 8.5.1. This causes two problems:
+
+1. **OpenMetadata requires ES 9.x** — the ES 9.x client is not backwards-compatible with 8.x servers
+2. **No version pinning** — while the archived Helm chart won't change, relying on an implicit default is fragile
+
+Only Gravitee depends on Elasticsearch, and it supports ES 9.2.x+. The upgrade is a single-line config change.
+
+---
+
+## Phase 1: Upgrade Elasticsearch Config and Metadata — ✅ DONE
+
+### Tasks
+
+- [x] 1.1 Add `imageTag: "9.3.0"` to `manifests/060-elasticsearch-config.yaml` (after the `replicas: 1` line) ✓
+- [x] 1.2 Update `website/docs/packages/databases/elasticsearch.md` — change Helm chart row from `(unpinned)` to `(pinned: 9.3.0)` ✓
+- [x] 1.3 Update `website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-version-pinning.md` ✓:
+  - Change the Elasticsearch row in the Helm Charts table from `UNPINNED` to `PINNED 9.3.0`
+  - Remove `elasticsearch` from the "Images controlled by Helm chart" list
+  - Add Elasticsearch to the Container Images table as `PINNED` with tag `9.3.0`
+  - Update the summary count (3 → 4 pinned, 18 → 17 unpinned)
+
+### Validation
+
+```bash
+# Deploy and verify version
+./uis deploy elasticsearch
+
+# Check version (should show 9.3.0)
+kubectl exec elasticsearch-master-0 -- curl -s http://localhost:9200 | jq '.version.number'
+
+# Check cluster health (yellow or green is OK for single node)
+kubectl exec elasticsearch-master-0 -- curl -s http://localhost:9200/_cluster/health | jq '.status'
+```
+
+User confirms Elasticsearch 9.3.0 is running and healthy.
+
+---
+
+## Phase 2: Update Investigation and Roadmap Status — ✅ DONE
+
+### Tasks
+
+- [x] 2.1 Update `website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-elasticsearch-upgrade.md` — mark both Next Steps checkboxes as done ✓
+- [x] 2.2 Update `website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md` — change item #1 status from "Ready for PLAN" to "Complete" ✓
+
+### Validation
+
+User confirms the status updates are correct.
+
+---
+
+## Acceptance Criteria
+
+- [x] `manifests/060-elasticsearch-config.yaml` contains `imageTag: "9.3.0"` ✓
+- [x] Elasticsearch pod runs version 9.3.0 ✓
+- [x] Cluster health is yellow or green (green) ✓
+- [x] Elasticsearch docs page shows pinned version ✓
+- [x] Version-pinning investigation shows ES as PINNED ✓
+- [x] Elasticsearch upgrade investigation shows next steps done ✓
+- [x] Platform roadmap shows item #1 as complete ✓
+
+---
+
+## Implementation Notes
+
+- The `elastic/elasticsearch` Helm chart is archived at chart version 8.5.1, but `imageTag` overrides the Docker image independently of the chart version
+- ES 9.x can read indices created by 8.x — no data migration needed
+- If the PVC has stale data causing issues, deleting it and letting Gravitee re-index is acceptable (dev data)
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `manifests/060-elasticsearch-config.yaml` | Add `imageTag: "9.3.0"` |
+| `website/docs/packages/databases/elasticsearch.md` | Update Helm chart row to show pinned version |
+| `website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-version-pinning.md` | Mark ES as PINNED 9.3.0 |
+| `website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-elasticsearch-upgrade.md` | Mark next steps as done |
+| `website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md` | Mark #1 as complete |

--- a/website/docs/packages/databases/elasticsearch.md
+++ b/website/docs/packages/databases/elasticsearch.md
@@ -14,7 +14,7 @@ Distributed search and analytics engine for full-text search and log analysis.
 | **Undeploy** | `./uis undeploy elasticsearch` |
 | **Depends on** | None |
 | **Required by** | None |
-| **Helm chart** | `elastic/elasticsearch` (unpinned) |
+| **Helm chart** | `elastic/elasticsearch` (pinned: 9.3.0) |
 | **Default namespace** | `default` |
 
 ## What It Does


### PR DESCRIPTION
## Summary
- Pin Elasticsearch image to version 9.3.0 (was unpinned at chart default 8.5.1)
- Unblocks OpenMetadata deployment (requires ES 9.x)
- Only Gravitee depends on ES, and it supports 9.2.x+
- Tested by uis-user1: deploy, version check, cluster health all PASS

## Changes
- `manifests/060-elasticsearch-config.yaml` — add `imageTag: "9.3.0"`
- Update version-pinning investigation (4 pinned, 17 unpinned)
- Create new investigation for service version metadata in docs generator
- Move ES upgrade plan and investigation to completed
- Update platform roadmap (item #1 complete)

## Test plan
- [x] `./uis deploy elasticsearch` succeeds
- [x] `kubectl exec elasticsearch-master-0 -- curl -s http://localhost:9200` shows version 9.3.0
- [x] Cluster health is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)