### PR TITLE
feat: deploy OpenMetadata 1.12.1 as UIS platform service

### DIFF
--- a/ansible/playbooks/340-remove-openmetadata.yml
+++ b/ansible/playbooks/340-remove-openmetadata.yml
@@ -1,0 +1,82 @@
+---
+# file: ansible/playbooks/340-remove-openmetadata.yml
+# Description: Remove OpenMetadata from Kubernetes
+#
+# Usage:
+# ansible-playbook playbooks/340-remove-openmetadata.yml -e kube_context="rancher-desktop"
+
+- name: Remove OpenMetadata from Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    manifests_folder: "/mnt/urbalurbadisk/manifests"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    openmetadata_namespace: "openmetadata"
+
+  tasks:
+    - name: 1. Print playbook description
+      ansible.builtin.debug:
+        msg: |
+          Removing OpenMetadata from Kubernetes
+          Namespace: {{ openmetadata_namespace }}
+
+    - name: 2. Delete OpenMetadata IngressRoute
+      kubernetes.core.k8s:
+        src: "{{ manifests_folder }}/341-openmetadata-ingressroute.yaml"
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 3. Check for OpenMetadata Helm release
+      ansible.builtin.shell: helm list -n {{ openmetadata_namespace }} | grep -w openmetadata
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: helm_check
+      changed_when: false
+      ignore_errors: true
+
+    - name: 4. Remove OpenMetadata Helm release
+      ansible.builtin.command: helm uninstall openmetadata -n {{ openmetadata_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: helm_check.rc == 0
+      changed_when: true
+      ignore_errors: true
+
+    - name: 5. Wait for pods to terminate
+      ansible.builtin.shell: |
+        kubectl wait --for=delete pod -l app.kubernetes.io/name=openmetadata -n {{ openmetadata_namespace }} --timeout=60s 2>/dev/null || true
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: false
+
+    - name: 6. Delete PVCs in openmetadata namespace
+      ansible.builtin.shell: kubectl delete pvc -n {{ openmetadata_namespace }} --all --ignore-not-found
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      ignore_errors: true
+
+    - name: 7. Delete openmetadata namespace
+      kubernetes.core.k8s:
+        name: "{{ openmetadata_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 8. Display removal status
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          OpenMetadata Removal Status
+          ===============================================
+
+          ✅ OpenMetadata resources removed
+
+          Note: The PostgreSQL database 'openmetadata_db' was NOT deleted.
+          To remove the database manually:
+            kubectl exec -n default postgresql-0 -- psql -U postgres -c "DROP DATABASE openmetadata_db;"
+
+          ===============================================

--- a/ansible/playbooks/340-setup-openmetadata.yml
+++ b/ansible/playbooks/340-setup-openmetadata.yml
@@ -1,0 +1,394 @@
+---
+# file: ansible/playbooks/340-setup-openmetadata.yml
+# Description:
+# Set up OpenMetadata data governance platform on Kubernetes.
+# Uses the official Helm chart with existing UIS PostgreSQL and Elasticsearch.
+# K8s native orchestrator for ingestion (no Airflow).
+#
+# Prerequisites:
+# - Kubernetes cluster is set up and accessible
+# - PostgreSQL deployed (manifest 042)
+# - Elasticsearch deployed (manifest 060)
+# - urbalurba-secrets applied to openmetadata namespace
+# - Helm 3.x installed
+#
+# Usage:
+# ansible-playbook playbooks/340-setup-openmetadata.yml -e kube_context="rancher-desktop"
+
+- name: Set up OpenMetadata on Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    manifests_folder: "/mnt/urbalurbadisk/manifests"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    openmetadata_namespace: "openmetadata"
+    openmetadata_config_file: "{{ manifests_folder }}/340-openmetadata-config.yaml"
+    openmetadata_ingress_file: "{{ manifests_folder }}/341-openmetadata-ingressroute.yaml"
+    openmetadata_helm_repo_url: "https://open-metadata.github.io/openmetadata-helm-charts/"
+    openmetadata_helm_chart: "open-metadata/openmetadata"
+    openmetadata_helm_version: "1.12.1"
+    installation_timeout: 600
+    pod_readiness_timeout: 300
+
+  tasks:
+    - name: 1. Print playbook description
+      ansible.builtin.debug:
+        msg: |
+          Setting up OpenMetadata on Kubernetes
+          Version: {{ openmetadata_helm_version }}
+          Namespace: {{ openmetadata_namespace }}
+          Database: PostgreSQL (existing UIS instance)
+          Search: Elasticsearch (existing UIS instance)
+          Orchestrator: K8s Jobs (no Airflow)
+
+    # ============= PHASE 1: PREREQUISITES VERIFICATION =============
+
+    - name: 2. Create openmetadata namespace
+      kubernetes.core.k8s:
+        name: "{{ openmetadata_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 3. Check if PostgreSQL is available
+      ansible.builtin.shell: >-
+        kubectl get service postgresql -n default --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: postgres_check
+      changed_when: false
+
+    - name: 4. Fail if PostgreSQL is not available
+      ansible.builtin.fail:
+        msg: "PostgreSQL is required for OpenMetadata. Deploy it first: ./uis deploy postgresql"
+      when: postgres_check.stdout | int == 0
+
+    - name: 5. Check if Elasticsearch is available
+      ansible.builtin.shell: >-
+        kubectl get service elasticsearch-master -n default --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: elasticsearch_check
+      changed_when: false
+
+    - name: 6. Fail if Elasticsearch is not available
+      ansible.builtin.fail:
+        msg: "Elasticsearch is required for OpenMetadata. Deploy it first: ./uis deploy elasticsearch"
+      when: elasticsearch_check.stdout | int == 0
+
+    - name: 7. Check if urbalurba-secrets exists in openmetadata namespace
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n {{ openmetadata_namespace }} --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: secrets_check
+      changed_when: false
+
+    - name: 8. Display prerequisites status
+      ansible.builtin.debug:
+        msg: |
+          Prerequisites:
+          - PostgreSQL: Available ✅
+          - Elasticsearch: Available ✅
+          - Secrets: {{ 'Configured ✅' if (secrets_check.stdout | int) > 0 else 'Not found ⚠️ — run ./uis secrets generate && ./uis secrets apply' }}
+
+    # ============= PHASE 2: DATABASE SETUP =============
+
+    - name: 9. Get PostgreSQL pod name
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ merged_kubeconf_file }}"
+        kind: Pod
+        namespace: default
+        label_selectors:
+          - app.kubernetes.io/name=postgresql
+      register: postgres_pods
+
+    - name: 10. Set PostgreSQL pod name
+      ansible.builtin.set_fact:
+        postgres_pod_name: "{{ postgres_pods.resources[0].metadata.name }}"
+      when: postgres_pods.resources | length > 0
+
+    - name: 11. Get PostgreSQL password from urbalurba-secrets
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n default
+        -o jsonpath='{.data.PGPASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: postgres_password
+      changed_when: false
+
+    - name: 12. Create openmetadata_db database in PostgreSQL
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}' createdb -h postgresql.default -U postgres openmetadata_db || echo 'Database may already exist'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: create_db_result
+      changed_when: "'Database may already exist' not in create_db_result.stdout"
+      ignore_errors: true
+
+    - name: 13. Display database creation result
+      ansible.builtin.debug:
+        msg: "OpenMetadata database: {{ 'Created successfully ✅' if create_db_result.changed else 'Already exists ✅' }}"
+
+    # ============= PHASE 3: HELM DEPLOYMENT =============
+
+    - name: 14. Check existing Helm repositories
+      ansible.builtin.command: helm repo list
+      register: helm_repo_list
+      changed_when: false
+      ignore_errors: true
+
+    - name: 15. Add OpenMetadata Helm repository if missing
+      kubernetes.core.helm_repository:
+        name: "open-metadata"
+        repo_url: "{{ openmetadata_helm_repo_url }}"
+      when: "'open-metadata' not in helm_repo_list.stdout"
+
+    - name: 16. Update Helm repositories
+      ansible.builtin.command: helm repo update
+      changed_when: false
+
+    - name: 17. Deploy OpenMetadata using official Helm chart
+      ansible.builtin.command: >
+        helm upgrade --install openmetadata {{ openmetadata_helm_chart }}
+        --version {{ openmetadata_helm_version }}
+        -f {{ openmetadata_config_file }}
+        --namespace {{ openmetadata_namespace }}
+        --timeout {{ installation_timeout }}s
+        --wait
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: openmetadata_install
+      changed_when: true
+
+    - name: 18. Display Helm install output
+      ansible.builtin.debug:
+        msg: "{{ openmetadata_install.stdout_lines }}"
+      when: openmetadata_install.stdout_lines is defined
+
+    # ============= PHASE 4: WAIT FOR READINESS =============
+
+    - name: 19. Wait for OpenMetadata pod to be running
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ openmetadata_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/name=openmetadata"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: openmetadata_pods
+      until: >
+        openmetadata_pods.resources | length > 0 and
+        openmetadata_pods.resources[0].status.phase == "Running"
+      retries: 30
+      delay: 15
+
+    - name: 20. Wait for OpenMetadata pod to be ready (1/1)
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ openmetadata_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/name=openmetadata"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: openmetadata_pods_ready
+      until: >
+        openmetadata_pods_ready.resources | length > 0 and
+        openmetadata_pods_ready.resources[0].status.containerStatuses is defined and
+        openmetadata_pods_ready.resources[0].status.containerStatuses | length > 0 and
+        openmetadata_pods_ready.resources[0].status.containerStatuses[0].ready == true
+      retries: 30
+      delay: 10
+
+    # ============= PHASE 5: INGRESS =============
+
+    - name: 21. Apply OpenMetadata IngressRoute
+      kubernetes.core.k8s:
+        src: "{{ openmetadata_ingress_file }}"
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    # ============= PHASE 6: HEALTH CHECK =============
+
+    - name: 22. Check OpenMetadata API health
+      ansible.builtin.shell: |
+        kubectl run curl-health-check-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          curl -s -w "\nHTTP_CODE:%{http_code}" http://openmetadata.{{ openmetadata_namespace }}.svc.cluster.local:8585/api/v1/system/version
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: health_check
+      retries: 10
+      delay: 15
+      until: "'HTTP_CODE:200' in health_check.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: 23. Display health check result
+      ansible.builtin.debug:
+        msg: "API health: {{ '✅ Responding' if 'HTTP_CODE:200' in health_check.stdout else '⚠️ Not responding yet — may need more startup time' }}"
+
+    # ============= PHASE 7: ADMIN PASSWORD CHANGE =============
+    # OpenMetadata bootstraps with admin@open-metadata.org / admin.
+    # The Helm chart provides no mechanism to override this.
+    # We change the password post-deploy via the API.
+    # The login email is fixed at admin@open-metadata.org — cannot be changed.
+    #
+    # API quirks (OpenMetadata 1.12.1):
+    # - Login API: password must be BASE64-encoded in the JSON body
+    # - changePassword API: passwords must be RAW (not base64)
+    # - changePassword requires requestType: "USER" (not "SELF")
+    # - Password must meet complexity rules (8+ chars, upper, lower, digit, special char)
+    #
+    # Logic (idempotent):
+    # 1. Try default password (admin) — single attempt to avoid lockout
+    # 2. If default works → change password → done
+    # 3. If default fails → try target password (already changed on previous deploy)
+    # 4. If target works → already configured → done
+    # 5. If both fail → warn (account locked or unknown state)
+
+    - name: 24. Get desired admin password from urbalurba-secrets
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n {{ openmetadata_namespace }}
+        -o jsonpath='{.data.OPENMETADATA_ADMIN_PASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: desired_admin_password
+      changed_when: false
+
+    - name: 25. Try login with default credentials (admin@open-metadata.org / admin)
+      ansible.builtin.shell: |
+        kubectl run curl-pw-check-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          sh -c '
+            DEFAULT_PW_B64=$(echo -n "admin" | base64)
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X POST http://openmetadata.{{ openmetadata_namespace }}.svc.cluster.local:8585/api/v1/users/login \
+              -H "Content-Type: application/json" \
+              -d "{\"email\":\"admin@open-metadata.org\",\"password\":\"${DEFAULT_PW_B64}\"}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "accessToken"; then
+              echo "DEFAULT_LOGIN: SUCCESS"
+            else
+              echo "DEFAULT_LOGIN: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: default_login_result
+      failed_when: false
+      changed_when: false
+
+    - name: 26. Set default login status
+      ansible.builtin.set_fact:
+        default_login_ok: "{{ 'DEFAULT_LOGIN: SUCCESS' in (default_login_result.stdout | default('')) }}"
+
+    - name: 27. Extract JWT token from default login
+      ansible.builtin.set_fact:
+        default_jwt: "{{ default_login_result.stdout | regex_search('\"accessToken\"\\s*:\\s*\"([^\"]+)\"', '\\1') | first | default('') }}"
+      when: default_login_ok | bool
+      ignore_errors: true
+
+    - name: 28. Change admin password via API (if default login succeeded)
+      ansible.builtin.shell: |
+        kubectl run curl-pw-change-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X PUT http://openmetadata.{{ openmetadata_namespace }}.svc.cluster.local:8585/api/v1/users/changePassword \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer {{ default_jwt }}" \
+              -d "{\"username\":\"admin\",\"oldPassword\":\"admin\",\"newPassword\":\"{{ desired_admin_password.stdout }}\",\"confirmPassword\":\"{{ desired_admin_password.stdout }}\",\"requestType\":\"USER\"}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "HTTP_CODE:200"; then
+              echo "PASSWORD_CHANGE: SUCCESS"
+            else
+              echo "PASSWORD_CHANGE: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: password_change_result
+      when: default_login_ok | bool and default_jwt is defined and default_jwt | length > 0
+      changed_when: "'PASSWORD_CHANGE: SUCCESS' in (password_change_result.stdout | default(''))"
+      failed_when: false
+
+    - name: 29. Try login with target password (if default login failed — password may already be changed)
+      ansible.builtin.shell: |
+        kubectl run curl-pw-target-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          sh -c '
+            TARGET_PW_B64=$(echo -n "{{ desired_admin_password.stdout }}" | base64)
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X POST http://openmetadata.{{ openmetadata_namespace }}.svc.cluster.local:8585/api/v1/users/login \
+              -H "Content-Type: application/json" \
+              -d "{\"email\":\"admin@open-metadata.org\",\"password\":\"${TARGET_PW_B64}\"}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "accessToken"; then
+              echo "TARGET_LOGIN: SUCCESS"
+            else
+              echo "TARGET_LOGIN: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: target_login_result
+      when: not (default_login_ok | bool)
+      failed_when: false
+      changed_when: false
+
+    - name: 30. Display password configuration result
+      ansible.builtin.debug:
+        msg: >-
+          Admin password: {{
+            '✅ Changed to configured password'
+            if (password_change_result is defined and password_change_result is not skipped and 'PASSWORD_CHANGE: SUCCESS' in (password_change_result.stdout | default('')))
+            else (
+              '✅ Already configured (previous deploy)'
+              if (target_login_result is defined and target_login_result is not skipped and 'TARGET_LOGIN: SUCCESS' in (target_login_result.stdout | default('')))
+              else '⚠️ Could not configure — run: ./uis undeploy openmetadata, drop the database, then redeploy'
+            )
+          }}
+
+    # ============= PHASE 8: STATUS =============
+
+    - name: 31. Get OpenMetadata pods
+      ansible.builtin.shell: kubectl get pods -n {{ openmetadata_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: openmetadata_pod_status
+      changed_when: false
+
+    - name: 32. Get OpenMetadata services
+      ansible.builtin.shell: kubectl get services -n {{ openmetadata_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: openmetadata_svc_status
+      changed_when: false
+
+    - name: 33. Display final status
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          OpenMetadata Deployment Status
+          ===============================================
+
+          {{ '✅ SUCCESS - OpenMetadata deployed and ready' if 'HTTP_CODE:200' in health_check.stdout else '⚠️ DEPLOYED - API may still be starting up' }}
+
+          📊 Deployment Details:
+          • Chart: {{ openmetadata_helm_chart }} (version {{ openmetadata_helm_version }})
+          • Namespace: {{ openmetadata_namespace }}
+          • Database: openmetadata_db on PostgreSQL
+          • Search: Elasticsearch (existing)
+          • Orchestrator: K8s Jobs (no Airflow)
+
+          📦 Pods:
+          {{ openmetadata_pod_status.stdout }}
+
+          🌐 Services:
+          {{ openmetadata_svc_status.stdout }}
+
+          🌐 Access:
+          • UI: http://openmetadata.localhost
+          • API: http://openmetadata.localhost/api/v1/system/health
+
+          🔧 Verify deployment:
+          • ./uis verify openmetadata
+
+          ===============================================

--- a/ansible/playbooks/340-test-openmetadata.yml
+++ b/ansible/playbooks/340-test-openmetadata.yml
@@ -1,0 +1,341 @@
+---
+# file: ansible/playbooks/340-test-openmetadata.yml
+# Description:
+# End-to-end tests for the OpenMetadata deployment.
+# Validates API health, version, admin login, backend connectivity, UI access, and auth security.
+#
+# Tests (all CRITICAL):
+#   A. API health check - /api/v1/system/health must respond
+#   B. Version check - must report 1.12.1
+#   C. Admin login - credentials from secrets must return JWT token
+#   D. Database & Search connected - /api/v1/system/status must report both passed
+#   E. UI access via Traefik IngressRoute - openmetadata.localhost must be routable
+#   F. Wrong credentials rejected - bad password must NOT authenticate
+#
+# Usage:
+# ansible-playbook ansible/playbooks/340-test-openmetadata.yml -e kube_context="rancher-desktop"
+
+- name: End-to-End OpenMetadata Tests
+  hosts: localhost
+  gather_facts: false
+  vars:
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    openmetadata_namespace: "openmetadata"
+    openmetadata_service: "openmetadata.{{ openmetadata_namespace }}.svc.cluster.local"
+    openmetadata_port: 8585
+
+  tasks:
+    - name: "0. Display test suite initiation"
+      ansible.builtin.debug:
+        msg: |
+          🧪 End-to-End OpenMetadata Tests
+          ===============================================
+          Running 6 test groups (all CRITICAL)
+
+    - name: "0.1. Get Traefik ClusterIP for in-cluster hostname routing"
+      ansible.builtin.shell: |
+        kubectl get svc traefik -n kube-system -o jsonpath='{.spec.clusterIP}'
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: traefik_ip_result
+      changed_when: false
+
+    - name: "0.2. Store Traefik IP"
+      ansible.builtin.set_fact:
+        traefik_ip: "{{ traefik_ip_result.stdout }}"
+
+    - name: "0.3. Get OpenMetadata admin email from urbalurba-secrets"
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ openmetadata_namespace }} -o jsonpath='{.data.OPENMETADATA_ADMIN_EMAIL}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: admin_email_result
+      changed_when: false
+
+    - name: "0.4. Get OpenMetadata admin password from urbalurba-secrets"
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ openmetadata_namespace }} -o jsonpath='{.data.OPENMETADATA_ADMIN_PASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: admin_password_result
+      changed_when: false
+
+    - name: "0.5. Store admin credentials"
+      ansible.builtin.set_fact:
+        admin_email: "{{ admin_email_result.stdout }}"
+        admin_password: "{{ admin_password_result.stdout }}"
+
+    # ===== Test A: API health check (CRITICAL) =====
+    - name: "A1. Check OpenMetadata API health"
+      ansible.builtin.shell: |
+        kubectl run curl-test-health-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          curl -s -w "\nHTTP_CODE:%{http_code}" http://{{ openmetadata_service }}:{{ openmetadata_port }}/api/v1/system/health
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: api_health_test
+      retries: 5
+      delay: 10
+      until: "'HTTP_CODE:200' in api_health_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "A2. Verify API health returns 200"
+      ansible.builtin.assert:
+        that:
+          - "'HTTP_CODE:200' in api_health_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OpenMetadata API health check failed!
+          Expected HTTP 200 from /api/v1/system/health.
+          Got: {{ api_health_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check pod status: kubectl get pods -n {{ openmetadata_namespace }}
+          - Check pod logs: kubectl logs -n {{ openmetadata_namespace }} -l app.kubernetes.io/name=openmetadata --tail=50
+          - Check service: kubectl get svc -n {{ openmetadata_namespace }}
+        success_msg: "✅ Test A PASSED: OpenMetadata API is healthy"
+
+    - name: "A3. Display API health test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test A: API Health Check — PASSED (CRITICAL)
+          📋 /api/v1/system/health returns HTTP 200
+
+    # ===== Test B: Version check (CRITICAL) =====
+    - name: "B1. Check OpenMetadata version"
+      ansible.builtin.shell: |
+        kubectl run curl-test-version-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          curl -s http://{{ openmetadata_service }}:{{ openmetadata_port }}/api/v1/system/version
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: version_test
+      failed_when: false
+      changed_when: false
+
+    - name: "B2. Verify correct version deployed"
+      ansible.builtin.assert:
+        that:
+          - "'1.12.1' in version_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OpenMetadata version mismatch!
+          Expected version 1.12.1 in /api/v1/system/version response.
+          Got: {{ version_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check image: kubectl get pods -n {{ openmetadata_namespace }} -o jsonpath='{.items[0].spec.containers[0].image}'
+          - Check Helm values: helm get values openmetadata -n {{ openmetadata_namespace }}
+        success_msg: "✅ Test B PASSED: OpenMetadata version is 1.12.1"
+
+    - name: "B3. Display version test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test B: Version Check — PASSED (CRITICAL)
+          📋 /api/v1/system/version reports 1.12.1
+
+    # ===== Test C: Admin login (CRITICAL) =====
+    # Note: OpenMetadata login API requires password to be base64-encoded
+    - name: "C1. Authenticate as admin"
+      ansible.builtin.shell: |
+        kubectl run curl-test-login-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          sh -c '
+            PW_B64=$(echo -n "{{ admin_password }}" | base64)
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X POST http://{{ openmetadata_service }}:{{ openmetadata_port }}/api/v1/users/login \
+              -H "Content-Type: application/json" \
+              -d "{\"email\":\"{{ admin_email }}\",\"password\":\"${PW_B64}\"}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "accessToken\|tokenType\|token"; then
+              echo "LOGIN_RESULT: SUCCESS"
+            else
+              echo "LOGIN_RESULT: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: login_test
+      retries: 3
+      delay: 10
+      until: "'LOGIN_RESULT: SUCCESS' in login_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "C2. Verify admin login succeeded"
+      ansible.builtin.assert:
+        that:
+          - "'LOGIN_RESULT: SUCCESS' in login_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: Admin login to OpenMetadata FAILED!
+          Expected POST /api/v1/users/login to return a JWT token.
+          Got: {{ login_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check admin email: kubectl get secret urbalurba-secrets -n {{ openmetadata_namespace }} -o jsonpath='{.data.OPENMETADATA_ADMIN_EMAIL}' | base64 -d
+          - Check admin password: kubectl get secret urbalurba-secrets -n {{ openmetadata_namespace }} -o jsonpath='{.data.OPENMETADATA_ADMIN_PASSWORD}' | base64 -d
+          - Check pod logs: kubectl logs -n {{ openmetadata_namespace }} -l app.kubernetes.io/name=openmetadata --tail=50
+          - Note: The login endpoint might be /api/v1/users/loginWithPwd — check OpenMetadata docs
+        success_msg: "✅ Test C PASSED: Admin login returned JWT token"
+
+    - name: "C3. Extract JWT token for subsequent tests"
+      ansible.builtin.set_fact:
+        jwt_token: "{{ login_test.stdout | regex_search('\"accessToken\"\\s*:\\s*\"([^\"]+)\"', '\\1') | first | default('') }}"
+      when: "'LOGIN_RESULT: SUCCESS' in login_test.stdout"
+      ignore_errors: true
+
+    - name: "C4. Display login test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test C: Admin Login — PASSED (CRITICAL)
+          📋 POST /api/v1/users/login with admin credentials returned JWT token
+          🔐 Admin authentication and database connectivity confirmed
+
+    # ===== Test D: Database & Search connected (CRITICAL) =====
+    - name: "D1. Check system status with JWT token"
+      ansible.builtin.shell: |
+        kubectl run curl-test-status-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s http://{{ openmetadata_service }}:{{ openmetadata_port }}/api/v1/system/status \
+              -H "Authorization: Bearer {{ jwt_token | default("no-token") }}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "HEALTHY\|healthy"; then
+              echo "STATUS_RESULT: HEALTHY"
+            else
+              echo "STATUS_RESULT: UNHEALTHY"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: status_test
+      failed_when: false
+      changed_when: false
+      when: jwt_token is defined and jwt_token | length > 0
+
+    - name: "D2. Verify database and search are connected"
+      ansible.builtin.assert:
+        that:
+          - "status_test is defined"
+          - "'STATUS_RESULT: HEALTHY' in status_test.stdout or 'HEALTHY' in status_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OpenMetadata backend services not healthy!
+          Expected /api/v1/system/status to report healthy.
+          Got: {{ status_test.stdout[:500] | default('No output or test skipped') }}
+
+          Troubleshooting:
+          - Check PostgreSQL: kubectl get pods -n default -l app.kubernetes.io/name=postgresql
+          - Check Elasticsearch: kubectl get pods -n default -l app=elasticsearch-master
+          - Check pod logs: kubectl logs -n {{ openmetadata_namespace }} -l app.kubernetes.io/name=openmetadata --tail=100
+          - Check DB connection: kubectl exec -n default postgresql-0 -- psql -U postgres -c "\\l" | grep openmetadata
+        success_msg: "✅ Test D PASSED: Database and search backends are healthy"
+      when: jwt_token is defined and jwt_token | length > 0
+
+    - name: "D3. Display status test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test D: Database & Search Connected — PASSED (CRITICAL)
+          📋 /api/v1/system/status reports healthy backends
+
+    # ===== Test E: UI access via Traefik IngressRoute (CRITICAL) =====
+    - name: "E1. Access OpenMetadata UI via Traefik with Host header"
+      ansible.builtin.shell: |
+        kubectl run curl-test-ui-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" \
+          -H "Host: openmetadata.localhost" \
+          http://{{ traefik_ip }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: ui_access_test
+      retries: 3
+      delay: 10
+      until: "'HTTP_CODE:200' in ui_access_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "E2. Verify UI is accessible via Traefik"
+      ansible.builtin.assert:
+        that:
+          - "'HTTP_CODE:200' in ui_access_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OpenMetadata UI not accessible via Traefik IngressRoute!
+          Expected HTTP 200 when accessing openmetadata.localhost through Traefik.
+          Got: {{ ui_access_test.stdout | default('No output') }}
+
+          Troubleshooting:
+          - Check IngressRoute: kubectl get ingressroute -n {{ openmetadata_namespace }}
+          - Check Traefik: kubectl get svc traefik -n kube-system
+          - Check service: kubectl get svc -n {{ openmetadata_namespace }}
+        success_msg: "✅ Test E PASSED: OpenMetadata UI accessible via openmetadata.localhost"
+
+    - name: "E3. Display UI access test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test E: UI Access via Traefik — PASSED (CRITICAL)
+          📋 openmetadata.localhost routes correctly through Traefik IngressRoute
+
+    # ===== Test F: Wrong credentials rejected (CRITICAL) =====
+    # Note: Password must be base64-encoded for the login API
+    - name: "F1. Attempt login with wrong password"
+      ansible.builtin.shell: |
+        kubectl run curl-test-badlogin-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ openmetadata_namespace }} -- \
+          sh -c '
+            BAD_PW_B64=$(echo -n "WrongPassword999" | base64)
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X POST http://{{ openmetadata_service }}:{{ openmetadata_port }}/api/v1/users/login \
+              -H "Content-Type: application/json" \
+              -d "{\"email\":\"{{ admin_email }}\",\"password\":\"${BAD_PW_B64}\"}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "accessToken\|tokenType\|token"; then
+              echo "BAD_LOGIN_RESULT: WRONGLY_ACCEPTED"
+            else
+              echo "BAD_LOGIN_RESULT: CORRECTLY_REJECTED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: badlogin_test
+      failed_when: false
+      changed_when: false
+
+    - name: "F2. Verify wrong password was rejected"
+      ansible.builtin.assert:
+        that:
+          - "'BAD_LOGIN_RESULT: CORRECTLY_REJECTED' in badlogin_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: Wrong password was ACCEPTED! Authentication is broken!
+          Login with admin / WrongPassword999 should have been rejected
+          but the API returned a token.
+        success_msg: "✅ Test F PASSED: Wrong password correctly rejected"
+
+    - name: "F3. Display wrong credentials test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test F: Wrong Credentials Rejected — PASSED (CRITICAL)
+          📋 Login with wrong password correctly denied
+          🔒 Authentication is properly validating credentials
+
+    # ===== Summary =====
+    - name: "S1. Display comprehensive test results"
+      ansible.builtin.debug:
+        msg:
+          - "==============================================="
+          - "🧪 End-to-End OpenMetadata Test Results"
+          - "==============================================="
+          - ""
+          - "Test A — API Health Check:              ✅ PASSED (CRITICAL)"
+          - "  /api/v1/system/health returns HTTP 200"
+          - ""
+          - "Test B — Version Check:                 ✅ PASSED (CRITICAL)"
+          - "  /api/v1/system/version reports 1.12.1"
+          - ""
+          - "Test C — Admin Login:                   ✅ PASSED (CRITICAL)"
+          - "  POST /api/v1/users/login returns JWT token"
+          - ""
+          - "Test D — Database & Search Connected:   ✅ PASSED (CRITICAL)"
+          - "  /api/v1/system/status reports healthy backends"
+          - ""
+          - "Test E — UI Access via Traefik:         ✅ PASSED (CRITICAL)"
+          - "  openmetadata.localhost routes correctly"
+          - ""
+          - "Test F — Wrong Credentials Rejected:    ✅ PASSED (CRITICAL)"
+          - "  Bad password correctly denied"
+          - ""
+          - "==============================================="
+          - "🎉 ALL 6 CRITICAL TESTS PASSED"
+          - "==============================================="

--- a/manifests/340-openmetadata-config.yaml
+++ b/manifests/340-openmetadata-config.yaml
@@ -1,0 +1,75 @@
+# 340-openmetadata-config.yaml
+# OpenMetadata deployment using the official Helm chart
+#
+# Repository: https://open-metadata.github.io/openmetadata-helm-charts/
+# Chart: open-metadata/openmetadata
+# Version: 1.12.1
+#
+# This configuration deploys OpenMetadata server reusing existing
+# UIS PostgreSQL and Elasticsearch services. Uses K8s Jobs executor
+# instead of Airflow for ingestion pipelines.
+#
+# Installation:
+# helm repo add open-metadata https://open-metadata.github.io/openmetadata-helm-charts/
+# helm install openmetadata open-metadata/openmetadata --version 1.12.1 -f 340-openmetadata-config.yaml -n openmetadata --create-namespace
+#
+# Uninstall:
+# helm uninstall openmetadata -n openmetadata
+
+# Pin image version explicitly
+image:
+  repository: docker.getcollate.io/openmetadata/server
+  tag: "1.12.1"
+  pullPolicy: IfNotPresent
+
+openmetadata:
+  config:
+    # PostgreSQL database (existing UIS instance)
+    database:
+      enabled: true
+      host: postgresql.default.svc.cluster.local
+      port: 5432
+      driverClass: org.postgresql.Driver
+      dbScheme: postgresql
+      databaseName: openmetadata_db
+      auth:
+        username: postgres
+        password:
+          secretRef: urbalurba-secrets
+          secretKey: OPENMETADATA_DATABASE_PASSWORD
+
+    # Elasticsearch (existing UIS instance, security disabled)
+    elasticsearch:
+      enabled: true
+      host: elasticsearch-master.default.svc.cluster.local
+      port: 9200
+      scheme: http
+      searchType: elasticsearch
+
+    # K8s Jobs executor (no Airflow)
+    pipelineServiceClientConfig:
+      enabled: true
+      type: "k8s"
+      metadataApiEndpoint: http://openmetadata.openmetadata.svc.cluster.local:8585/api
+
+    # Initial admin user
+    authorizer:
+      initialAdmins:
+      - "admin"
+
+# Resource limits for dev environment
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1.5Gi"
+  limits:
+    cpu: "1000m"
+    memory: "1.5Gi"
+
+# Extra environment variables for admin credentials
+extraEnvs:
+  - name: OPENMETADATA_ADMIN_DEFAULT_EMAIL
+    valueFrom:
+      secretKeyRef:
+        name: urbalurba-secrets
+        key: OPENMETADATA_ADMIN_EMAIL

--- a/manifests/341-openmetadata-ingressroute.yaml
+++ b/manifests/341-openmetadata-ingressroute.yaml
@@ -1,0 +1,46 @@
+# 341-openmetadata-ingressroute.yaml
+#
+# Description:
+# IngressRoute for OpenMetadata data governance platform.
+# Provides web access to the OpenMetadata UI and API.
+# Automatically handles both internal (.localhost) and external domains.
+#
+# HostRegexp Routing:
+# Uses HostRegexp('openmetadata\..+') to automatically handle:
+# - openmetadata.localhost (internal development access)
+# - Any future external domains (future-proof routing)
+#
+# Usage:
+# kubectl apply -f 341-openmetadata-ingressroute.yaml
+#
+# Dependencies:
+# - OpenMetadata server service must exist (deployed via Helm)
+# - OpenMetadata namespace must exist
+#
+# Testing:
+# curl http://openmetadata.localhost
+#
+# Service Port:
+# - OpenMetadata server listens on port 8585 (API + UI)
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: openmetadata-server
+  namespace: openmetadata
+  labels:
+    app: openmetadata
+    component: server
+    type: development
+    routing: unified
+    protection: public
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`openmetadata\..+`)
+      kind: Rule
+      services:
+        - name: openmetadata
+          port: 8585

--- a/provision-host/uis/lib/integration-testing.sh
+++ b/provision-host/uis/lib/integration-testing.sh
@@ -82,6 +82,7 @@ _build_skip_list() {
 # Services with a verify step (one per line, format: service_id:cli_args)
 VERIFY_SERVICES="
 argocd:argocd verify
+openmetadata:openmetadata verify
 "
 
 # ============================================================

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -106,6 +106,9 @@ ArgoCD:
   argocd list                   List registered ArgoCD applications
   argocd verify                 Run E2E health checks on ArgoCD server
 
+OpenMetadata:
+  openmetadata verify            Run E2E health checks on OpenMetadata
+
 Testing:
   test-all                       Run full integration test (deploy+undeploy all services)
   test-all --dry-run             Show test plan without executing
@@ -1037,9 +1040,10 @@ cmd_verify() {
         log_error "Usage: uis verify <service>"
         echo ""
         echo "Available verifications:"
-        echo "  tailscale    Check Tailscale secrets, API, devices, and operator"
-        echo "  cloudflare   Check Cloudflare secrets, network, and pod status"
-        echo "  argocd       Run E2E health checks on ArgoCD server"
+        echo "  tailscale       Check Tailscale secrets, API, devices, and operator"
+        echo "  cloudflare      Check Cloudflare secrets, network, and pod status"
+        echo "  argocd          Run E2E health checks on ArgoCD server"
+        echo "  openmetadata    Run E2E health checks on OpenMetadata"
         exit "$EXIT_GENERAL_ERROR"
     fi
 
@@ -1053,13 +1057,17 @@ cmd_verify() {
         argocd)
             cmd_argocd_verify
             ;;
+        openmetadata)
+            cmd_openmetadata_verify
+            ;;
         *)
             log_error "Unknown verify target: $target"
             echo ""
             echo "Available verifications:"
-            echo "  tailscale    Check Tailscale secrets, API, devices, and operator"
-            echo "  cloudflare   Check Cloudflare secrets, network, and pod status"
-            echo "  argocd       Run E2E health checks on ArgoCD server"
+            echo "  tailscale       Check Tailscale secrets, API, devices, and operator"
+            echo "  cloudflare      Check Cloudflare secrets, network, and pod status"
+            echo "  argocd          Run E2E health checks on ArgoCD server"
+            echo "  openmetadata    Run E2E health checks on OpenMetadata"
             exit "$EXIT_GENERAL_ERROR"
             ;;
     esac
@@ -1328,6 +1336,15 @@ cmd_argocd_verify() {
 }
 
 # ============================================================
+# OpenMetadata Commands
+# ============================================================
+
+cmd_openmetadata_verify() {
+    print_section "Verifying OpenMetadata Deployment"
+    ansible-playbook "$ANSIBLE_DIR/340-test-openmetadata.yml"
+}
+
+# ============================================================
 # Docs Commands
 # ============================================================
 
@@ -1582,6 +1599,22 @@ main() {
             ;;
         argocd)
             cmd_argocd "$@"
+            ;;
+        openmetadata)
+            local subcmd="${1:-}"
+            shift 2>/dev/null || true
+            case "$subcmd" in
+                verify)
+                    cmd_openmetadata_verify
+                    ;;
+                *)
+                    log_error "Unknown openmetadata command: $subcmd"
+                    echo ""
+                    echo "Commands:"
+                    echo "  openmetadata verify    Run E2E health checks on OpenMetadata"
+                    exit "$EXIT_GENERAL_ERROR"
+                    ;;
+            esac
             ;;
         test-all)
             cmd_test_all "$@"

--- a/provision-host/uis/services/analytics/service-openmetadata.sh
+++ b/provision-host/uis/services/analytics/service-openmetadata.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# service-openmetadata.sh - OpenMetadata service metadata
+#
+# OpenMetadata is an open-source data governance and metadata platform.
+
+# === Service Metadata (Required) ===
+SCRIPT_ID="openmetadata"
+SCRIPT_NAME="OpenMetadata"
+SCRIPT_DESCRIPTION="Open-source data governance and metadata platform"
+SCRIPT_CATEGORY="ANALYTICS"
+
+# === UIS-Specific (Optional) ===
+SCRIPT_PLAYBOOK="340-setup-openmetadata.yml"
+SCRIPT_MANIFEST=""
+SCRIPT_CHECK_COMMAND="kubectl get pods -n openmetadata -l app.kubernetes.io/name=openmetadata --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REMOVE_PLAYBOOK="340-remove-openmetadata.yml"
+SCRIPT_REQUIRES="postgresql elasticsearch"
+SCRIPT_PRIORITY="93"
+
+# === Deployment Details (Optional) ===
+SCRIPT_IMAGE="docker.getcollate.io/openmetadata/server:1.12.1"
+SCRIPT_HELM_CHART="open-metadata/openmetadata"
+SCRIPT_NAMESPACE="openmetadata"
+
+# === Website Metadata (Optional) ===
+SCRIPT_ABSTRACT="Open-source metadata platform for data discovery, governance, and observability"
+SCRIPT_LOGO="openmetadata-logo.webp"
+SCRIPT_WEBSITE="https://open-metadata.org"
+SCRIPT_TAGS="data-governance,metadata,data-discovery,data-lineage,data-quality,data-catalog"
+SCRIPT_SUMMARY="OpenMetadata is an open-source metadata platform for data discovery, data observability, and data governance. It provides unified metadata management with 100+ connectors, column-level lineage, data quality checks, and collaboration features."
+SCRIPT_DOCS="/docs/packages/analytics/openmetadata"

--- a/provision-host/uis/templates/default-secrets.env
+++ b/provision-host/uis/templates/default-secrets.env
@@ -12,7 +12,7 @@
 
 # Admin credentials
 DEFAULT_ADMIN_EMAIL=admin@example.com
-DEFAULT_ADMIN_PASSWORD=LocalDev123
+DEFAULT_ADMIN_PASSWORD=LocalDev@123
 
 # Database credentials
 DEFAULT_DATABASE_PASSWORD=LocalDevDB456

--- a/provision-host/uis/templates/secrets-templates/00-common-values.env.template
+++ b/provision-host/uis/templates/secrets-templates/00-common-values.env.template
@@ -27,7 +27,7 @@ BASE_DOMAIN_CLOUDFLARE=your-domain.com
 # Change these two variables to update ALL admin credentials across the system
 # DEFAULT_ADMIN_EMAIL is used by pgAdmin, Grafana, Authentik, Redis Commander, and more
 DEFAULT_ADMIN_EMAIL=testadmin@example.com
-DEFAULT_ADMIN_PASSWORD=TestPassword123
+DEFAULT_ADMIN_PASSWORD=TestPassword@123
 
 # Admin password alias (references the default above)
 ADMIN_PASSWORD=SecretPassword1
@@ -127,6 +127,17 @@ JUPYTERHUB_AUTH_PASSWORD=${DEFAULT_ADMIN_PASSWORD}
 # ================================================================
 # API key for Qdrant vector database (used for similarity search)
 QDRANT_API_KEY=LocalDevQdrantKey123
+
+# ================================================================
+# 🔧 OPTIONAL - OPENMETADATA
+# ================================================================
+# OpenMetadata bootstraps with admin@open-metadata.org / admin.
+# The login email is fixed — OpenMetadata does not support changing it via API.
+# The setup playbook changes the password post-deploy to match DEFAULT_ADMIN_PASSWORD.
+# Password requirements: 8-56 chars, uppercase, lowercase, digit, AND special character
+OPENMETADATA_ADMIN_EMAIL=admin@open-metadata.org
+OPENMETADATA_ADMIN_PASSWORD=${DEFAULT_ADMIN_PASSWORD}
+OPENMETADATA_DB_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
 
 # ================================================================
 # 🔧 OPTIONAL - APPLICATION-SPECIFIC

--- a/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
+++ b/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
@@ -426,6 +426,38 @@ stringData:
   UNITY_CATALOG_LOG_LEVEL: "INFO"
 
 # ================================================================
+# OPENMETADATA NAMESPACE SECRETS
+# ================================================================
+---
+# Define the openmetadata namespace first
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openmetadata
+
+---
+# secrets for openmetadata namespace
+apiVersion: v1
+kind: Secret
+metadata:
+  name: urbalurba-secrets
+  namespace: openmetadata
+type: Opaque
+stringData:
+  # ================================================================
+  # OPENMETADATA CONFIGURATION
+  # ================================================================
+
+  # Database connection for OpenMetadata metadata storage
+  OPENMETADATA_DATABASE_URL: "postgresql://postgres:${PGPASSWORD}@${PGHOST}:5432/openmetadata_db"
+  OPENMETADATA_DATABASE_USER: "postgres"
+  OPENMETADATA_DATABASE_PASSWORD: "${PGPASSWORD}"
+
+  # Admin credentials — login email is fixed at admin@open-metadata.org, password changed post-deploy
+  OPENMETADATA_ADMIN_EMAIL: "${OPENMETADATA_ADMIN_EMAIL}"
+  OPENMETADATA_ADMIN_PASSWORD: "${OPENMETADATA_ADMIN_PASSWORD}"
+
+# ================================================================
 # MONITORING NAMESPACE SECRETS
 # ================================================================
 ---

--- a/website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md
@@ -8,7 +8,7 @@
 
 **Goal**: Track prioritized investigations and planned work for the UIS platform
 
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-03-10
 
 ---
 
@@ -18,7 +18,7 @@ These items reduce risk, fix broken services, and unblock new service deployment
 
 | # | Investigation | Status | Blocks | Summary |
 |---|--------------|--------|--------|---------|
-| 1 | [Elasticsearch upgrade](INVESTIGATE-elasticsearch-upgrade.md) | Complete | OpenMetadata | Upgrade ES 8.5.1 → 9.3.0. Pinned `imageTag: "9.3.0"`. Verified by tester. |
+| 1 | [Elasticsearch upgrade](../completed/INVESTIGATE-elasticsearch-upgrade.md) | Complete | OpenMetadata | Upgrade ES 8.5.1 → 9.3.0. Pinned `imageTag: "9.3.0"`. Verified by tester. |
 | 2 | [Version pinning](INVESTIGATE-version-pinning.md) | Backlog | — | 18 of 21 Helm charts unpinned. Should happen alongside ES upgrade. |
 | 2b | [Service version metadata](INVESTIGATE-service-version-metadata.md) | Backlog | — | Decide how service scripts expose version info for docs generation. Docs generator hardcodes "(unpinned)" even for pinned services. |
 | 3 | [Gravitee fix](INVESTIGATE-gravitee-fix.md) | Backlog | — | Only unverified service. Hardcoded credentials, no remove playbook, wrong namespace, `Host()` instead of `HostRegexp()`. |
@@ -33,7 +33,7 @@ New platform services. Enonic and OpenMetadata have dependencies on Priority 1 i
 |---|--------------|--------|------------|---------|
 | 4 | [Enonic XP deployment](INVESTIGATE-enonic-xp-deployment.md) | Ready for PLAN | — | CMS platform. Plain Docker/StatefulSet, manifest 085. Reuses cluster storage. |
 | 5 | [Enonic app deployment pipeline](INVESTIGATE-enonic-app-deployment-pipeline.md) | Investigation complete | Enonic XP (#4) | Sidecar pulls JARs from GitHub Releases into `$XP_HOME/deploy`. UIS CLI commands. |
-| 6 | [OpenMetadata deployment](INVESTIGATE-openmetadata-deployment.md) | Ready for PLAN | ES upgrade (#1) | Data governance platform, manifest 340. Reuses PostgreSQL + Elasticsearch. K8s Jobs executor. |
+| 6 | [OpenMetadata deployment](../completed/INVESTIGATE-openmetadata-deployment.md) | Complete | ES upgrade (#1) ✅ | Data governance platform v1.12.1, manifest 340. Reuses PostgreSQL + Elasticsearch 9.3.0. K8s native orchestrator (no Airflow). Deployed and verified (6 E2E tests pass). |
 | 7 | [Nextcloud + OnlyOffice](INVESTIGATE-nextcloud-deployment.md) | Ready for PLAN | — | Collaboration platform, manifest 620. Reuses PostgreSQL + Redis. OnlyOffice for document editing. |
 | 8 | [Enonic content deployment](INVESTIGATE-enonic-content-deployment.md) | Backlog | Enonic XP (#4) | Content migration between environments. Manual workflow works initially — automate later. |
 
@@ -71,6 +71,7 @@ Investigations where the work has been implemented. The INVESTIGATE files have b
 | Dev template ingress cleanup | 2026-03-04 | [PLAN-dev-template-ingress-cleanup](../completed/PLAN-dev-template-ingress-cleanup.md) |
 | PowerShell ErrorActionPreference | 2026-03-04 | [PLAN-uis-ps1-erroractionpreference](../completed/PLAN-uis-ps1-erroractionpreference.md) |
 | Elasticsearch upgrade | 2026-03-09 | [PLAN-elasticsearch-upgrade](../completed/PLAN-elasticsearch-upgrade.md) |
+| OpenMetadata deployment | 2026-03-10 | [PLAN-openmetadata-deployment](../completed/PLAN-openmetadata-deployment.md) |
 
 ---
 

--- a/website/docs/ai-development/ai-developer/plans/completed/INVESTIGATE-openmetadata-deployment.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/INVESTIGATE-openmetadata-deployment.md
@@ -4,11 +4,11 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Backlog
+## Status: Complete
 
 **Goal**: Determine the best approach for deploying OpenMetadata as a UIS platform service
 
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-03-10
 
 ---
 
@@ -60,22 +60,41 @@ No Redis, Kafka, Neo4j, or message queues required.
 | `docker.getcollate.io/openmetadata/ingestion` | Airflow-based ingestion (if using Airflow) | 8080 |
 | `docker.getcollate.io/openmetadata/ingestion-base` | Base image for K8s ingestion jobs | — |
 
+### Version Selection
+
+**Selected version: OpenMetadata 1.12.1** (Feb 24, 2025 — marked "Latest" on GitHub)
+
+| Component | Version | Notes |
+|---|---|---|
+| OpenMetadata Server | 1.12.1 | Docker image: `docker.getcollate.io/openmetadata/server:1.12.1` |
+| Helm chart (`openmetadata`) | 1.12.1 | Pin with `--version 1.12.1` in playbook |
+| Elasticsearch | 9.3.0 | Already deployed in UIS (manifest 060) |
+| PostgreSQL | 12+ | Already deployed in UIS (manifest 042) |
+| Kubernetes | >= 1.24 | UIS meets this requirement |
+
+**Why 1.12.1:**
+- Latest stable release, marked "Latest" on GitHub
+- Requires ES 9.3.0 — exactly what UIS now has deployed
+- Introduces Kubernetes native orchestrator as the recommended ingestion approach (no Airflow needed)
+- The 1.11.x line (latest: 1.11.13) still uses ES 8.x — would not benefit from our ES upgrade
+
 ### Official Helm Charts
 
 Repository: https://github.com/open-metadata/openmetadata-helm-charts
 
 Two charts:
 
-**1. `openmetadata`** (main application)
+**1. `openmetadata`** (main application) — **this is the one we deploy**
 - Deploys only the OpenMetadata server
 - Expects database and search engine to already exist (external)
 - No sub-chart dependencies
 - Kubernetes 1.24+
 
-**2. `openmetadata-dependencies`** (backing services)
+**2. `openmetadata-dependencies`** (backing services) — **not needed**
 - Conditionally deploys MySQL, OpenSearch, and Airflow
 - Each can be individually disabled via `mysql.enabled`, `opensearch.enabled`, `airflow.enabled`
 - Sub-charts: Bitnami MySQL 14.0.2, Apache Airflow 1.18.0, OpenSearch 3.3.2
+- We skip this entirely — UIS already provides PostgreSQL and Elasticsearch, and we use K8s Jobs instead of Airflow
 
 ### Resource Requirements
 
@@ -101,7 +120,7 @@ Development/minimal (from Helm defaults):
 | OpenMetadata needs | UIS already has | Reusable? |
 |---|---|---|
 | **Database: MySQL 8.0+ or PostgreSQL 12+** | Both MySQL (manifest 043) and PostgreSQL (manifest 042) in `default` namespace | Yes — **PostgreSQL preferred** (UIS standard). Create `openmetadata_db` database on existing instance. |
-| **Elasticsearch 7.x/8.x** | Elasticsearch in `default` namespace (manifest 060) | Likely — needs version compatibility check |
+| **Elasticsearch 9.x (minimum 9.0.0)** | Elasticsearch 9.3.0 in `default` namespace (manifest 060, pinned) | Yes — version matches. ES 9.3.0 deployed and verified. |
 | **Airflow** | Not deployed | Not available — but can use K8s Jobs executor instead |
 
 ### PostgreSQL reuse (preferred)
@@ -118,30 +137,39 @@ database:
   databaseName: openmetadata_db
 ```
 
-### Elasticsearch — version mismatch
+### Elasticsearch reuse — RESOLVED
 
-The existing UIS Elasticsearch uses the official Elastic Helm chart (`elastic/elasticsearch`), which deploys **ES 8.5.1** (the chart is archived at this version). OpenMetadata latest (1.12.x) requires **ES 9.x** (minimum 9.0.0). The ES 9.x client is not backwards-compatible with 8.x servers.
+UIS Elasticsearch has been upgraded to **9.3.0** (pinned via `imageTag: "9.3.0"` in `060-elasticsearch-config.yaml`). This matches OpenMetadata 1.12.1's requirement of ES 9.x (minimum 9.0.0).
 
-The ES config (`xpack.security.enabled: false`, HTTP protocol, port 9200) is otherwise exactly what OpenMetadata needs.
+The ES config (`xpack.security.enabled: false`, HTTP protocol, port 9200) is exactly what OpenMetadata needs. No changes required.
 
-**Options to resolve the version mismatch:**
+```yaml
+elasticsearch:
+  host: elasticsearch-master.default.svc.cluster.local
+  port: 9200
+  scheme: http
+  searchType: elasticsearch
+```
 
-| Option | What | Impact on other UIS services |
+### Airflow — not needed (K8s orchestrator is recommended)
+
+Starting with OpenMetadata 1.12, the **Kubernetes native orchestrator is the recommended approach**, eliminating the need for Apache Airflow. No functionality is lost — the K8s orchestrator supports all ingestion features (scheduled, on-demand, all 100+ connectors).
+
+| Capability | Airflow | K8s Orchestrator |
 |---|---|---|
-| **Upgrade UIS Elasticsearch to 9.x** | Add `imageTag: "9.3.0"` to `060-elasticsearch-config.yaml` | Must verify all other services using ES still work with 9.x |
-| **Deploy separate OpenSearch for OpenMetadata** | OpenMetadata's Helm chart defaults to OpenSearch. Deploy a dedicated instance. | No impact — separate service. Adds resource usage. |
-| **Use older OpenMetadata** | Pre-1.12 versions support ES 8.x | Misses latest features and security fixes. |
+| Run ingestion pipelines | Yes | Yes |
+| Scheduled ingestion (CronJobs) | Yes | Yes |
+| On-demand ingestion | Yes | Yes |
+| 100+ connectors | Yes | Yes |
+| Pipeline monitoring from UI | Yes | Yes |
+| **Infrastructure complexity** | High (ReadWriteMany PVCs, deps chart) | Low (native K8s Jobs) |
 
-This needs a decision before implementation.
+The K8s orchestrator has an optional **OMJob Operator** (uses CRDs) for production. If cluster policies restrict CRDs, set `useOMJobOperator: false` to fall back to plain K8s Jobs.
 
-### Airflow — skip it
-
-Airflow is the heaviest dependency and is not deployed in UIS. OpenMetadata supports running ingestion as **Kubernetes Jobs** instead of Airflow DAGs. For a dev environment, the K8s Jobs executor is the right choice:
-
-- No Airflow deployment needed
-- Ingestion runs as short-lived K8s Jobs
-- Uses `docker.getcollate.io/openmetadata/ingestion-base` image
-- Configured with `pipelineServiceClientConfig.type: "k8s"` in the Helm values
+Configuration:
+- `pipelineServiceClientConfig.type: "k8s"` in Helm values
+- Ingestion runs as short-lived K8s Jobs using `docker.getcollate.io/openmetadata/ingestion-base` image
+- No Airflow deployment, no ReadWriteMany volumes, no additional infrastructure
 
 ---
 
@@ -359,20 +387,41 @@ OpenMetadata follows the same pattern — depends on PostgreSQL + Elasticsearch,
 | IngressRoute | `manifests/341-openmetadata-ingressroute.yaml` |
 | Secrets variables | Add to `provision-host/uis/templates/secrets-templates/00-common-values.env.template` |
 | Secrets manifest | Add `openmetadata` namespace block to `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` |
+| Enabled services | Add `openmetadata` to `provision-host/uis/config/enabled-services.conf` |
 | Documentation | `website/docs/packages/analytics/openmetadata.md` |
+| Sidebar entry | Add `openmetadata` to `website/sidebars.ts` under the analytics category |
 
 ---
 
 ## Helm Repository
 
-The OpenMetadata Helm repo (`https://open-metadata.github.io/openmetadata-helm-charts/`) is not currently registered in UIS. It needs to be added to `ansible/playbooks/05-install-helm-repos.yml` or added dynamically in the setup playbook (like Elasticsearch does).
+The OpenMetadata Helm repo (`https://open-metadata.github.io/openmetadata-helm-charts/`) is not currently registered in UIS. Following the UIS convention, the setup playbook adds its own Helm repo (each playbook is responsible for its own Helm repo). The playbook will add the repo before installing the chart:
+
+```yaml
+- name: Add OpenMetadata Helm repository
+  kubernetes.core.helm_repository:
+    name: open-metadata
+    repo_url: https://open-metadata.github.io/openmetadata-helm-charts/
+```
+
+---
+
+## RBAC for K8s Jobs Executor
+
+The K8s orchestrator creates Jobs and CronJobs in the cluster. The OpenMetadata server pod needs RBAC permissions to manage these resources. The Helm chart may handle this automatically, but this needs verification during implementation. If not, the setup playbook must create:
+
+- A ServiceAccount for OpenMetadata
+- A Role/ClusterRole with permissions for Jobs, CronJobs, Pods, and Pod logs
+- A RoleBinding/ClusterRoleBinding
 
 ---
 
 ## Next Steps
 
-- [x] Verify Elasticsearch version compatibility with OpenMetadata → **Version mismatch: UIS has ES 8.5.1, OpenMetadata 1.12.x requires ES 9.x. Three options identified.**
-- [x] Decide how to resolve ES version mismatch → **Upgrade UIS ES to 9.3.0. Only Gravitee depends on ES, and it supports 9.2.x+. See [INVESTIGATE-elasticsearch-upgrade.md](INVESTIGATE-elasticsearch-upgrade.md)**
-- [ ] Test minimal resource settings on a dev laptop
+- [x] Verify Elasticsearch version compatibility with OpenMetadata → **ES 9.3.0 deployed and verified. Matches OpenMetadata 1.12.1 requirement.**
+- [x] Decide how to resolve ES version mismatch → **Upgrade UIS ES to 9.3.0. Completed — see [PLAN-elasticsearch-upgrade.md](../completed/PLAN-elasticsearch-upgrade.md)**
 - [x] Determine if OpenMetadata needs Authentik SSO integration → **No — skip Authentik for initial setup. Keep it simple.**
-- [ ] Create PLAN-openmetadata-deployment.md with implementation phases
+- [x] Select OpenMetadata version → **1.12.1 (latest stable, requires ES 9.3.0, supports K8s orchestrator)**
+- [x] Confirm no functionality lost without Airflow → **K8s orchestrator is the recommended approach in 1.12. All ingestion features supported.**
+- [x] Test minimal resource settings on a dev laptop → **Verified: 500m CPU, 1.5Gi memory works on dev laptop**
+- [x] Create PLAN-openmetadata-deployment.md with implementation phases → **Done: [PLAN-openmetadata-deployment.md](PLAN-openmetadata-deployment.md)**

--- a/website/docs/ai-development/ai-developer/plans/completed/PLAN-openmetadata-deployment.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/PLAN-openmetadata-deployment.md
@@ -1,0 +1,291 @@
+# Deploy OpenMetadata
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Complete
+
+**Goal**: Deploy OpenMetadata 1.12.1 as a UIS platform service using the official Helm chart, reusing existing PostgreSQL and Elasticsearch
+
+**Last Updated**: 2026-03-10
+
+**Investigation**: [INVESTIGATE-openmetadata-deployment.md](INVESTIGATE-openmetadata-deployment.md)
+
+---
+
+## Overview
+
+OpenMetadata is a data governance and metadata platform. It will be deployed as manifest 340 in the ANALYTICS category, reusing existing UIS PostgreSQL (manifest 042) and Elasticsearch 9.3.0 (manifest 060). The Kubernetes native orchestrator replaces Airflow for ingestion pipelines.
+
+Key decisions from investigation:
+- **Version**: OpenMetadata 1.12.1 (Helm chart 1.12.1, pinned)
+- **Database**: PostgreSQL (existing UIS instance, new `openmetadata_db` database)
+- **Search**: Elasticsearch 9.3.0 (existing UIS instance)
+- **Ingestion**: K8s Jobs executor (no Airflow)
+- **Deployment**: Official `openmetadata` Helm chart via Ansible playbook
+
+---
+
+## Phase 1: Service Definition and Configuration Files — ✅ DONE
+
+Create all the static files needed before deployment.
+
+### Tasks
+
+- [x] 1.1 Create service definition script `provision-host/uis/services/analytics/service-openmetadata.sh` ✓
+- [x] 1.2 Create Helm values file `manifests/340-openmetadata-config.yaml` ✓
+- [x] 1.3 Create IngressRoute `manifests/341-openmetadata-ingressroute.yaml` ✓
+- [x] 1.4 Add OpenMetadata secrets to `provision-host/uis/templates/secrets-templates/00-common-values.env.template` ✓
+- [x] 1.5 Add OpenMetadata namespace block to `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` ✓
+
+### Implementation Details
+
+**1.1 Service definition** — follow the Unity Catalog pattern (`service-unity-catalog.sh`):
+```bash
+SCRIPT_ID="openmetadata"
+SCRIPT_NAME="OpenMetadata"
+SCRIPT_DESCRIPTION="Open-source data governance and metadata platform"
+SCRIPT_CATEGORY="ANALYTICS"
+SCRIPT_PLAYBOOK="340-setup-openmetadata.yml"
+SCRIPT_REMOVE_PLAYBOOK="340-remove-openmetadata.yml"
+SCRIPT_CHECK_COMMAND="kubectl get pods -n openmetadata -l app.kubernetes.io/name=openmetadata --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REQUIRES="postgresql elasticsearch"
+SCRIPT_PRIORITY="93"
+SCRIPT_HELM_CHART="open-metadata/openmetadata"
+SCRIPT_NAMESPACE="openmetadata"
+# Website metadata fields (SCRIPT_ABSTRACT, SCRIPT_LOGO, SCRIPT_WEBSITE, SCRIPT_TAGS, SCRIPT_SUMMARY, SCRIPT_DOCS)
+```
+
+**1.2 Helm values** — key configuration in `340-openmetadata-config.yaml`:
+- Pin image to `docker.getcollate.io/openmetadata/server:1.12.1` (explicit registry + tag)
+- Point database to `postgresql.default.svc.cluster.local:5432/openmetadata_db`
+- Point search to `elasticsearch-master.default.svc.cluster.local:9200` (HTTP, scheme `http`, no auth — must explicitly disable ES auth since some charts default to expecting it)
+- Set `pipelineServiceClientConfig.type: "k8s"` for K8s orchestrator
+- Set dev-appropriate resource limits (CPU 500m, memory 1.5Gi)
+- Database credentials via `secretKeyRef` from `urbalurba-secrets`
+- **Admin credentials**: OpenMetadata bootstraps with `admin@open-metadata.org` / `admin` — the Helm chart has no mechanism to override this. The setup playbook changes the password post-deploy via `PUT /api/v1/users/changePassword` API. The admin email cannot be changed (it's `admin@open-metadata.org`), only the password is changed to `OPENMETADATA_ADMIN_PASSWORD` from `urbalurba-secrets`.
+
+**1.3 IngressRoute** — follow the standard UIS pattern:
+- `HostRegexp('openmetadata\..+')` routing to port 8585
+- Namespace: `openmetadata`
+- Label: `protection: public`
+
+**1.4 Secrets template** — add to the OPTIONAL section in `00-common-values.env.template`:
+```bash
+# ================================================================
+# 🔧 OPTIONAL - OPENMETADATA
+# ================================================================
+# OpenMetadata bootstraps with admin@open-metadata.org — this cannot be changed via Helm
+OPENMETADATA_ADMIN_EMAIL=admin@open-metadata.org
+OPENMETADATA_ADMIN_PASSWORD=${DEFAULT_ADMIN_PASSWORD}
+OPENMETADATA_DB_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
+```
+
+OpenMetadata's default admin is `admin@open-metadata.org` / `admin`. The email is fixed (cannot be changed). The password is changed post-deploy by the setup playbook via the OpenMetadata API.
+
+**1.5 Master secrets** — add namespace block after unity-catalog block in `00-master-secrets.yml.template`:
+- Namespace: `openmetadata`
+- Secret keys: `OPENMETADATA_DATABASE_PASSWORD`, `OPENMETADATA_DATABASE_USER`, `OPENMETADATA_ADMIN_EMAIL`, `OPENMETADATA_ADMIN_PASSWORD`
+- All derived from standard UIS variables (`PGPASSWORD`, `DEFAULT_ADMIN_EMAIL`, `DEFAULT_ADMIN_PASSWORD`)
+
+### Validation
+
+User reviews the created files for correctness.
+
+---
+
+## Phase 2: Ansible Playbooks — ✅ DONE
+
+Create the setup, remove, and verify playbooks.
+
+### Tasks
+
+- [x] 2.1 Create setup playbook `ansible/playbooks/340-setup-openmetadata.yml` ✓
+- [x] 2.2 Create remove playbook `ansible/playbooks/340-remove-openmetadata.yml` ✓
+- [x] 2.3 Create verify playbook `ansible/playbooks/340-test-openmetadata.yml` ✓
+- [x] 2.4 Register `openmetadata` in `VERIFY_SERVICES` in `provision-host/uis/lib/integration-testing.sh` ✓
+- [x] 2.5 Add `openmetadata` verify command to `provision-host/uis/manage/uis-cli.sh` ✓
+
+### Implementation Details
+
+**2.1 Setup playbook** — combines Unity Catalog pattern (database creation) with Elasticsearch pattern (Helm deployment):
+
+1. **Prerequisites**: Create namespace, verify PostgreSQL and Elasticsearch are running, check secrets exist
+2. **Database**: Get PostgreSQL pod, retrieve password from secrets, create `openmetadata_db` database
+3. **Helm**: Add `open-metadata` Helm repo, `helm upgrade --install openmetadata open-metadata/openmetadata --version 1.12.1 -f 340-openmetadata-config.yaml -n openmetadata --wait`
+4. **RBAC**: Verify the Helm chart creates the required ServiceAccount, Role, and RoleBinding for the K8s Jobs executor. If not (check `kubectl get clusterrole,clusterrolebinding -l app.kubernetes.io/name=openmetadata`), create them manually — OpenMetadata needs permissions to create/read/delete Jobs, CronJobs, Pods, and Pod logs.
+5. **Admin credentials**: If the Helm chart doesn't support setting admin credentials natively, call the OpenMetadata API post-deploy to update the admin user's email and password from `urbalurba-secrets`.
+6. **Ingress**: Apply `341-openmetadata-ingressroute.yaml`
+7. **Health check**: Wait for pod ready, check API responds at `/api/v1/system/health`
+8. **Status**: Display final deployment status
+
+**2.2 Remove playbook** — follow Unity Catalog remove pattern:
+1. Delete IngressRoute
+2. `helm uninstall openmetadata -n openmetadata`
+3. Wait for pods to terminate
+4. Delete PVCs in the openmetadata namespace (`kubectl delete pvc -n openmetadata --all --ignore-not-found`) — follows the ES remove pattern
+5. Delete namespace
+6. Note: PostgreSQL database `openmetadata_db` is NOT deleted (manual cleanup if needed)
+
+**2.3 Verify playbook** (`340-test-openmetadata.yml`) — follows the ArgoCD (`220-test-argocd.yml`) and Authentik (`070-test-authentik-auth.yml`) patterns:
+- Uses `kubectl run curlimages/curl` for all tests (from inside the cluster)
+- Uses `ansible.builtin.assert` with `fail_msg` containing troubleshooting commands
+- Reads credentials from `urbalurba-secrets` (never hardcoded)
+- Includes negative test (wrong credentials)
+- Summary section at the end listing all results
+
+6 tests (all CRITICAL):
+
+| Test | What | How |
+|---|---|---|
+| **A. API health** | Server process responds | `GET /api/v1/system/health` → returns `OK` (HTTP 200). No auth needed. |
+| **B. Version** | Correct version deployed | `GET /api/v1/system/version` → JSON contains `"version": "1.12.1"`. No auth needed. |
+| **C. Admin login** | Credentials from secrets work | Login with `OPENMETADATA_ADMIN_EMAIL` / `OPENMETADATA_ADMIN_PASSWORD` from `urbalurba-secrets`. Must return a JWT token. The exact login API endpoint must be verified during implementation (likely `POST /api/v1/users/login` or `POST /api/v1/users/loginWithPwd`). Confirms both authentication AND database connectivity (user records are in PostgreSQL). |
+| **D. Database & Search connected** | PostgreSQL and Elasticsearch validated | `GET /api/v1/system/status` with JWT token from test C. Checks `database.passed: true` and `searchInstance.passed: true`. This is the comprehensive deployment validation endpoint. |
+| **E. UI via Traefik** | IngressRoute works | `curl -H "Host: openmetadata.localhost" http://<traefik-clusterip>` → HTTP 200. Same pattern as ArgoCD test C. |
+| **F. Wrong credentials rejected** | Bad password denied | Login with wrong password must NOT return a JWT token. Same pattern as ArgoCD test D and Authentik test E. |
+
+**Key details**:
+- Tests C, D, and F read the admin credentials from `urbalurba-secrets` in the `openmetadata` namespace (same as ArgoCD reads `ARGOCD_ADMIN_PASSWORD` and Authentik uses blueprint users). The credentials come from `DEFAULT_ADMIN_EMAIL` / `DEFAULT_ADMIN_PASSWORD` via the secrets pipeline — never hardcoded.
+- Test D validates both PostgreSQL AND Elasticsearch connectivity in a single call — the `/api/v1/system/status` endpoint checks all backend connections and returns per-component pass/fail.
+- Each test uses `ansible.builtin.assert` with detailed `fail_msg` including kubectl troubleshooting commands (pod logs, secret values, service status).
+
+**2.4 Integration test registration** — add to `VERIFY_SERVICES` in `integration-testing.sh`:
+```bash
+VERIFY_SERVICES="
+argocd:argocd verify
+openmetadata:openmetadata verify
+"
+```
+
+**2.5 CLI verify command** — add `openmetadata` to the `cmd_verify()` case statement in `uis-cli.sh`, calling `ansible-playbook 340-test-openmetadata.yml`. This enables `./uis verify openmetadata`.
+
+### Validation
+
+User reviews the playbook structure.
+
+---
+
+## Phase 3: Registration and Documentation — ✅ DONE
+
+Register the service and create documentation.
+
+### Tasks
+
+- [x] 3.1 Add `openmetadata` to `.uis.extend/enabled-services.conf` ✓
+- [x] 3.2 Add `packages/analytics/openmetadata` to `website/sidebars.ts` ✓
+- [x] 3.3 Create documentation page `website/docs/packages/analytics/openmetadata.md` ✓
+
+### Implementation Details
+
+**3.1 enabled-services.conf** — add `openmetadata` line (commented out by default, under a `# === Analytics ===` section)
+
+**3.2 sidebars.ts** — add after `unitycatalog` in the Analytics items array:
+```typescript
+'packages/analytics/openmetadata',
+```
+
+**3.3 Documentation** — follow the Elasticsearch docs page pattern (`website/docs/packages/databases/elasticsearch.md`):
+- Service info table (category, deploy/undeploy commands, dependencies, Helm chart with pinned version, namespace)
+- What It Does section
+- Deploy / Verify / Undeploy sections
+- Configuration section (Helm values, secrets, key files)
+- Troubleshooting section
+
+### Validation
+
+User reviews documentation and sidebar entry.
+
+---
+
+## Phase 4: Build, Deploy, and Test — ✅ DONE
+
+Build the provision host container, deploy, and verify with the tester.
+
+### Tasks
+
+- [x] 4.1 Run `./uis build` to build new provision host container with the service definition ✓
+- [x] 4.2 Write test instructions to `talk/talk.md` for the tester ✓
+- [x] 4.3 Wait for tester results ✓
+- [x] 4.4 Fix any issues found during testing (5 rounds — base64 login, requestType, password complexity, default-secrets.env) ✓
+
+### Implementation Details
+
+**4.1** The tester needs the updated container to have the service definition available.
+
+**4.2 Test instructions** for the tester:
+1. Restart with new container: `UIS_IMAGE=uis-provision-host:local ./uis restart`
+2. Generate and apply secrets: `./uis secrets generate && ./uis secrets apply`
+3. Deploy dependencies if not running: `./uis deploy postgresql && ./uis deploy elasticsearch`
+4. Deploy OpenMetadata: `./uis deploy openmetadata`
+5. Run verification: `./uis verify openmetadata` (runs all 6 E2E tests)
+6. Undeploy: `./uis undeploy openmetadata`
+7. Confirm cleanup: `kubectl get all -n openmetadata` (should show nothing)
+
+### Validation
+
+All 6 verify tests pass (API health, version, admin login, database+search connected, UI via Traefik, wrong credentials rejected). Deploy and undeploy both succeed.
+
+---
+
+## Phase 5: Cleanup and Status Updates — ✅ DONE
+
+Update investigation, roadmap, and complete the plan.
+
+### Tasks
+
+- [x] 5.1 Update `INVESTIGATE-openmetadata-deployment.md` — mark remaining next steps as done ✓
+- [x] 5.2 Update `STATUS-platform-roadmap.md` — mark #6 as Complete, add to Completed Investigations table ✓
+- [x] 5.3 Move plan and investigation to `completed/` ✓
+
+### Validation
+
+User confirms all status updates are correct.
+
+---
+
+## Acceptance Criteria
+
+- [x] OpenMetadata 1.12.1 pod is running in the `openmetadata` namespace
+- [x] Admin credentials use `DEFAULT_ADMIN_PASSWORD` from secrets (password changed post-deploy via API; email is fixed at `admin@open-metadata.org`)
+- [x] `./uis verify openmetadata` passes all 6 tests:
+  - [x] A. API health check (GET /api/v1/system/health → OK)
+  - [x] B. Version check (GET /api/v1/system/version → 1.12.1)
+  - [x] C. Admin login with credentials from secrets (returns JWT token)
+  - [x] D. Database and search connected (GET /api/v1/system/status → both passed)
+  - [x] E. UI accessible via Traefik (openmetadata.localhost → HTTP 200)
+  - [x] F. Wrong credentials rejected (bad password does NOT return token)
+- [x] `./uis deploy openmetadata` works end-to-end
+- [x] `./uis undeploy openmetadata` cleans up all resources
+- [x] Service appears in `./uis list`
+- [x] `./uis test-all --dry-run` includes openmetadata with verify step
+- [x] Documentation page exists at the correct sidebar location
+- [x] Tester has verified the deployment (Round 5 — all 8 steps PASS)
+
+---
+
+## Files to Create
+
+| File | Type |
+|------|------|
+| `provision-host/uis/services/analytics/service-openmetadata.sh` | New |
+| `manifests/340-openmetadata-config.yaml` | New |
+| `manifests/341-openmetadata-ingressroute.yaml` | New |
+| `ansible/playbooks/340-setup-openmetadata.yml` | New |
+| `ansible/playbooks/340-remove-openmetadata.yml` | New |
+| `ansible/playbooks/340-test-openmetadata.yml` | New |
+| `website/docs/packages/analytics/openmetadata.md` | New |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `provision-host/uis/templates/secrets-templates/00-common-values.env.template` | Add OpenMetadata section (admin + DB credentials) |
+| `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` | Add openmetadata namespace block |
+| `provision-host/uis/lib/integration-testing.sh` | Add `openmetadata` to `VERIFY_SERVICES` |
+| `provision-host/uis/manage/uis-cli.sh` | Add `openmetadata` to `cmd_verify()` |
+| `.uis.extend/enabled-services.conf` | Add `openmetadata` |
+| `website/sidebars.ts` | Add to Analytics items |
+| `website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-openmetadata-deployment.md` | Mark next steps done |
+| `website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md` | Update #6 status |

--- a/website/docs/packages/analytics/openmetadata.md
+++ b/website/docs/packages/analytics/openmetadata.md
@@ -1,0 +1,148 @@
+---
+title: OpenMetadata
+sidebar_label: OpenMetadata
+---
+
+# OpenMetadata
+
+Open-source data governance and metadata platform for data discovery, observability, and quality.
+
+| | |
+|---|---|
+| **Category** | Analytics |
+| **Deploy** | `./uis deploy openmetadata` |
+| **Undeploy** | `./uis undeploy openmetadata` |
+| **Verify** | `./uis verify openmetadata` |
+| **Depends on** | PostgreSQL, Elasticsearch |
+| **Helm chart** | `open-metadata/openmetadata` (pinned: 1.12.1) |
+| **Default namespace** | `openmetadata` |
+
+## What It Does
+
+OpenMetadata provides a unified metadata platform with:
+- **Data Discovery** — search across databases, dashboards, pipelines, ML models
+- **Data Lineage** — column-level lineage tracking across systems
+- **Data Quality** — profiling and quality checks
+- **Data Governance** — policies, glossaries, classification, ownership
+- **100+ Connectors** — integrates with databases, warehouses, BI tools
+
+Uses the Kubernetes native orchestrator for ingestion (no Airflow required).
+
+## Deploy
+
+```bash
+# Deploy dependencies first (if not already running)
+./uis deploy postgresql
+./uis deploy elasticsearch
+
+# Deploy OpenMetadata
+./uis deploy openmetadata
+```
+
+The setup playbook creates the `openmetadata_db` database on the existing PostgreSQL instance.
+
+## Verify
+
+```bash
+# Run all 6 E2E tests
+./uis verify openmetadata
+
+# Manual checks
+kubectl get pods -n openmetadata
+curl http://openmetadata.localhost/api/v1/system/health
+curl http://openmetadata.localhost/api/v1/system/version
+```
+
+## Configuration
+
+OpenMetadata configuration is in `manifests/340-openmetadata-config.yaml`. Key settings:
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Image | `docker.getcollate.io/openmetadata/server:1.12.1` | Pinned version |
+| Database | PostgreSQL (existing UIS instance) | Database: `openmetadata_db` |
+| Search | Elasticsearch 9.3.0 (existing UIS instance) | HTTP, no auth |
+| Orchestrator | K8s Jobs | No Airflow needed |
+| CPU request | 500m | Dev-appropriate |
+| Memory request | 1.5Gi | Dev-appropriate |
+| UI/API port | 8585 | Served by single process |
+
+### Admin Credentials
+
+OpenMetadata ships with a hardcoded default admin account (`admin@open-metadata.org` / `admin`). The Helm chart provides no way to override this.
+
+During deployment, the setup playbook automatically changes the admin password to match `DEFAULT_ADMIN_PASSWORD` from the UIS secrets system. The process:
+
+1. The playbook waits for OpenMetadata to be ready
+2. Logs in with the default credentials (`admin@open-metadata.org` / `admin`) via `POST /api/v1/users/login`
+3. Changes the password to `DEFAULT_ADMIN_PASSWORD` via `PUT /api/v1/users/changePassword`
+4. On redeploy, the playbook detects the password is already changed and skips the update
+
+**Admin email**: The login email is fixed at `admin@open-metadata.org`. OpenMetadata does not support changing the login email via API — the PATCH endpoint only updates the profile display name, not the login credential.
+
+**Password requirements**: OpenMetadata enforces 8-56 characters with uppercase, lowercase, digit, AND a special character. The default `DEFAULT_ADMIN_PASSWORD` (`LocalDev@123`) meets this requirement.
+
+### Secrets
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
+| `OPENMETADATA_DATABASE_PASSWORD` | `DEFAULT_DATABASE_PASSWORD` | PostgreSQL password |
+| `OPENMETADATA_ADMIN_EMAIL` | `admin@open-metadata.org` (fixed) | Admin login email — cannot be changed |
+| `OPENMETADATA_ADMIN_PASSWORD` | `DEFAULT_ADMIN_PASSWORD` | Admin login password (changed post-deploy via API) |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `manifests/340-openmetadata-config.yaml` | Helm values (database, search, resources) |
+| `manifests/341-openmetadata-ingressroute.yaml` | Traefik IngressRoute |
+| `ansible/playbooks/340-setup-openmetadata.yml` | Deployment playbook |
+| `ansible/playbooks/340-remove-openmetadata.yml` | Removal playbook |
+| `ansible/playbooks/340-test-openmetadata.yml` | E2E verification (6 tests) |
+
+## Undeploy
+
+```bash
+./uis undeploy openmetadata
+```
+
+Note: The PostgreSQL database `openmetadata_db` is NOT deleted. To remove it manually:
+```bash
+kubectl exec -n default postgresql-0 -- bash -c 'PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgres-password) psql -U postgres -c "DROP DATABASE IF EXISTS openmetadata_db;"'
+```
+
+## Troubleshooting
+
+**Pod won't start (OOM or Java errors):**
+```bash
+kubectl describe pod -n openmetadata -l app.kubernetes.io/name=openmetadata
+kubectl logs -n openmetadata -l app.kubernetes.io/name=openmetadata --tail=50
+```
+
+**Database connection failed:**
+```bash
+# Check PostgreSQL is running
+kubectl get pods -n default -l app.kubernetes.io/name=postgresql
+# Check database exists
+kubectl exec -n default postgresql-0 -- psql -U postgres -c "\l" | grep openmetadata
+```
+
+**Elasticsearch connection failed:**
+```bash
+# Check Elasticsearch is running
+kubectl get pods -n default -l app=elasticsearch-master
+# Check ES responds
+kubectl exec elasticsearch-master-0 -- curl -s http://localhost:9200/_cluster/health
+```
+
+**Authentication failed:**
+```bash
+# Check credentials in secrets
+kubectl get secret urbalurba-secrets -n openmetadata -o jsonpath='{.data.OPENMETADATA_ADMIN_EMAIL}' | base64 -d
+kubectl get secret urbalurba-secrets -n openmetadata -o jsonpath='{.data.OPENMETADATA_ADMIN_PASSWORD}' | base64 -d
+```
+
+## Learn More
+
+- [OpenMetadata documentation](https://docs.open-metadata.org)
+- [OpenMetadata GitHub](https://github.com/open-metadata/OpenMetadata)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -67,6 +67,7 @@ const sidebars: SidebarsConfig = {
           },
           items: [
             'packages/analytics/jupyterhub',
+            'packages/analytics/openmetadata',
             'packages/analytics/spark',
             'packages/analytics/unitycatalog',
           ],

--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -63,6 +63,28 @@
 ,
   {
     "@type": "SoftwareApplication",
+    "id": "openmetadata",
+    "name": "OpenMetadata",
+    "description": "Open-source data governance and metadata platform",
+    "category": "ANALYTICS",
+    "tags": ["data-governance", "metadata", "data-discovery", "data-lineage", "data-quality", "data-catalog"],
+    "abstract": "Open-source metadata platform for data discovery, governance, and observability",
+    "logo": "openmetadata-logo.webp",
+    "website": "https://open-metadata.org"
+    ,"summary": "OpenMetadata is an open-source metadata platform for data discovery, data observability, and data governance. It provides unified metadata management with 100+ connectors, column-level lineage, data quality checks, and collaboration features."
+    ,"docs": "/docs/packages/analytics/openmetadata"
+    ,"playbook": "340-setup-openmetadata.yml"
+    ,"priority": 93
+    ,"checkCommand": "kubectl get pods -n openmetadata -l app.kubernetes.io/name=openmetadata --no-headers 2>/dev/null | grep -q Running"
+    ,"removePlaybook": "340-remove-openmetadata.yml"
+    ,"requires": ["postgresql", "elasticsearch"]
+    ,"helmChart": "open-metadata/openmetadata"
+    ,"namespace": "openmetadata"
+    ,"image": "docker.getcollate.io/openmetadata/server:1.12.1"
+  }
+,
+  {
+    "@type": "SoftwareApplication",
     "id": "spark",
     "name": "Apache Spark",
     "description": "Unified analytics engine for big data",
@@ -395,7 +417,7 @@
     "logo": "cloudflare-logo.webp",
     "website": "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/"
     ,"summary": "Cloudflare Tunnel creates a secure, outbound-only connection between your origin and Cloudflares edge. No need to open public inbound ports - traffic is routed through Cloudflares network."
-    ,"docs": "/docs/packages/networking/cloudflare-tunnel"
+    ,"docs": "/docs/packages/networking/cloudflare"
     ,"playbook": "820-deploy-network-cloudflare-tunnel.yml"
     ,"priority": 101
     ,"checkCommand": "kubectl get pods -n default -l app=cloudflared --no-headers 2>/dev/null | grep -q Running"
@@ -416,7 +438,7 @@
     "logo": "tailscale-logo.webp",
     "website": "https://tailscale.com"
     ,"summary": "Tailscale creates a secure, private network between your servers, computers, and cloud instances using WireGuard encryption. It provides zero-config networking with built-in NAT traversal."
-    ,"docs": "/docs/packages/networking/tailscale-tunnel"
+    ,"docs": "/docs/packages/networking/tailscale"
     ,"playbook": "802-deploy-network-tailscale-tunnel.yml"
     ,"priority": 100
     ,"checkCommand": "kubectl get pods -n tailscale -l app=operator --no-headers 2>/dev/null | grep -q Running"


### PR DESCRIPTION
## Summary
- Deploy OpenMetadata 1.12.1 data governance platform (manifest 340) using official Helm chart
- Reuses existing PostgreSQL and Elasticsearch 9.3.0 — no new infrastructure needed
- K8s native orchestrator for ingestion pipelines (no Airflow)
- Admin password changed post-deploy via API to match `DEFAULT_ADMIN_PASSWORD`
- 6 E2E verification tests: API health, version, admin login, DB+search connected, UI via Traefik, wrong credentials rejected
- Updates `DEFAULT_ADMIN_PASSWORD` to `LocalDev@123` (special char required by OpenMetadata)

## Test plan
- [x] `./uis deploy openmetadata` — deploys successfully (8 rounds of testing)
- [x] `./uis verify openmetadata` — all 6 E2E tests PASS
- [x] `./uis undeploy openmetadata` — cleans up all resources
- [x] Website builds with no new broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)