### PR TITLE
feat: deploy Nextcloud 33 + OnlyOffice 9.3.1

### DIFF
--- a/ansible/playbooks/620-remove-nextcloud.yml
+++ b/ansible/playbooks/620-remove-nextcloud.yml
@@ -1,0 +1,98 @@
+---
+# file: ansible/playbooks/620-remove-nextcloud.yml
+# Description: Remove Nextcloud and OnlyOffice from Kubernetes
+#
+# Usage:
+# ansible-playbook playbooks/620-remove-nextcloud.yml -e kube_context="rancher-desktop"
+
+- name: Remove Nextcloud + OnlyOffice from Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    manifests_folder: "/mnt/urbalurbadisk/manifests"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    nextcloud_namespace: "nextcloud"
+    helm_release_name: "nextcloud"
+
+  tasks:
+    - name: 1. Print playbook description
+      ansible.builtin.debug:
+        msg: |
+          Removing Nextcloud + OnlyOffice from Kubernetes
+          Namespace: {{ nextcloud_namespace }}
+
+    - name: 2. Delete OnlyOffice IngressRoute
+      kubernetes.core.k8s:
+        src: "{{ manifests_folder }}/623-onlyoffice-ingressroute.yaml"
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 3. Delete OnlyOffice Deployment and Service
+      kubernetes.core.k8s:
+        src: "{{ manifests_folder }}/622-onlyoffice-config.yaml"
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 4. Delete Nextcloud IngressRoute
+      kubernetes.core.k8s:
+        src: "{{ manifests_folder }}/621-nextcloud-ingressroute.yaml"
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 5. Check for Nextcloud Helm release
+      ansible.builtin.shell: helm list -n {{ nextcloud_namespace }} | grep -w {{ helm_release_name }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: helm_check
+      changed_when: false
+      ignore_errors: true
+
+    - name: 6. Remove Nextcloud Helm release
+      ansible.builtin.command: helm uninstall {{ helm_release_name }} -n {{ nextcloud_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: helm_check.rc == 0
+      changed_when: true
+      ignore_errors: true
+
+    - name: 7. Wait for pods to terminate
+      ansible.builtin.shell: |
+        kubectl wait --for=delete pod -l app.kubernetes.io/name=nextcloud -n {{ nextcloud_namespace }} --timeout=60s 2>/dev/null || true
+        kubectl wait --for=delete pod -l app=onlyoffice -n {{ nextcloud_namespace }} --timeout=60s 2>/dev/null || true
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: false
+
+    - name: 8. Delete PVCs in nextcloud namespace
+      ansible.builtin.shell: kubectl delete pvc -n {{ nextcloud_namespace }} --all --ignore-not-found
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      ignore_errors: true
+
+    - name: 9. Delete nextcloud namespace
+      kubernetes.core.k8s:
+        name: "{{ nextcloud_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 10. Display removal status
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          Nextcloud + OnlyOffice Removal Status
+          ===============================================
+
+          ✅ Nextcloud and OnlyOffice resources removed
+
+          Note: The PostgreSQL database 'nextcloud' was NOT deleted.
+          To remove the database manually:
+            kubectl exec -n default postgresql-0 -- psql -U postgres -c "DROP DATABASE nextcloud;"
+
+          ===============================================

--- a/ansible/playbooks/620-setup-nextcloud.yml
+++ b/ansible/playbooks/620-setup-nextcloud.yml
@@ -1,0 +1,464 @@
+---
+# file: ansible/playbooks/620-setup-nextcloud.yml
+# Description:
+# Set up Nextcloud collaboration platform with OnlyOffice Document Server on Kubernetes.
+# Uses the official Helm chart with existing UIS PostgreSQL and Redis.
+# OnlyOffice is deployed as a separate Deployment in the same namespace.
+#
+# Prerequisites:
+# - Kubernetes cluster is set up and accessible
+# - PostgreSQL deployed (manifest 042)
+# - Redis deployed (manifest 050)
+# - urbalurba-secrets applied to nextcloud namespace
+# - Helm 3.x installed
+#
+# Usage:
+# ansible-playbook playbooks/620-setup-nextcloud.yml -e kube_context="rancher-desktop"
+
+- name: Set up Nextcloud + OnlyOffice on Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    manifests_folder: "/mnt/urbalurbadisk/manifests"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    nextcloud_namespace: "nextcloud"
+    nextcloud_config_file: "{{ manifests_folder }}/620-nextcloud-config.yaml"
+    nextcloud_ingress_file: "{{ manifests_folder }}/621-nextcloud-ingressroute.yaml"
+    onlyoffice_config_file: "{{ manifests_folder }}/622-onlyoffice-config.yaml"
+    onlyoffice_ingress_file: "{{ manifests_folder }}/623-onlyoffice-ingressroute.yaml"
+    nextcloud_helm_repo_url: "https://nextcloud.github.io/helm/"
+    nextcloud_helm_chart: "nextcloud/nextcloud"
+    nextcloud_helm_version: "9.0.3"
+    helm_release_name: "nextcloud"
+    installation_timeout: 600
+
+  tasks:
+    - name: 1. Print playbook description
+      ansible.builtin.debug:
+        msg: |
+          Setting up Nextcloud + OnlyOffice on Kubernetes
+          Helm chart: {{ nextcloud_helm_chart }} v{{ nextcloud_helm_version }}
+          Namespace: {{ nextcloud_namespace }}
+          Database: PostgreSQL (existing UIS instance)
+          Cache: Redis (existing UIS instance)
+          Document editing: OnlyOffice Document Server 9.3.1
+
+    # ============= PHASE 1: PREREQUISITES VERIFICATION =============
+
+    - name: 2. Create nextcloud namespace
+      kubernetes.core.k8s:
+        name: "{{ nextcloud_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 3. Check if PostgreSQL is available
+      ansible.builtin.shell: >-
+        kubectl get service postgresql -n default --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: postgres_check
+      changed_when: false
+
+    - name: 4. Fail if PostgreSQL is not available
+      ansible.builtin.fail:
+        msg: "PostgreSQL is required for Nextcloud. Deploy it first: ./uis deploy postgresql"
+      when: postgres_check.stdout | int == 0
+
+    - name: 5. Check if Redis is available
+      ansible.builtin.shell: >-
+        kubectl get service redis-master -n default --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: redis_check
+      changed_when: false
+
+    - name: 6. Fail if Redis is not available
+      ansible.builtin.fail:
+        msg: "Redis is required for Nextcloud. Deploy it first: ./uis deploy redis"
+      when: redis_check.stdout | int == 0
+
+    - name: 7. Check if urbalurba-secrets exists in nextcloud namespace
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: secrets_check
+      changed_when: false
+
+    - name: 8. Display prerequisites status
+      ansible.builtin.debug:
+        msg: |
+          Prerequisites:
+          - PostgreSQL: Available ✅
+          - Redis: Available ✅
+          - Secrets: {{ 'Configured ✅' if (secrets_check.stdout | int) > 0 else 'Not found ⚠️ — run ./uis secrets generate && ./uis secrets apply' }}
+
+    # ============= PHASE 2: DATABASE SETUP =============
+
+    - name: 9. Get PostgreSQL pod name
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ merged_kubeconf_file }}"
+        kind: Pod
+        namespace: default
+        label_selectors:
+          - app.kubernetes.io/name=postgresql
+      register: postgres_pods
+
+    - name: 10. Set PostgreSQL pod name
+      ansible.builtin.set_fact:
+        postgres_pod_name: "{{ postgres_pods.resources[0].metadata.name }}"
+      when: postgres_pods.resources | length > 0
+
+    - name: 11. Get PostgreSQL password from urbalurba-secrets
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n default
+        -o jsonpath='{.data.PGPASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: postgres_password
+      changed_when: false
+
+    - name: 12. Check if nextcloud database exists
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}' psql -h postgresql.default -U postgres -tAc \"SELECT 1 FROM pg_database WHERE datname='nextcloud'\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: db_exists_check
+      changed_when: false
+      ignore_errors: true
+
+    - name: 13. Drop stale nextcloud database if it exists (avoids permission errors on redeploy)
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}' psql -h postgresql.default -U postgres -c 'DROP DATABASE IF EXISTS nextcloud;'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: db_exists_check.stdout | trim == "1"
+      changed_when: true
+      ignore_errors: true
+
+    - name: 14. Create fresh nextcloud database in PostgreSQL
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}' createdb -h postgresql.default -U postgres nextcloud"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: create_db_result
+      changed_when: true
+
+    - name: 15. Display database creation result
+      ansible.builtin.debug:
+        msg: "Nextcloud database: {{ 'Recreated (dropped stale) ✅' if (db_exists_check.stdout | trim == '1') else 'Created fresh ✅' }}"
+
+    # ============= PHASE 3: HELM DEPLOYMENT =============
+
+    - name: 16. Check existing Helm repositories
+      ansible.builtin.command: helm repo list
+      register: helm_repo_list
+      changed_when: false
+      ignore_errors: true
+
+    - name: 17. Add Nextcloud Helm repository if missing
+      kubernetes.core.helm_repository:
+        name: "nextcloud"
+        repo_url: "{{ nextcloud_helm_repo_url }}"
+      when: "'nextcloud' not in helm_repo_list.stdout"
+
+    - name: 18. Update Helm repositories
+      ansible.builtin.command: helm repo update
+      changed_when: false
+
+    - name: 19. Deploy Nextcloud using official Helm chart
+      ansible.builtin.command: >
+        helm upgrade --install {{ helm_release_name }} {{ nextcloud_helm_chart }}
+        --version {{ nextcloud_helm_version }}
+        -f {{ nextcloud_config_file }}
+        --namespace {{ nextcloud_namespace }}
+        --timeout {{ installation_timeout }}s
+        --wait
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: nextcloud_install
+      changed_when: true
+
+    - name: 20. Display Helm install output
+      ansible.builtin.debug:
+        msg: "{{ nextcloud_install.stdout_lines }}"
+      when: nextcloud_install.stdout_lines is defined
+
+    # ============= PHASE 4: WAIT FOR NEXTCLOUD READINESS =============
+
+    - name: 21. Wait for Nextcloud pod to be running
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ nextcloud_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/name=nextcloud"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: nextcloud_pods
+      until: >
+        nextcloud_pods.resources | length > 0 and
+        nextcloud_pods.resources[0].status.phase == "Running"
+      retries: 30
+      delay: 15
+
+    - name: 22. Wait for Nextcloud pod to be ready (1/1)
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ nextcloud_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/name=nextcloud"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: nextcloud_pods_ready
+      until: >
+        nextcloud_pods_ready.resources | length > 0 and
+        nextcloud_pods_ready.resources[0].status.containerStatuses is defined and
+        nextcloud_pods_ready.resources[0].status.containerStatuses | length > 0 and
+        nextcloud_pods_ready.resources[0].status.containerStatuses[0].ready == true
+      retries: 30
+      delay: 10
+
+    # ============= PHASE 5: INGRESS =============
+
+    - name: 23. Apply Nextcloud IngressRoute
+      kubernetes.core.k8s:
+        src: "{{ nextcloud_ingress_file }}"
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    # ============= PHASE 6: NEXTCLOUD HEALTH CHECK =============
+
+    - name: 24. Check Nextcloud health via /status.php
+      ansible.builtin.shell: |
+        kubectl run curl-health-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          curl -s -H "Host: nextcloud.localhost" http://{{ helm_release_name }}.{{ nextcloud_namespace }}.svc.cluster.local/status.php
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: health_check
+      retries: 10
+      delay: 15
+      until: "'\"installed\":true' in health_check.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: 25. Display health check result
+      ansible.builtin.debug:
+        msg: "Nextcloud health: {{ '✅ Installed and running' if '\"installed\":true' in health_check.stdout else '⚠️ Not ready yet — may need more startup time' }}"
+
+    # ============= PHASE 7: ONLYOFFICE DEPLOYMENT =============
+
+    - name: 26. Deploy OnlyOffice Document Server (image ~1.5 GB — first pull may take several minutes)
+      kubernetes.core.k8s:
+        src: "{{ onlyoffice_config_file }}"
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 27. Apply OnlyOffice IngressRoute
+      kubernetes.core.k8s:
+        src: "{{ onlyoffice_ingress_file }}"
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 28. Wait for OnlyOffice pod to be ready
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ nextcloud_namespace }}"
+        label_selectors:
+          - "app=onlyoffice"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: onlyoffice_pods
+      until: >
+        onlyoffice_pods.resources | length > 0 and
+        onlyoffice_pods.resources[0].status.phase == "Running" and
+        onlyoffice_pods.resources[0].status.containerStatuses is defined and
+        onlyoffice_pods.resources[0].status.containerStatuses | length > 0 and
+        onlyoffice_pods.resources[0].status.containerStatuses[0].ready == true
+      retries: 40
+      delay: 15
+
+    # ============= PHASE 8: ONLYOFFICE INTEGRATION VIA OCC =============
+
+    - name: 29. Get Nextcloud pod name
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ nextcloud_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/name=nextcloud"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: nc_pods
+
+    - name: 30. Set Nextcloud pod name
+      ansible.builtin.set_fact:
+        nextcloud_pod_name: "{{ nc_pods.resources[0].metadata.name }}"
+
+    - name: 31. Get OnlyOffice JWT secret from urbalurba-secrets
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }}
+        -o jsonpath='{.data.ONLYOFFICE_JWT_SECRET}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: onlyoffice_jwt_secret
+      changed_when: false
+
+    - name: 32. Install OnlyOffice connector app (downloads from Nextcloud App Store — needs internet)
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ app:install onlyoffice || echo 'App may already be installed'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: occ_install
+      changed_when: "'App may already be installed' not in occ_install.stdout"
+      ignore_errors: true
+
+    - name: 33. Configure OnlyOffice Document Server URL (public)
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ config:app:set onlyoffice DocumentServerUrl --value='http://onlyoffice.localhost'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+
+    - name: 34. Configure OnlyOffice internal server-to-server URL
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ config:app:set onlyoffice DocumentServerInternalUrl --value='http://onlyoffice-svc.{{ nextcloud_namespace }}.svc.cluster.local:80'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+
+    - name: 35. Configure OnlyOffice storage callback URL
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ config:app:set onlyoffice StorageUrl --value='http://{{ helm_release_name }}.{{ nextcloud_namespace }}.svc.cluster.local/'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+
+    - name: 36. Configure OnlyOffice JWT shared secret
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ config:app:set onlyoffice jwt_secret --value='{{ onlyoffice_jwt_secret.stdout }}'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      no_log: true
+
+    - name: 37. Get admin credentials for OnlyOffice settings API call
+      ansible.builtin.shell: |
+        USER=$(kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} -o jsonpath='{.data.NEXTCLOUD_ADMIN_USER}' | base64 -d)
+        PASS=$(kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} -o jsonpath='{.data.NEXTCLOUD_ADMIN_PASSWORD}' | base64 -d)
+        echo "${USER}:${PASS}"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: admin_creds
+      changed_when: false
+      no_log: true
+
+    - name: 38. Trigger OnlyOffice settings save with internal URL (registers file handlers)
+      ansible.builtin.shell: |
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} -- \
+          su -s /bin/bash www-data -c "
+            curl -s -X PUT \
+              -u '{{ admin_creds.stdout }}' \
+              -H 'Content-Type: application/json' \
+              -H 'OCS-APIRequest: true' \
+              -H 'Host: nextcloud.localhost' \
+              http://localhost/index.php/apps/onlyoffice/ajax/settings \
+              -d '{
+                \"documentserver\": \"http://onlyoffice-svc.{{ nextcloud_namespace }}.svc.cluster.local:80/\",
+                \"documentserverInternal\": \"http://onlyoffice-svc.{{ nextcloud_namespace }}.svc.cluster.local:80/\",
+                \"storageUrl\": \"http://{{ helm_release_name }}.{{ nextcloud_namespace }}.svc.cluster.local/\",
+                \"secret\": \"{{ onlyoffice_jwt_secret.stdout }}\",
+                \"demo\": false
+              }'
+          "
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: settings_save_result
+      changed_when: true
+      no_log: true
+
+    - name: 39. Set DocumentServerUrl to public URL for browser access
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ config:app:set onlyoffice DocumentServerUrl --value='http://onlyoffice.localhost/'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+
+    - name: "39b. Wait for OnlyOffice connector to process settings change"
+      ansible.builtin.pause:
+        seconds: 5
+
+    - name: 40. Clear any settings error from validation
+      ansible.builtin.shell: >-
+        kubectl exec -n {{ nextcloud_namespace }} {{ nextcloud_pod_name }} --
+        su -s /bin/bash www-data -c "php occ config:app:delete onlyoffice settings_error"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      ignore_errors: true
+
+    - name: 41. Display OnlyOffice settings save result
+      ansible.builtin.debug:
+        msg: "OnlyOffice settings save: {{ '✅ File handlers registered' if settings_save_result.rc == 0 else '⚠️ Check logs — file handlers may need manual registration via admin UI' }}"
+
+    - name: 42. Display OnlyOffice integration result
+      ansible.builtin.debug:
+        msg: |
+          OnlyOffice integration:
+          - App installed: {{ '✅' if occ_install.rc == 0 else '⚠️ Check logs' }}
+          - DocumentServerUrl: http://onlyoffice.localhost
+          - DocumentServerInternalUrl: http://onlyoffice-svc.{{ nextcloud_namespace }}.svc.cluster.local:80
+          - StorageUrl: http://{{ helm_release_name }}.{{ nextcloud_namespace }}.svc.cluster.local/
+          - JWT secret: configured ✅
+
+    # ============= PHASE 9: STATUS =============
+
+    - name: 43. Get all pods in nextcloud namespace
+      ansible.builtin.shell: kubectl get pods -n {{ nextcloud_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: nextcloud_pod_status
+      changed_when: false
+
+    - name: 44. Get all services in nextcloud namespace
+      ansible.builtin.shell: kubectl get services -n {{ nextcloud_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: nextcloud_svc_status
+      changed_when: false
+
+    - name: 45. Display final status
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          Nextcloud + OnlyOffice Deployment Status
+          ===============================================
+
+          {{ '✅ SUCCESS - Nextcloud deployed and ready' if '\"installed\":true' in health_check.stdout else '⚠️ DEPLOYED - Nextcloud may still be starting up' }}
+
+          📊 Deployment Details:
+          • Chart: {{ nextcloud_helm_chart }} v{{ nextcloud_helm_version }}
+          • Namespace: {{ nextcloud_namespace }}
+          • Database: nextcloud on PostgreSQL (existing UIS)
+          • Cache: Redis (existing UIS)
+          • Document editing: OnlyOffice Document Server 9.3.1
+
+          📦 Pods:
+          {{ nextcloud_pod_status.stdout }}
+
+          🌐 Services:
+          {{ nextcloud_svc_status.stdout }}
+
+          🌐 Access:
+          • Nextcloud: http://nextcloud.localhost
+          • OnlyOffice: http://onlyoffice.localhost
+
+          🔧 Verify deployment:
+          • ./uis verify nextcloud
+
+          ===============================================

--- a/ansible/playbooks/620-test-nextcloud.yml
+++ b/ansible/playbooks/620-test-nextcloud.yml
@@ -1,0 +1,449 @@
+---
+# file: ansible/playbooks/620-test-nextcloud.yml
+# Description:
+# End-to-end tests for the Nextcloud + OnlyOffice deployment.
+# Validates health, WebDAV auth, Traefik routing, OnlyOffice health, and auth security.
+#
+# Tests (all CRITICAL):
+#   A. Health endpoint - /status.php must report installed:true
+#   B. Admin login via WebDAV - correct credentials must return 207 multistatus
+#   C. Wrong credentials rejected - bad password must return 401
+#   D. UI access via Traefik IngressRoute - nextcloud.localhost must be routable
+#   E. OnlyOffice health - /healthcheck must return true
+#   F. OnlyOffice JWT enforcement - unsigned request must be rejected
+#   G. OnlyOffice editor endpoint - editor must render for .docx files
+#   H. OnlyOffice config clean - no settings_error in config
+#
+# Usage:
+# ansible-playbook ansible/playbooks/620-test-nextcloud.yml -e kube_context="rancher-desktop"
+
+- name: End-to-End Nextcloud + OnlyOffice Tests
+  hosts: localhost
+  gather_facts: false
+  vars:
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    nextcloud_namespace: "nextcloud"
+    nextcloud_service: "nextcloud.{{ nextcloud_namespace }}.svc.cluster.local"
+    onlyoffice_service: "onlyoffice-svc.{{ nextcloud_namespace }}.svc.cluster.local"
+
+  tasks:
+    - name: "0. Display test suite initiation"
+      ansible.builtin.debug:
+        msg: |
+          🧪 End-to-End Nextcloud + OnlyOffice Tests
+          ===============================================
+          Running 8 test groups (all CRITICAL)
+
+    - name: "0.1. Get Traefik ClusterIP for in-cluster hostname routing"
+      ansible.builtin.shell: |
+        kubectl get svc traefik -n kube-system -o jsonpath='{.spec.clusterIP}'
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: traefik_ip_result
+      changed_when: false
+
+    - name: "0.2. Store Traefik IP"
+      ansible.builtin.set_fact:
+        traefik_ip: "{{ traefik_ip_result.stdout }}"
+
+    - name: "0.3. Get Nextcloud admin user from urbalurba-secrets"
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} -o jsonpath='{.data.NEXTCLOUD_ADMIN_USER}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: admin_user_result
+      changed_when: false
+
+    - name: "0.4. Get Nextcloud admin password from urbalurba-secrets"
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} -o jsonpath='{.data.NEXTCLOUD_ADMIN_PASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: admin_password_result
+      changed_when: false
+
+    - name: "0.5. Store admin credentials"
+      ansible.builtin.set_fact:
+        admin_user: "{{ admin_user_result.stdout }}"
+        admin_password: "{{ admin_password_result.stdout }}"
+
+    # ===== Test A: Health endpoint (CRITICAL) =====
+    - name: "A1. Check Nextcloud health via /status.php"
+      ansible.builtin.shell: |
+        kubectl run curl-test-health-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          curl -s -H "Host: nextcloud.localhost" http://{{ nextcloud_service }}/status.php
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: health_test
+      retries: 5
+      delay: 10
+      until: "'\"installed\":true' in health_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "A2. Verify Nextcloud is installed and not in maintenance"
+      ansible.builtin.assert:
+        that:
+          - "'\"installed\":true' in health_test.stdout"
+          - "'\"maintenance\":false' in health_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: Nextcloud health check failed!
+          Expected /status.php to report installed:true and maintenance:false.
+          Got: {{ health_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check pod status: kubectl get pods -n {{ nextcloud_namespace }}
+          - Check pod logs: kubectl logs -n {{ nextcloud_namespace }} -l app.kubernetes.io/name=nextcloud --tail=50
+          - Check service: kubectl get svc -n {{ nextcloud_namespace }}
+        success_msg: "✅ Test A PASSED: Nextcloud is installed and running"
+
+    - name: "A3. Display health test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test A: Health Endpoint — PASSED (CRITICAL)
+          📋 /status.php reports installed:true, maintenance:false
+
+    # ===== Test B: Admin login via WebDAV (CRITICAL) =====
+    - name: "B1. Authenticate via WebDAV with admin credentials"
+      ansible.builtin.shell: |
+        kubectl run curl-test-webdav-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X PROPFIND \
+              -u "{{ admin_user }}:{{ admin_password }}" \
+              -H "Host: nextcloud.localhost" \
+              http://{{ nextcloud_service }}/remote.php/dav)
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "HTTP_CODE:207\|multistatus"; then
+              echo "WEBDAV_LOGIN: SUCCESS"
+            else
+              echo "WEBDAV_LOGIN: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: webdav_test
+      retries: 3
+      delay: 10
+      until: "'WEBDAV_LOGIN: SUCCESS' in webdav_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "B2. Verify admin WebDAV login succeeded"
+      ansible.builtin.assert:
+        that:
+          - "'WEBDAV_LOGIN: SUCCESS' in webdav_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: Admin WebDAV login to Nextcloud FAILED!
+          Expected GET /remote.php/dav with basic auth to return HTTP 207.
+          Got: {{ webdav_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check admin user: kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} -o jsonpath='{.data.NEXTCLOUD_ADMIN_USER}' | base64 -d
+          - Check admin password: kubectl get secret urbalurba-secrets -n {{ nextcloud_namespace }} -o jsonpath='{.data.NEXTCLOUD_ADMIN_PASSWORD}' | base64 -d
+          - Check pod logs: kubectl logs -n {{ nextcloud_namespace }} -l app.kubernetes.io/name=nextcloud --tail=50
+        success_msg: "✅ Test B PASSED: Admin WebDAV login returned 207 multistatus"
+
+    - name: "B3. Display WebDAV test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test B: Admin Login via WebDAV — PASSED (CRITICAL)
+          📋 GET /remote.php/dav with admin credentials returned 207
+          🔐 Admin authentication and database connectivity confirmed
+
+    # ===== Test C: Wrong credentials rejected (CRITICAL) =====
+    - name: "C1. Attempt WebDAV access with wrong password"
+      ansible.builtin.shell: |
+        kubectl run curl-test-badauth-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X PROPFIND \
+              -u "{{ admin_user }}:WrongPassword999" \
+              -H "Host: nextcloud.localhost" \
+              http://{{ nextcloud_service }}/remote.php/dav)
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "HTTP_CODE:401"; then
+              echo "BAD_AUTH: CORRECTLY_REJECTED"
+            else
+              echo "BAD_AUTH: WRONGLY_ACCEPTED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: badauth_test
+      failed_when: false
+      changed_when: false
+
+    - name: "C2. Verify wrong password was rejected"
+      ansible.builtin.assert:
+        that:
+          - "'BAD_AUTH: CORRECTLY_REJECTED' in badauth_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: Wrong password was ACCEPTED! Authentication is broken!
+          Login with admin / WrongPassword999 should have been rejected.
+        success_msg: "✅ Test C PASSED: Wrong password correctly rejected"
+
+    - name: "C3. Display wrong credentials test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test C: Wrong Credentials Rejected — PASSED (CRITICAL)
+          📋 WebDAV with wrong password correctly returned HTTP 401
+          🔒 Authentication is properly validating credentials
+
+    # ===== Test D: UI access via Traefik IngressRoute (CRITICAL) =====
+    - name: "D1. Access Nextcloud UI via Traefik with Host header"
+      ansible.builtin.shell: |
+        kubectl run curl-test-ui-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -H "Host: nextcloud.localhost" \
+              http://{{ traefik_ip }})
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "HTTP_CODE:200\|HTTP_CODE:302\|Nextcloud"; then
+              echo "TRAEFIK_ROUTING: SUCCESS"
+            else
+              echo "TRAEFIK_ROUTING: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: ui_access_test
+      retries: 3
+      delay: 10
+      until: "'TRAEFIK_ROUTING: SUCCESS' in ui_access_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "D2. Verify UI is accessible via Traefik"
+      ansible.builtin.assert:
+        that:
+          - "'TRAEFIK_ROUTING: SUCCESS' in ui_access_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: Nextcloud UI not accessible via Traefik IngressRoute!
+          Expected response when accessing nextcloud.localhost through Traefik.
+          Got: {{ ui_access_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check IngressRoute: kubectl get ingressroute -n {{ nextcloud_namespace }}
+          - Check Traefik: kubectl get svc traefik -n kube-system
+          - Check service: kubectl get svc -n {{ nextcloud_namespace }}
+        success_msg: "✅ Test D PASSED: Nextcloud UI accessible via nextcloud.localhost"
+
+    - name: "D3. Display UI access test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test D: UI Access via Traefik — PASSED (CRITICAL)
+          📋 nextcloud.localhost routes correctly through Traefik IngressRoute
+
+    # ===== Test E: OnlyOffice health (CRITICAL) =====
+    - name: "E1. Check OnlyOffice healthcheck endpoint"
+      ansible.builtin.shell: |
+        kubectl run curl-test-oo-health-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s http://{{ onlyoffice_service }}/healthcheck)
+            echo "HEALTHCHECK_RESPONSE: $RESPONSE"
+            if echo "$RESPONSE" | grep -q "true"; then
+              echo "ONLYOFFICE_HEALTH: PASSED"
+            else
+              echo "ONLYOFFICE_HEALTH: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: oo_health_test
+      retries: 5
+      delay: 10
+      until: "'ONLYOFFICE_HEALTH: PASSED' in oo_health_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "E2. Verify OnlyOffice is healthy"
+      ansible.builtin.assert:
+        that:
+          - "'ONLYOFFICE_HEALTH: PASSED' in oo_health_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OnlyOffice Document Server health check failed!
+          Expected /healthcheck to return 'true'.
+          Got: {{ oo_health_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check pod status: kubectl get pods -n {{ nextcloud_namespace }} -l app=onlyoffice
+          - Check pod logs: kubectl logs -n {{ nextcloud_namespace }} -l app=onlyoffice --tail=50
+          - Note: OnlyOffice image is ~1.5 GB and takes 30-60s to start
+        success_msg: "✅ Test E PASSED: OnlyOffice Document Server is healthy"
+
+    - name: "E3. Display OnlyOffice health test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test E: OnlyOffice Health — PASSED (CRITICAL)
+          📋 /healthcheck returns true
+
+    # ===== Test F: OnlyOffice JWT enforcement (CRITICAL) =====
+    - name: "F1. Send unsigned request to OnlyOffice command endpoint"
+      ansible.builtin.shell: |
+        kubectl run curl-test-oo-jwt-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          sh -c '
+            RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -X POST http://{{ onlyoffice_service }}/coauthoring/CommandService.ashx \
+              -H "Content-Type: application/json" \
+              -d "{\"c\":\"version\"}")
+            echo "$RESPONSE"
+            if echo "$RESPONSE" | grep -q "HTTP_CODE:401\|HTTP_CODE:403\|\"error\":6\|\"error\":7\|token"; then
+              echo "JWT_ENFORCEMENT: PASSED"
+            else
+              echo "JWT_ENFORCEMENT: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: oo_jwt_test
+      failed_when: false
+      changed_when: false
+
+    - name: "F2. Verify unsigned request was rejected"
+      ansible.builtin.assert:
+        that:
+          - "'JWT_ENFORCEMENT: PASSED' in oo_jwt_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OnlyOffice accepted unsigned request! JWT enforcement is broken!
+          Expected an unsigned POST to /coauthoring/CommandService.ashx to be rejected.
+          Got: {{ oo_jwt_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check JWT_SECRET env: kubectl exec -n {{ nextcloud_namespace }} deploy/onlyoffice -- printenv JWT_SECRET
+          - Check JWT_ENABLED env: kubectl exec -n {{ nextcloud_namespace }} deploy/onlyoffice -- printenv JWT_ENABLED
+        success_msg: "✅ Test F PASSED: Unsigned request correctly rejected"
+
+    - name: "F3. Display JWT enforcement test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test F: OnlyOffice JWT Enforcement — PASSED (CRITICAL)
+          📋 Unsigned request to CommandService.ashx correctly rejected
+          🔒 JWT authentication is properly enforced
+
+    # ===== Test G: OnlyOffice editor endpoint (CRITICAL) =====
+    - name: "G1. Check OnlyOffice editor renders for .docx file"
+      ansible.builtin.shell: |
+        kubectl run curl-test-editor-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ nextcloud_namespace }} -- \
+          sh -c '
+            FILEID=$(curl -s -X PROPFIND \
+              -u "{{ admin_user }}:{{ admin_password }}" \
+              -H "Host: nextcloud.localhost" \
+              -H "Depth: 0" \
+              -d "<?xml version=\"1.0\"?><d:propfind xmlns:d=\"DAV:\" xmlns:oc=\"http://owncloud.org/ns\"><d:prop><oc:fileid/></d:prop></d:propfind>" \
+              http://{{ nextcloud_service }}/remote.php/dav/files/{{ admin_user }}/Documents/Welcome%20to%20Nextcloud%20Hub.docx \
+              | grep -o "<oc:fileid>[0-9]*</oc:fileid>" | grep -o "[0-9]*" | head -1)
+            if [ -z "$FILEID" ]; then
+              echo "FILEID: NOT_FOUND"
+              echo "EDITOR_ENDPOINT: FAILED"
+              exit 0
+            fi
+            echo "FILEID: $FILEID"
+            EDITOR_RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -u "{{ admin_user }}:{{ admin_password }}" \
+              -H "Host: nextcloud.localhost" \
+              http://{{ nextcloud_service }}/apps/onlyoffice/$FILEID)
+            HTTP_CODE=$(echo "$EDITOR_RESPONSE" | grep "HTTP_CODE:" | tail -1)
+            if echo "$HTTP_CODE" | grep -q "HTTP_CODE:200" && echo "$EDITOR_RESPONSE" | grep -q "iframeEditor"; then
+              echo "EDITOR_ENDPOINT: PASSED"
+            else
+              echo "EDITOR_HTTP: $HTTP_CODE"
+              echo "EDITOR_ENDPOINT: FAILED"
+            fi
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: editor_test
+      retries: 3
+      delay: 10
+      until: "'EDITOR_ENDPOINT: PASSED' in editor_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "G2. Verify OnlyOffice editor renders for .docx"
+      ansible.builtin.assert:
+        that:
+          - "'EDITOR_ENDPOINT: PASSED' in editor_test.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OnlyOffice editor endpoint did not render for .docx file!
+          File handlers may not be registered. This means .docx files will download
+          instead of opening in the OnlyOffice editor.
+          Got: {{ editor_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check OnlyOffice config: kubectl exec -n {{ nextcloud_namespace }} deploy/nextcloud -c nextcloud -- su -s /bin/bash www-data -c "php occ config:list onlyoffice"
+          - Re-run deploy to trigger settings save
+          - Manual fix: visit http://nextcloud.localhost/settings/admin/onlyoffice and click Save
+        success_msg: "✅ Test G PASSED: OnlyOffice editor renders for .docx files"
+
+    - name: "G3. Display editor endpoint test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test G: OnlyOffice Editor Endpoint — PASSED (CRITICAL)
+          📋 /apps/onlyoffice/{fileid} returns 200 with iframeEditor
+          📝 File handlers are registered — .docx opens in OnlyOffice
+
+    # ===== Test H: OnlyOffice config clean (CRITICAL) =====
+    - name: "H1. Check OnlyOffice config for settings_error"
+      ansible.builtin.shell: |
+        kubectl exec -n {{ nextcloud_namespace }} deploy/nextcloud -c nextcloud -- \
+          su -s /bin/bash www-data -c "php occ config:list onlyoffice"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: oo_config_check
+      changed_when: false
+
+    - name: "H2. Verify no settings_error in OnlyOffice config"
+      ansible.builtin.assert:
+        that:
+          - "'settings_error' not in oo_config_check.stdout"
+        fail_msg: |
+          ❌ CRITICAL: OnlyOffice config contains settings_error!
+          Config: {{ oo_config_check.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Clear error: kubectl exec -n {{ nextcloud_namespace }} deploy/nextcloud -c nextcloud -- su -s /bin/bash www-data -c "php occ config:app:delete onlyoffice settings_error"
+          - This may be a race condition in the deploy playbook — re-run deploy
+        success_msg: "✅ Test H PASSED: No settings_error in OnlyOffice config"
+
+    - name: "H3. Display config clean test success"
+      ansible.builtin.debug:
+        msg: |
+          ✅ Test H: OnlyOffice Config Clean — PASSED (CRITICAL)
+          📋 No settings_error present in OnlyOffice configuration
+
+    # ===== Summary =====
+    - name: "S1. Display comprehensive test results"
+      ansible.builtin.debug:
+        msg:
+          - "==============================================="
+          - "🧪 End-to-End Nextcloud + OnlyOffice Test Results"
+          - "==============================================="
+          - ""
+          - "Test A — Health Endpoint:                ✅ PASSED (CRITICAL)"
+          - "  /status.php reports installed:true"
+          - ""
+          - "Test B — Admin Login via WebDAV:         ✅ PASSED (CRITICAL)"
+          - "  GET /remote.php/dav returns 207 multistatus"
+          - ""
+          - "Test C — Wrong Credentials Rejected:     ✅ PASSED (CRITICAL)"
+          - "  Bad password correctly denied with HTTP 401"
+          - ""
+          - "Test D — UI Access via Traefik:          ✅ PASSED (CRITICAL)"
+          - "  nextcloud.localhost routes correctly"
+          - ""
+          - "Test E — OnlyOffice Health:              ✅ PASSED (CRITICAL)"
+          - "  /healthcheck returns true"
+          - ""
+          - "Test F — OnlyOffice JWT Enforcement:     ✅ PASSED (CRITICAL)"
+          - "  Unsigned request correctly rejected"
+          - ""
+          - "Test G — OnlyOffice Editor Endpoint:     ✅ PASSED (CRITICAL)"
+          - "  .docx opens in OnlyOffice editor (file handlers registered)"
+          - ""
+          - "Test H — OnlyOffice Config Clean:        ✅ PASSED (CRITICAL)"
+          - "  No settings_error in configuration"
+          - ""
+          - "==============================================="
+          - "🎉 ALL 8 CRITICAL TESTS PASSED"
+          - "==============================================="

--- a/manifests/620-nextcloud-config.yaml
+++ b/manifests/620-nextcloud-config.yaml
@@ -1,0 +1,99 @@
+# 620-nextcloud-config.yaml
+#
+# Description:
+# Helm values for Nextcloud deployment.
+# Disables bundled sub-charts and points to existing UIS PostgreSQL and Redis.
+#
+# Usage:
+#   Referenced by ansible/playbooks/620-setup-nextcloud.yml
+#
+# Dependencies:
+# - PostgreSQL must be running in default namespace (manifest 042)
+# - Redis must be running in default namespace (manifest 050)
+# - urbalurba-secrets must exist in nextcloud namespace
+
+# Disable bundled sub-charts — use existing UIS services
+internalDatabase:
+  enabled: false
+postgresql:
+  enabled: false
+mariadb:
+  enabled: false
+redis:
+  enabled: false
+
+# Point to existing PostgreSQL
+externalDatabase:
+  enabled: true
+  type: postgresql
+  host: postgresql.default.svc.cluster.local
+  database: nextcloud
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    usernameKey: NEXTCLOUD_DATABASE_USER
+    passwordKey: NEXTCLOUD_DATABASE_PASSWORD
+
+# Point to existing Redis
+externalRedis:
+  enabled: true
+  host: redis-master.default.svc.cluster.local
+  port: "6379"
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    passwordKey: REDIS_PASSWORD
+
+# Persistence — local-path storage class (UIS standard)
+persistence:
+  enabled: true
+  size: 10Gi
+  storageClass: local-path
+
+# Nextcloud configuration
+nextcloud:
+  host: nextcloud.localhost
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    usernameKey: NEXTCLOUD_ADMIN_USER
+    passwordKey: NEXTCLOUD_ADMIN_PASSWORD
+  trustedDomains:
+    - nextcloud.localhost
+    - "nextcloud.*"
+  # PHP tuning — default upload limit is 2MB, increase it
+  phpConfigs:
+    upload.ini: |
+      upload_max_filesize = 512M
+      post_max_size = 512M
+      memory_limit = 512M
+
+# Cron — sidecar runs /cron.sh alongside the main container
+cronjob:
+  enabled: true
+  type: sidecar
+
+# Service — override Helm chart default (8080) to use standard HTTP port
+# Required because OnlyOffice connector has a bug constructing callback URLs with non-standard ports
+service:
+  port: 80
+
+# Probes — generous startup for first boot (DB migrations, file copy, 1-5 min)
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3

--- a/manifests/621-nextcloud-ingressroute.yaml
+++ b/manifests/621-nextcloud-ingressroute.yaml
@@ -1,0 +1,44 @@
+# 621-nextcloud-ingressroute.yaml
+#
+# Description:
+# IngressRoute for Nextcloud collaboration platform.
+# Provides web access to file management, document editing, and admin UI.
+# Automatically handles both internal (.localhost) and external domains.
+#
+# HostRegexp Routing:
+# Uses HostRegexp('nextcloud\..+') to automatically handle:
+# - nextcloud.localhost (internal development access)
+# - Any future external domains (future-proof routing)
+#
+# Usage:
+#   kubectl apply -f 621-nextcloud-ingressroute.yaml
+#
+# Dependencies:
+# - Nextcloud Helm release must exist in nextcloud namespace
+#
+# Testing:
+#   curl http://nextcloud.localhost
+#
+# Service Port:
+# - Nextcloud Service port 80 (set via Helm values, container listens on 80)
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nextcloud
+  namespace: nextcloud
+  labels:
+    app: nextcloud
+    type: development
+    routing: unified
+    protection: public
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`nextcloud\..+`)
+      kind: Rule
+      services:
+        - name: nextcloud
+          port: 80

--- a/manifests/622-onlyoffice-config.yaml
+++ b/manifests/622-onlyoffice-config.yaml
@@ -1,0 +1,93 @@
+# 622-onlyoffice-config.yaml
+#
+# Description:
+# OnlyOffice Document Server deployment for Nextcloud document editing.
+# Community Edition (AGPL v3) — supports up to 20 simultaneous connections.
+# Provides browser-based editing for DOCX, XLSX, PPTX, and PDF files.
+#
+# Note: The image is ~1.5 GB. First pull takes several minutes.
+#
+# Usage:
+#   kubectl apply -f 622-onlyoffice-config.yaml
+#
+# Dependencies:
+# - nextcloud namespace must exist
+# - urbalurba-secrets must exist with ONLYOFFICE_JWT_SECRET key
+#
+# JWT Authentication:
+# OnlyOffice uses JWT to authenticate requests from Nextcloud.
+# The JWT_SECRET env var must match the jwt_secret configured in
+# Nextcloud's OnlyOffice app (set via occ in the setup playbook).
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onlyoffice
+  namespace: nextcloud
+  labels:
+    app: onlyoffice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: onlyoffice
+  template:
+    metadata:
+      labels:
+        app: onlyoffice
+    spec:
+      containers:
+        - name: onlyoffice
+          image: onlyoffice/documentserver:9.3.1
+          ports:
+            - containerPort: 80
+              name: http
+          env:
+            - name: JWT_ENABLED
+              value: "true"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: urbalurba-secrets
+                  key: ONLYOFFICE_JWT_SECRET
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onlyoffice-svc
+  namespace: nextcloud
+  labels:
+    app: onlyoffice
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: onlyoffice

--- a/manifests/623-onlyoffice-ingressroute.yaml
+++ b/manifests/623-onlyoffice-ingressroute.yaml
@@ -1,0 +1,42 @@
+# 623-onlyoffice-ingressroute.yaml
+#
+# Description:
+# IngressRoute for OnlyOffice Document Server.
+# Provides browser access to the document editing interface.
+# Nextcloud connects to OnlyOffice internally via K8s Service name,
+# but the browser needs direct access for the editor iframe.
+#
+# HostRegexp Routing:
+# Uses HostRegexp('onlyoffice\..+') to automatically handle:
+# - onlyoffice.localhost (internal development access)
+# - Any future external domains (future-proof routing)
+#
+# Usage:
+#   kubectl apply -f 623-onlyoffice-ingressroute.yaml
+#
+# Dependencies:
+# - OnlyOffice Deployment and Service must exist in nextcloud namespace
+#
+# Testing:
+#   curl http://onlyoffice.localhost/healthcheck
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: onlyoffice
+  namespace: nextcloud
+  labels:
+    app: onlyoffice
+    type: development
+    routing: unified
+    protection: public
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`onlyoffice\..+`)
+      kind: Rule
+      services:
+        - name: onlyoffice-svc
+          port: 80

--- a/provision-host/uis/lib/categories.sh
+++ b/provision-host/uis/lib/categories.sh
@@ -33,13 +33,14 @@ _CATEGORY_DATA=(
     "IDENTITY|Identity|Identity and access management|identity,auth,sso|shield"
     "DATABASES|Databases|Data storage and caching services|database,storage|database"
     "MANAGEMENT|Management|Admin tools, GitOps, and test services|admin,management|cog"
+    "APPLICATIONS|Applications|End-user applications and collaboration platforms|applications,collaboration|briefcase"
     "NETWORKING|Networking|VPN tunnels and network access|network,vpn|globe"
     "STORAGE|Storage|Platform storage infrastructure|storage,persistent|hard-drive"
     "INTEGRATION|Integration|Messaging, API gateways, and event streams|integration,messaging|inbox"
 )
 
 # Category display order (just the IDs)
-CATEGORY_ORDER=(OBSERVABILITY AI ANALYTICS IDENTITY DATABASES MANAGEMENT NETWORKING STORAGE INTEGRATION)
+CATEGORY_ORDER=(OBSERVABILITY AI ANALYTICS IDENTITY DATABASES MANAGEMENT APPLICATIONS NETWORKING STORAGE INTEGRATION)
 
 # Internal: Find category data by ID
 # Usage: _find_category_data "OBSERVABILITY"

--- a/provision-host/uis/lib/integration-testing.sh
+++ b/provision-host/uis/lib/integration-testing.sh
@@ -83,6 +83,7 @@ _build_skip_list() {
 VERIFY_SERVICES="
 argocd:argocd verify
 enonic:enonic verify
+nextcloud:nextcloud verify
 openmetadata:openmetadata verify
 "
 

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -1047,6 +1047,7 @@ cmd_verify() {
         echo "  cloudflare      Check Cloudflare secrets, network, and pod status"
         echo "  argocd          Run E2E health checks on ArgoCD server"
         echo "  enonic          Run E2E health checks on Enonic XP"
+        echo "  nextcloud       Run E2E health checks on Nextcloud + OnlyOffice"
         echo "  openmetadata    Run E2E health checks on OpenMetadata"
         exit "$EXIT_GENERAL_ERROR"
     fi
@@ -1064,6 +1065,9 @@ cmd_verify() {
         enonic)
             cmd_enonic_verify
             ;;
+        nextcloud)
+            cmd_nextcloud_verify
+            ;;
         openmetadata)
             cmd_openmetadata_verify
             ;;
@@ -1075,6 +1079,7 @@ cmd_verify() {
             echo "  cloudflare      Check Cloudflare secrets, network, and pod status"
             echo "  argocd          Run E2E health checks on ArgoCD server"
             echo "  enonic          Run E2E health checks on Enonic XP"
+            echo "  nextcloud       Run E2E health checks on Nextcloud + OnlyOffice"
             echo "  openmetadata    Run E2E health checks on OpenMetadata"
             exit "$EXIT_GENERAL_ERROR"
             ;;
@@ -1350,6 +1355,15 @@ cmd_argocd_verify() {
 cmd_enonic_verify() {
     print_section "Verifying Enonic XP Deployment"
     ansible-playbook "$ANSIBLE_DIR/085-test-enonic.yml"
+}
+
+# ============================================================
+# Nextcloud Commands
+# ============================================================
+
+cmd_nextcloud_verify() {
+    print_section "Verifying Nextcloud + OnlyOffice Deployment"
+    ansible-playbook "$ANSIBLE_DIR/620-test-nextcloud.yml"
 }
 
 # ============================================================
@@ -1629,6 +1643,22 @@ main() {
                     echo ""
                     echo "Commands:"
                     echo "  enonic verify    Run E2E health checks on Enonic XP"
+                    exit "$EXIT_GENERAL_ERROR"
+                    ;;
+            esac
+            ;;
+        nextcloud)
+            local subcmd="${1:-}"
+            shift 2>/dev/null || true
+            case "$subcmd" in
+                verify)
+                    cmd_nextcloud_verify
+                    ;;
+                *)
+                    log_error "Unknown nextcloud command: $subcmd"
+                    echo ""
+                    echo "Commands:"
+                    echo "  nextcloud verify    Run E2E health checks on Nextcloud + OnlyOffice"
                     exit "$EXIT_GENERAL_ERROR"
                     ;;
             esac

--- a/provision-host/uis/services/management/service-nextcloud.sh
+++ b/provision-host/uis/services/management/service-nextcloud.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# service-nextcloud.sh - Nextcloud service metadata
+#
+# Nextcloud is a self-hosted collaboration platform with file sync,
+# document editing (via OnlyOffice), calendar, contacts, and more.
+
+# === Service Metadata (Required) ===
+SCRIPT_ID="nextcloud"
+SCRIPT_NAME="Nextcloud"
+SCRIPT_DESCRIPTION="Self-hosted collaboration platform with file sync and document editing"
+SCRIPT_CATEGORY="APPLICATIONS"
+
+# === UIS-Specific (Optional) ===
+SCRIPT_PLAYBOOK="620-setup-nextcloud.yml"
+SCRIPT_MANIFEST=""
+SCRIPT_CHECK_COMMAND="kubectl get pods -n nextcloud -l app.kubernetes.io/name=nextcloud --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REMOVE_PLAYBOOK="620-remove-nextcloud.yml"
+SCRIPT_REQUIRES="postgresql redis"
+SCRIPT_PRIORITY="620"
+
+# === Deployment Details (Optional) ===
+SCRIPT_IMAGE="nextcloud:33-apache"
+SCRIPT_HELM_CHART="nextcloud/nextcloud"
+SCRIPT_NAMESPACE="nextcloud"
+
+# === Website Metadata (Optional) ===
+SCRIPT_ABSTRACT="Self-hosted collaboration platform — file sync, document editing, calendar, and contacts"
+SCRIPT_LOGO="nextcloud-logo.webp"
+SCRIPT_WEBSITE="https://nextcloud.com"
+SCRIPT_TAGS="collaboration,file-sync,document-editing,calendar,contacts,onlyoffice"
+SCRIPT_SUMMARY="Nextcloud is a self-hosted content collaboration platform providing file sync and sharing, browser-based document editing via OnlyOffice, calendar, contacts, and more. Deployed with the official Helm chart, reusing existing UIS PostgreSQL and Redis services."
+SCRIPT_DOCS="/docs/packages/applications/nextcloud"

--- a/provision-host/uis/templates/secrets-templates/00-common-values.env.template
+++ b/provision-host/uis/templates/secrets-templates/00-common-values.env.template
@@ -146,6 +146,15 @@ OPENMETADATA_DB_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
 ENONIC_ADMIN_PASSWORD=${DEFAULT_ADMIN_PASSWORD}
 
 # ================================================================
+# 🔧 OPTIONAL - NEXTCLOUD + ONLYOFFICE
+# ================================================================
+# Admin credentials for Nextcloud
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=NextcloudAdmin123
+# Shared JWT secret between OnlyOffice Document Server and Nextcloud
+ONLYOFFICE_JWT_SECRET=OnlyOfficeJwtSecret123
+
+# ================================================================
 # 🔧 OPTIONAL - APPLICATION-SPECIFIC
 # ================================================================
 # Add your own application variables here

--- a/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
+++ b/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
@@ -484,6 +484,43 @@ stringData:
   ENONIC_ADMIN_PASSWORD: "${ENONIC_ADMIN_PASSWORD}"
 
 # ================================================================
+# NEXTCLOUD NAMESPACE SECRETS
+# ================================================================
+---
+# Define the nextcloud namespace first
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud
+
+---
+# secrets for nextcloud namespace
+apiVersion: v1
+kind: Secret
+metadata:
+  name: urbalurba-secrets
+  namespace: nextcloud
+type: Opaque
+stringData:
+  # ================================================================
+  # NEXTCLOUD CONFIGURATION
+  # ================================================================
+
+  # Admin credentials
+  NEXTCLOUD_ADMIN_USER: "${NEXTCLOUD_ADMIN_USER}"
+  NEXTCLOUD_ADMIN_PASSWORD: "${NEXTCLOUD_ADMIN_PASSWORD}"
+
+  # Database credentials (reuses existing UIS PostgreSQL)
+  NEXTCLOUD_DATABASE_USER: "postgres"
+  NEXTCLOUD_DATABASE_PASSWORD: "${PGPASSWORD}"
+
+  # Redis password (reuses existing UIS Redis)
+  REDIS_PASSWORD: "${REDIS_PASSWORD}"
+
+  # OnlyOffice JWT shared secret
+  ONLYOFFICE_JWT_SECRET: "${ONLYOFFICE_JWT_SECRET}"
+
+# ================================================================
 # MONITORING NAMESPACE SECRETS
 # ================================================================
 ---

--- a/provision-host/uis/templates/uis.extend/enabled-services.conf.default
+++ b/provision-host/uis/templates/uis.extend/enabled-services.conf.default
@@ -19,3 +19,6 @@ nginx
 # === Databases ===
 # postgresql
 # redis
+
+# === Applications ===
+# nextcloud

--- a/website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-docs-markdown-update-logic.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-docs-markdown-update-logic.md
@@ -1,0 +1,138 @@
+# Investigate: Docs Markdown Generator Update Logic
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Add logic to `uis-docs-markdown.sh` to update metadata-driven sections of existing markdown pages without overwriting manually written content
+
+**Last Updated**: 2026-03-11
+
+**Related**:
+- [INVESTIGATE-service-version-metadata.md](INVESTIGATE-service-version-metadata.md) — Version field is also missing from generator
+- [PLAN-015-documentation-generation](../completed/PLAN-015-documentation-generation.md) — Original docs generator implementation
+
+---
+
+## Problem
+
+`uis-docs-markdown.sh` has two modes: **skip** existing files (default) or **overwrite** them entirely (`--force`). There is no update/merge mode.
+
+This means:
+1. After initial generation, metadata changes in service scripts (e.g. `SCRIPT_DESCRIPTION`, `SCRIPT_REQUIRES`, `SCRIPT_NAMESPACE`) are never reflected in existing docs pages
+2. Using `--force` destroys all manually written content (configuration tables, troubleshooting, secrets, key files)
+3. Hand-written pages like `nextcloud.md` and `openmetadata.md` are completely disconnected from service metadata
+
+### What should stay in sync with metadata
+
+These sections are generated from service script fields and should update automatically:
+
+| Section | Source fields |
+|---------|-------------|
+| Frontmatter (`title`, `sidebar_label`) | `SCRIPT_NAME` |
+| Description line under `# Name` | `SCRIPT_DESCRIPTION` |
+| Info table (Category, Deploy, Undeploy, Depends on, etc.) | `SCRIPT_CATEGORY`, `SCRIPT_ID`, `SCRIPT_REQUIRES`, `SCRIPT_HELM_CHART`, `SCRIPT_NAMESPACE` |
+| "What It Does" paragraph | `SCRIPT_SUMMARY` |
+| Deploy code block (prerequisites) | `SCRIPT_REQUIRES` |
+| Verify code block (check command) | `SCRIPT_CHECK_COMMAND` |
+| Learn More link | `SCRIPT_WEBSITE` |
+
+### What should NOT be overwritten
+
+These sections contain manually written content that varies per service:
+
+- Configuration tables and details
+- Secrets tables
+- Key Files tables
+- Troubleshooting sections
+- Access URLs
+- Service-specific notes (e.g. OnlyOffice integration, admin credentials)
+- Any custom sections added by contributors
+
+---
+
+## Questions to Answer
+
+1. What marker/delimiter strategy should separate auto-generated from manual sections?
+2. Should the script update in-place or generate to a temp file for diff review?
+3. How do we handle pages that were written entirely by hand (no markers)?
+4. Should there be a `--update` mode alongside `--force` and default skip?
+5. Is it acceptable to require a one-time migration to add markers to existing pages?
+
+---
+
+## Options
+
+### Option A: Marker comments in markdown
+
+Add HTML comments as markers around auto-generated sections:
+
+```markdown
+<!-- AUTO:INFO_TABLE -->
+| | |
+|---|---|
+| **Category** | Management |
+...
+<!-- /AUTO:INFO_TABLE -->
+
+## Configuration
+
+(manual content here — never touched by generator)
+```
+
+The generator replaces content between matching `AUTO:` markers and leaves everything else untouched.
+
+**Pros:**
+- Clear, explicit boundaries
+- HTML comments are invisible in rendered docs
+- Easy to parse with sed/awk
+
+**Cons:**
+- Requires one-time migration to add markers to all existing pages
+- Contributors must not delete markers
+- Adds visual noise to raw markdown
+
+### Option B: Section-based replacement
+
+The generator identifies sections by heading (`## What It Does`, `## Deploy`, etc.) and replaces only the content of known auto-generated sections.
+
+**Pros:**
+- No markers needed
+- Works with existing pages immediately
+
+**Cons:**
+- Fragile — relies on exact heading text
+- Hard to distinguish auto-generated content from manual additions within a section
+- Risk of overwriting manual content added under a "known" heading
+
+### Option C: Frontmatter-only updates
+
+Only update the YAML frontmatter and the info table. Leave all other sections untouched.
+
+**Pros:**
+- Minimal risk of overwriting manual content
+- Simple to implement (just replace lines 1-N before first `## ` heading)
+
+**Cons:**
+- Doesn't update "What It Does", deploy prerequisites, or verify commands
+- Partial solution
+
+---
+
+## Current State
+
+- 27 service scripts exist in `provision-host/uis/services/`
+- 27 corresponding `.md` pages exist in `website/docs/packages/`
+- Some pages are auto-generated scaffolds (placeholder text), others are hand-written with full content
+- Hand-written pages: `nextcloud.md`, `openmetadata.md`, `argocd.md`, `authentik.md`, `elasticsearch.md` (at minimum)
+- No markers or conventions currently distinguish auto-generated from manual content
+
+---
+
+## Next Steps
+
+- [ ] Decide on an approach
+- [ ] Create PLAN to implement the chosen approach
+- [ ] Migrate existing pages if markers are needed

--- a/website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md
@@ -34,7 +34,7 @@ New platform services. Enonic and OpenMetadata have dependencies on Priority 1 i
 | 4 | [Enonic XP deployment](../completed/INVESTIGATE-enonic-xp-deployment.md) | Complete | — | CMS platform. Plain Docker/StatefulSet, manifest 085. Reuses cluster storage. Deployed and verified (6 E2E tests pass). |
 | 5 | [Enonic app deployment pipeline](INVESTIGATE-enonic-app-deployment-pipeline.md) | Investigation complete | Enonic XP (#4) | Sidecar pulls JARs from GitHub Releases into `$XP_HOME/deploy`. UIS CLI commands. |
 | 6 | [OpenMetadata deployment](../completed/INVESTIGATE-openmetadata-deployment.md) | Complete | ES upgrade (#1) ✅ | Data governance platform v1.12.1, manifest 340. Reuses PostgreSQL + Elasticsearch 9.3.0. K8s native orchestrator (no Airflow). Deployed and verified (6 E2E tests pass). |
-| 7 | [Nextcloud + OnlyOffice](INVESTIGATE-nextcloud-deployment.md) | Ready for PLAN | — | Collaboration platform, manifest 620. Reuses PostgreSQL + Redis. OnlyOffice for document editing. |
+| 7 | [Nextcloud + OnlyOffice](../completed/INVESTIGATE-nextcloud-deployment.md) | Complete | — | Collaboration platform, manifest 620. Reuses PostgreSQL + Redis. OnlyOffice for document editing. Deployed and verified (8 E2E tests pass). |
 | 8 | [Enonic content deployment](INVESTIGATE-enonic-content-deployment.md) | Backlog | Enonic XP (#4) | Content migration between environments. Manual workflow works initially — automate later. |
 
 ---
@@ -46,6 +46,7 @@ Feature improvements that are not blocking anything.
 | # | Investigation | Status | Summary |
 |---|--------------|--------|---------|
 | 9 | [Authentik user config](INVESTIGATE-authentik-user-config.md) | Investigation complete | Move user-configurable Authentik data from `manifests/` to `.uis.extend/`. |
+| 12 | [Docs markdown update logic](INVESTIGATE-docs-markdown-update-logic.md) | Backlog | `uis-docs-markdown.sh` can only skip or overwrite pages — no merge/update mode. Metadata changes in service scripts are never reflected in existing docs pages. |
 
 ---
 
@@ -73,6 +74,7 @@ Investigations where the work has been implemented. The INVESTIGATE files have b
 | Elasticsearch upgrade | 2026-03-09 | [PLAN-elasticsearch-upgrade](../completed/PLAN-elasticsearch-upgrade.md) |
 | OpenMetadata deployment | 2026-03-10 | [PLAN-openmetadata-deployment](../completed/PLAN-openmetadata-deployment.md) |
 | Enonic XP deployment | 2026-03-10 | [PLAN-enonic-xp-deployment](../completed/PLAN-enonic-xp-deployment.md) |
+| Nextcloud + OnlyOffice deployment | 2026-03-11 | [PLAN-nextcloud-deployment](../completed/PLAN-nextcloud-deployment.md) |
 
 ---
 

--- a/website/docs/ai-development/ai-developer/plans/completed/INVESTIGATE-nextcloud-deployment.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/INVESTIGATE-nextcloud-deployment.md
@@ -4,22 +4,30 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Backlog
+## Status: Complete
 
 **Goal**: Determine the best approach for deploying Nextcloud as a UIS platform service
 
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-03-10
 
 ---
 
 ## Questions to Answer
 
-1. What is Nextcloud and what does it provide?
-2. Which existing UIS services can Nextcloud reuse?
-3. What category and manifest number should it use?
-4. What are the resource requirements — is it feasible on a developer laptop?
-5. Should we use the Helm chart or custom manifests?
-6. What does the initial setup look like (skip Authentik, keep it simple)?
+1. What is Nextcloud and what does it provide? ✅
+2. Which existing UIS services can Nextcloud reuse? ✅
+3. What category and manifest number should it use? ✅
+4. What are the resource requirements — is it feasible on a developer laptop? ✅
+5. Should we use the Helm chart or custom manifests? ✅
+6. What does the initial setup look like (skip Authentik, keep it simple)? ✅
+7. What are the exact Helm chart values for external Redis with auth? ✅
+8. How does OnlyOffice JWT authentication work? ✅
+9. Can OnlyOffice integration be fully automated (no manual UI steps)? ✅
+10. What is the health endpoint for verify tests? ✅
+11. What are the pinned versions (image, chart, OnlyOffice)? ✅
+12. How should cron jobs run in Kubernetes? ✅
+13. What PHP tuning is needed? ✅
+14. How long does first boot take? ✅
 
 ---
 
@@ -53,8 +61,8 @@ Used by tens of millions of users, popular for organizations needing data sovere
 
 ### Docker Image
 
-- **Image**: `nextcloud` on Docker Hub (official, maintained by Nextcloud project)
-- **Recommended variant**: `nextcloud:<version>-apache` — bundles Apache, simplest to deploy
+- **Image**: `nextcloud:33-apache` (Nextcloud 33.0.0, updated 2026-03-03)
+- **Variant**: `-apache` bundles Apache, simplest to deploy
 - **Port**: 80
 - **Key environment variables**:
   - `NEXTCLOUD_ADMIN_USER` / `NEXTCLOUD_ADMIN_PASSWORD` — initial admin account
@@ -70,6 +78,7 @@ Community-maintained chart under the Nextcloud GitHub organization:
 - **Repository**: https://github.com/nextcloud/helm
 - **Chart repo URL**: `https://nextcloud.github.io/helm/`
 - **Helm repo add**: `helm repo add nextcloud https://nextcloud.github.io/helm/`
+- **Chart version**: `9.0.3` (released 2026-03-09, targets Nextcloud 33)
 - **Requires**: Helm 3.7.0+
 
 The chart includes Bitnami sub-charts for PostgreSQL, MariaDB, and Redis — all can be **disabled** to use existing UIS services instead.
@@ -122,13 +131,15 @@ Create a `nextcloud` database on the existing PostgreSQL instance. The setup pla
 
 ### Redis reuse
 
-Nextcloud connects to the existing Redis via `REDIS_HOST` and `REDIS_HOST_PASSWORD` environment variables. Redis is already shared by other services.
+Nextcloud connects to the existing Redis via the Helm chart's `externalRedis` section. The UIS Redis host is `redis-master.default.svc.cluster.local` (Bitnami naming). The Redis password is in the `default` namespace secrets as `REDIS_PASSWORD`.
+
+The Helm chart handles Redis config automatically via `defaultConfigs.redis.config.php: true` — no need for manual PHP config.
 
 ---
 
 ## Deployment Approach
 
-### Recommendation: Official Helm chart
+### Recommendation: Official Helm chart (v9.0.3)
 
 Use the `nextcloud/nextcloud` Helm chart with sub-charts disabled, pointing to existing UIS services:
 
@@ -149,20 +160,87 @@ externalDatabase:
   type: postgresql
   host: postgresql.default.svc.cluster.local
   database: nextcloud
-  # user and password via secretKeyRef — see Secrets Integration section
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    usernameKey: NEXTCLOUD_DATABASE_USER
+    passwordKey: NEXTCLOUD_DATABASE_PASSWORD
 
 # Point to existing Redis
-# Configured via environment variables in the pod spec
+externalRedis:
+  enabled: true
+  host: redis-master.default.svc.cluster.local
+  port: "6379"
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    passwordKey: REDIS_PASSWORD
 
-# Persistence
+# Persistence — local-path storage class (UIS standard)
 persistence:
   enabled: true
   size: 10Gi
+  storageClass: local-path
 
-# Initial admin account — from secrets
+# Nextcloud configuration
 nextcloud:
   host: nextcloud.localhost
+  trustedDomains:
+    - nextcloud.localhost
+    - nextcloud.tailnet-name.ts.net
+  # PHP tuning — default upload limit is 2MB, increase it
+  phpConfigs:
+    upload.ini: |
+      upload_max_filesize = 512M
+      post_max_size = 512M
+      memory_limit = 512M
+
+# Cron — sidecar is simplest, runs /cron.sh alongside the main container
+cronjob:
+  enabled: true
+  type: sidecar
+
+# Startup probe — first boot can take 3-5 minutes (DB migrations, file copy)
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 ```
+
+### Health endpoint
+
+Nextcloud exposes `/status.php` which returns JSON:
+
+```json
+{
+  "installed": true,
+  "maintenance": false,
+  "needsDbUpgrade": false,
+  "version": "33.0.0.7",
+  "versionstring": "33.0.0",
+  "productname": "Nextcloud"
+}
+```
+
+The Helm chart probes use this endpoint automatically. The `Host: localhost` header is required in probes to avoid trusted domain rejection.
+
+### First boot timing
+
+First boot takes **30 seconds to 5+ minutes** depending on storage speed. The bottleneck is copying Nextcloud files to the PVC and running database schema creation. With `local-path` storage (UIS default), expect ~1-2 minutes. The `startupProbe` with `failureThreshold: 30` allows up to 5 minutes before Kubernetes gives up.
 
 ---
 
@@ -207,10 +285,11 @@ Following the UIS secrets pattern (same as Unity Catalog, OpenMetadata):
 **1. Variables in `00-common-values.env.template`:**
 
 ```bash
-# Nextcloud
+# Nextcloud + OnlyOffice
 NEXTCLOUD_ADMIN_USER=admin
 NEXTCLOUD_ADMIN_PASSWORD=NextcloudAdmin123
 NEXTCLOUD_DB_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
+ONLYOFFICE_JWT_SECRET=OnlyOfficeJwtSecret123
 ```
 
 **2. Secret block in `00-master-secrets.yml.template`:**
@@ -231,12 +310,13 @@ type: Opaque
 stringData:
   NEXTCLOUD_ADMIN_USER: "${NEXTCLOUD_ADMIN_USER}"
   NEXTCLOUD_ADMIN_PASSWORD: "${NEXTCLOUD_ADMIN_PASSWORD}"
-  NEXTCLOUD_DATABASE_URL: "postgresql://postgres:${PGPASSWORD}@${PGHOST}:5432/nextcloud"
   NEXTCLOUD_DATABASE_USER: "postgres"
   NEXTCLOUD_DATABASE_PASSWORD: "${PGPASSWORD}"
+  REDIS_PASSWORD: "${REDIS_PASSWORD}"
+  ONLYOFFICE_JWT_SECRET: "${ONLYOFFICE_JWT_SECRET}"
 ```
 
-**3. Setup playbook** retrieves credentials from secrets, creates the database on PostgreSQL, passes credentials to Helm via `secretKeyRef`.
+**3. Setup playbook** retrieves credentials from secrets, creates the database on PostgreSQL, passes credentials to Helm via `existingSecret`. The OnlyOffice JWT secret must be passed to both the OnlyOffice container (`JWT_SECRET` env var) and to Nextcloud's OnlyOffice app config (`occ config:app:set onlyoffice jwt_secret`).
 
 ### Password restrictions
 
@@ -253,9 +333,12 @@ SCRIPT_REQUIRES="postgresql redis"
 The setup playbook should:
 1. Verify PostgreSQL and Redis are running
 2. Create the `nextcloud` database on the existing PostgreSQL
-3. Deploy the Nextcloud Helm chart
-4. Deploy the IngressRoute
-5. Wait for the server to be ready
+3. Deploy the Nextcloud Helm chart (with external DB + Redis)
+4. Deploy the OnlyOffice Document Server (separate Deployment/StatefulSet)
+5. Deploy IngressRoutes for both Nextcloud and OnlyOffice
+6. Wait for Nextcloud to be ready (`/status.php` returns `installed: true`)
+7. Install and configure the OnlyOffice connector via `occ` CLI (automated, no manual UI)
+8. Display deployment summary
 
 ---
 
@@ -263,11 +346,14 @@ The setup playbook should:
 
 | Piece | File |
 |-------|------|
-| Service definition | `provision-host/uis/services/management/service-nextcloud.sh` (must include website metadata — `uis-docs.sh` generates JSON from these for the docs website) |
+| Service definition | `provision-host/uis/services/management/service-nextcloud.sh` (must include `SCRIPT_IMAGE="nextcloud:33-apache"` and website metadata) |
 | Setup playbook | `ansible/playbooks/620-setup-nextcloud.yml` |
 | Remove playbook | `ansible/playbooks/620-remove-nextcloud.yml` |
+| Verify playbook | `ansible/playbooks/620-test-nextcloud.yml` |
 | Config / Helm values | `manifests/620-nextcloud-config.yaml` |
-| IngressRoute | `manifests/621-nextcloud-ingressroute.yaml` |
+| IngressRoute (Nextcloud) | `manifests/621-nextcloud-ingressroute.yaml` |
+| OnlyOffice config | `manifests/622-onlyoffice-config.yaml` |
+| IngressRoute (OnlyOffice) | `manifests/623-onlyoffice-ingressroute.yaml` |
 | Secrets variables | Add to `provision-host/uis/templates/secrets-templates/00-common-values.env.template` |
 | Secrets manifest | Add `nextcloud` namespace block to `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` |
 | Documentation | `website/docs/packages/management/nextcloud.md` |
@@ -304,12 +390,46 @@ OnlyOffice has two editions:
 
 ### OnlyOffice details
 
-- **Docker image**: `onlyoffice/documentserver` (Community Edition)
-- **Port**: 80 (HTTP), 443 (HTTPS)
+- **Docker image**: `onlyoffice/documentserver:9.3.1` (Community Edition, ~1.5 GB, updated 2026-03-05)
+- **Port**: 80 (HTTP)
 - **Resource requirements**: ~2-4 GiB RAM (heavier than Collabora)
 - **No database needed** — OnlyOffice Document Server is stateless, it processes documents sent by Nextcloud
-- **Helm chart**: `onlyoffice/docs` — official chart at https://github.com/ONLYOFFICE/Kubernetes-Docs
-- **Integration**: Nextcloud connects to OnlyOffice via the "ONLYOFFICE" app (install from Nextcloud App Store), configured with the OnlyOffice server URL
+- **Deployment**: Simple Kubernetes Deployment + Service (no Helm chart needed for a single container)
+
+### OnlyOffice JWT authentication
+
+OnlyOffice uses JWT to authenticate requests from Nextcloud. Since v7.2, JWT is **enabled by default** and a random secret is generated if not set explicitly — this breaks on every restart.
+
+**Must set explicitly:**
+- `JWT_SECRET` environment variable on the OnlyOffice container
+- `jwt_secret` config key in Nextcloud's OnlyOffice app (via `occ`)
+
+Both values must match.
+
+### OnlyOffice integration — fully automated via occ CLI
+
+No manual web UI steps required. The setup playbook automates everything:
+
+```bash
+# 1. Install the OnlyOffice connector app
+kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c "php occ app:install onlyoffice"
+
+# 2. Set the Document Server URL (internal cluster address)
+kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice DocumentServerUrl --value='http://onlyoffice.localhost'"
+
+# 3. Set internal server-to-server URL (bypasses ingress)
+kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice DocumentServerInternalUrl --value='http://onlyoffice-svc.nextcloud.svc.cluster.local:80'"
+
+# 4. Set the storage URL (how OnlyOffice calls back to Nextcloud)
+kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice StorageUrl --value='http://nextcloud.nextcloud.svc.cluster.local:80'"
+
+# 5. Set the shared JWT secret (must match OnlyOffice container's JWT_SECRET)
+kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice jwt_secret --value='<secret-from-k8s-secret>'"
+```
 
 ### OnlyOffice ingress
 
@@ -336,15 +456,34 @@ OnlyOffice is deployed as part of the Nextcloud setup playbook (`620-setup-nextc
 
 ---
 
+## Verify Playbook Plan
+
+The verify playbook (`620-test-nextcloud.yml`) should test these scenarios:
+
+| Test | What it checks |
+|------|---------------|
+| A. Health endpoint | `GET /status.php` returns `installed: true` and `maintenance: false` |
+| B. Admin login | Login with admin credentials returns 200 (not redirect to setup) |
+| C. Wrong credentials | Login with bad password returns 401 |
+| D. Traefik routing | `http://nextcloud.localhost` resolves to Nextcloud |
+| E. OnlyOffice health | OnlyOffice healthcheck endpoint returns 200 |
+| F. OnlyOffice JWT | OnlyOffice rejects unsigned requests (JWT enforcement) |
+
+Register in `integration-testing.sh` (VERIFY_SERVICES) and `uis-cli.sh` (cmd_verify).
+
+---
+
 ## What we skip for initial setup
 
 - **Authentik SSO** — use Nextcloud's built-in admin account. Add OIDC later.
 - **TURN/STUN server** — only needed for Talk video calls behind NAT.
 - **SMTP** — email notifications. Not needed for local dev.
+- **enabled-services.conf** — add commented-out entry during implementation.
+- **Stack membership** — consider a "collaboration" stack if more tools are added later.
 
 ---
 
 ## Next Steps
 
-- [ ] Verify Nextcloud Helm chart works with external PostgreSQL and Redis
-- [ ] Create PLAN-nextcloud-deployment.md with implementation phases
+- [x] Create PLAN-nextcloud-deployment.md with implementation phases ✓
+- [x] Implement and deploy Nextcloud + OnlyOffice (8 E2E tests pass) ✓

--- a/website/docs/ai-development/ai-developer/plans/completed/PLAN-nextcloud-deployment.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/PLAN-nextcloud-deployment.md
@@ -1,0 +1,424 @@
+# Deploy Nextcloud + OnlyOffice
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Complete
+
+**Goal**: Deploy Nextcloud 33 with OnlyOffice Document Server as a UIS platform service, reusing existing PostgreSQL and Redis
+
+**Last Updated**: 2026-03-10
+
+**Investigation**: [INVESTIGATE-nextcloud-deployment.md](../completed/INVESTIGATE-nextcloud-deployment.md)
+
+---
+
+## Overview
+
+Nextcloud is a self-hosted collaboration platform (file sync, document editing, calendar, contacts). It will be deployed as manifest 620 in the MANAGEMENT category using the official Helm chart (v9.0.3). OnlyOffice Document Server provides browser-based document editing (DOCX, XLSX, PPTX) and is deployed as a separate Deployment in the same namespace.
+
+Key decisions from investigation:
+- **Nextcloud image**: `nextcloud:33-apache` (Nextcloud 33.0.0, pinned)
+- **OnlyOffice image**: `onlyoffice/documentserver:9.3.1` (~1.5 GB, pinned)
+- **Helm chart**: `nextcloud/nextcloud` v9.0.3
+- **Pattern**: Helm for Nextcloud, plain Deployment for OnlyOffice
+- **Category**: MANAGEMENT, manifest **620**
+- **Namespace**: `nextcloud`
+- **Dependencies**: Reuses existing PostgreSQL (manifest 042) and Redis (manifest 050) — no new backing services
+- **Redis host**: `redis-master.default.svc.cluster.local` (Bitnami naming)
+- **Admin**: `admin` / password from `NEXTCLOUD_ADMIN_PASSWORD` secret
+- **OnlyOffice JWT**: Shared secret (`ONLYOFFICE_JWT_SECRET`) must match between containers
+- **OnlyOffice integration**: Fully automated via `occ` CLI — no manual UI steps
+- **Cron**: Sidecar container running `/cron.sh`
+- **Health endpoint**: `GET /status.php` returns JSON with `installed`, `maintenance`, `needsDbUpgrade`
+- **First boot**: 1–5 minutes (DB migrations, file copy). Startup probe allows 5 minutes.
+- **PHP tuning**: Upload limit increased to 512M (default is 2MB)
+
+---
+
+## Phase 1: Service Definition and Configuration Files — ✅ DONE
+
+Create all static files needed before deployment.
+
+### Tasks
+
+- [x] 1.1 Create service definition `provision-host/uis/services/management/service-nextcloud.sh` ✓
+- [x] 1.2 Create Helm values `manifests/620-nextcloud-config.yaml` ✓
+- [x] 1.3 Create Nextcloud IngressRoute `manifests/621-nextcloud-ingressroute.yaml` ✓
+- [x] 1.4 Create OnlyOffice config `manifests/622-onlyoffice-config.yaml` (Deployment + Service) ✓
+- [x] 1.5 Create OnlyOffice IngressRoute `manifests/623-onlyoffice-ingressroute.yaml` ✓
+- [x] 1.6 Add Nextcloud + OnlyOffice secrets to `provision-host/uis/templates/secrets-templates/00-common-values.env.template` ✓
+- [x] 1.7 Add `nextcloud` namespace block to `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` ✓
+
+### Implementation Details
+
+**1.1 Service definition** — follow the OpenMetadata pattern (`service-openmetadata.sh`):
+```bash
+SCRIPT_ID="nextcloud"
+SCRIPT_NAME="Nextcloud"
+SCRIPT_DESCRIPTION="Self-hosted collaboration platform with file sync and document editing"
+SCRIPT_CATEGORY="MANAGEMENT"
+SCRIPT_PLAYBOOK="620-setup-nextcloud.yml"
+SCRIPT_REMOVE_PLAYBOOK="620-remove-nextcloud.yml"
+SCRIPT_CHECK_COMMAND="kubectl get pods -n nextcloud -l app.kubernetes.io/name=nextcloud --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REQUIRES="postgresql redis"
+SCRIPT_PRIORITY="620"
+SCRIPT_IMAGE="nextcloud:33-apache"
+SCRIPT_HELM_CHART="nextcloud/nextcloud"
+SCRIPT_NAMESPACE="nextcloud"
+# Website metadata fields (SCRIPT_ABSTRACT, SCRIPT_LOGO, SCRIPT_WEBSITE, SCRIPT_TAGS, SCRIPT_SUMMARY, SCRIPT_DOCS)
+```
+
+**1.2 Helm values** — `620-nextcloud-config.yaml`:
+```yaml
+# Disable bundled sub-charts — use existing UIS services
+internalDatabase:
+  enabled: false
+postgresql:
+  enabled: false
+mariadb:
+  enabled: false
+redis:
+  enabled: false
+
+# Point to existing PostgreSQL
+externalDatabase:
+  enabled: true
+  type: postgresql
+  host: postgresql.default.svc.cluster.local
+  database: nextcloud
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    usernameKey: NEXTCLOUD_DATABASE_USER
+    passwordKey: NEXTCLOUD_DATABASE_PASSWORD
+
+# Point to existing Redis
+externalRedis:
+  enabled: true
+  host: redis-master.default.svc.cluster.local
+  port: "6379"
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    passwordKey: REDIS_PASSWORD
+
+# Persistence
+persistence:
+  enabled: true
+  size: 10Gi
+  storageClass: local-path
+
+# Nextcloud configuration
+nextcloud:
+  host: nextcloud.localhost
+  existingSecret:
+    enabled: true
+    secretName: urbalurba-secrets
+    usernameKey: NEXTCLOUD_ADMIN_USER
+    passwordKey: NEXTCLOUD_ADMIN_PASSWORD
+  trustedDomains:
+    - nextcloud.localhost
+  phpConfigs:
+    upload.ini: |
+      upload_max_filesize = 512M
+      post_max_size = 512M
+      memory_limit = 512M
+
+# Cron — sidecar is simplest
+cronjob:
+  enabled: true
+  type: sidecar
+
+# Probes — generous startup for first boot (DB migrations, file copy)
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+```
+
+**1.3 Nextcloud IngressRoute** — standard UIS pattern:
+- `HostRegexp('nextcloud\..+')` routing to port 80
+- Namespace: `nextcloud`
+- Label: `protection: public`
+
+**1.4 OnlyOffice config** — plain Kubernetes Deployment + Service in namespace `nextcloud`:
+- Image: `onlyoffice/documentserver:9.3.1` (~1.5 GB — first pull takes several minutes)
+- Service name: `onlyoffice-svc` (referenced by occ commands in setup playbook)
+- Port: 80
+- Env: `JWT_ENABLED=true`, `JWT_SECRET` from secret `urbalurba-secrets` key `ONLYOFFICE_JWT_SECRET`
+- Resource requests: 500m CPU, 2Gi memory
+- Readiness probe: `GET /healthcheck` on port 80 (OnlyOffice takes 30-60s to initialize)
+- No PVC needed (stateless)
+
+**1.5 OnlyOffice IngressRoute** — standard UIS pattern:
+- `HostRegexp('onlyoffice\..+')` routing to port 80
+- Namespace: `nextcloud`
+- Label: `protection: public`
+
+**1.6 Secrets template** — add to the OPTIONAL section in `00-common-values.env.template`:
+```bash
+# Nextcloud + OnlyOffice
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=NextcloudAdmin123
+ONLYOFFICE_JWT_SECRET=OnlyOfficeJwtSecret123
+```
+
+**1.7 Master secrets** — add namespace block in `00-master-secrets.yml.template`:
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: urbalurba-secrets
+  namespace: nextcloud
+type: Opaque
+stringData:
+  NEXTCLOUD_ADMIN_USER: "${NEXTCLOUD_ADMIN_USER}"
+  NEXTCLOUD_ADMIN_PASSWORD: "${NEXTCLOUD_ADMIN_PASSWORD}"
+  NEXTCLOUD_DATABASE_USER: "postgres"
+  NEXTCLOUD_DATABASE_PASSWORD: "${PGPASSWORD}"
+  REDIS_PASSWORD: "${REDIS_PASSWORD}"
+  ONLYOFFICE_JWT_SECRET: "${ONLYOFFICE_JWT_SECRET}"
+```
+
+### Validation
+
+User reviews the created files for correctness.
+
+---
+
+## Phase 2: Ansible Playbooks — ✅ DONE
+
+Create the setup, remove, and verify playbooks.
+
+### Tasks
+
+- [x] 2.1 Create setup playbook `ansible/playbooks/620-setup-nextcloud.yml` ✓
+- [x] 2.2 Create remove playbook `ansible/playbooks/620-remove-nextcloud.yml` ✓
+- [x] 2.3 Create verify playbook `ansible/playbooks/620-test-nextcloud.yml` ✓
+- [x] 2.4 Register `nextcloud` in `VERIFY_SERVICES` in `provision-host/uis/lib/integration-testing.sh` ✓
+- [x] 2.5 Add `nextcloud` verify command to `provision-host/uis/manage/uis-cli.sh` ✓
+
+### Implementation Details
+
+**2.1 Setup playbook** — follow OpenMetadata pattern (`340-setup-openmetadata.yml`):
+
+Key vars:
+```yaml
+helm_release_name: "nextcloud"       # Determines K8s Service name
+helm_chart: "nextcloud/nextcloud"
+helm_chart_version: "9.0.3"
+```
+
+Steps:
+1. **Prerequisites**: Create namespace, check secrets exist, verify PostgreSQL and Redis are running
+2. **Database**: Create `nextcloud` database on existing PostgreSQL (same pattern as OpenMetadata)
+3. **Helm repo**: Add `nextcloud` repo (`https://nextcloud.github.io/helm/`) via `kubernetes.core.helm_repository`
+4. **Helm install**: Install chart with `--version 9.0.3` and values from `620-nextcloud-config.yaml`
+5. **Nextcloud IngressRoute**: Apply `621-nextcloud-ingressroute.yaml`
+6. **Wait for Nextcloud**: Wait for pod ready (startup probe handles first boot — up to 5 minutes)
+7. **Deploy OnlyOffice**: Apply `622-onlyoffice-config.yaml` (Deployment + Service). Note: image is ~1.5 GB, first pull takes several minutes
+8. **OnlyOffice IngressRoute**: Apply `623-onlyoffice-ingressroute.yaml`
+9. **Wait for OnlyOffice**: Wait for OnlyOffice pod ready (readiness probe on `/healthcheck`, ~30-60s)
+10. **Configure OnlyOffice integration** via `occ` CLI (requires internet — Nextcloud downloads the connector app from the App Store):
+    ```bash
+    # Install the OnlyOffice connector app (downloads from Nextcloud App Store — needs internet)
+    kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c "php occ app:install onlyoffice"
+    # Set Document Server URL (public, for browser access)
+    kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+      "php occ config:app:set onlyoffice DocumentServerUrl --value='http://onlyoffice.localhost'"
+    # Set internal server-to-server URL (bypasses ingress, uses K8s Service name from 622-onlyoffice-config.yaml)
+    kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+      "php occ config:app:set onlyoffice DocumentServerInternalUrl --value='http://onlyoffice-svc.nextcloud.svc.cluster.local:80'"
+    # Set storage URL (how OnlyOffice calls back to Nextcloud, uses Helm release name as Service name)
+    kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+      "php occ config:app:set onlyoffice StorageUrl --value='http://nextcloud.nextcloud.svc.cluster.local:80'"
+    # Set shared JWT secret (must match JWT_SECRET env var on OnlyOffice container)
+    kubectl exec <nextcloud-pod> -- su -s /bin/bash www-data -c \
+      "php occ config:app:set onlyoffice jwt_secret --value='<secret-from-k8s-secret>'"
+    ```
+    **Important:** The Nextcloud Service name (`nextcloud`) comes from `helm_release_name`. The OnlyOffice Service name (`onlyoffice-svc`) is defined in `622-onlyoffice-config.yaml`. Both must match the URLs above.
+11. **Status**: Display deployment summary with URLs
+
+**2.2 Remove playbook** — follow OpenMetadata pattern (`300-remove-openmetadata.yml`):
+1. Remove OnlyOffice IngressRoute
+2. Delete OnlyOffice Deployment + Service
+3. Remove Nextcloud Helm release
+4. Remove Nextcloud IngressRoute
+5. Delete PVCs (opt-in via `remove_pvc` flag)
+6. Drop `nextcloud` database from PostgreSQL (opt-in via `remove_database` flag)
+7. Delete namespace
+
+**2.3 Verify playbook** (`620-test-nextcloud.yml`) — 6 tests:
+
+| Test | What | How |
+|------|------|-----|
+| **A. Health endpoint** | Nextcloud is installed and running | `GET /status.php` → JSON contains `"installed":true` and `"maintenance":false` |
+| **B. Admin login via WebDAV** | Admin credentials work | `GET /remote.php/dav` with basic auth (admin + correct password) → HTTP 200 with multistatus XML |
+| **C. Wrong credentials** | Bad password rejected | `GET /remote.php/dav` with basic auth (admin + wrong password) → HTTP 401 |
+| **D. Traefik routing** | IngressRoute works for Nextcloud | `curl -H "Host: nextcloud.localhost" http://<traefik-clusterip>` → HTTP 200 |
+| **E. OnlyOffice health** | OnlyOffice is running | `GET /healthcheck` on OnlyOffice service → response contains `true` |
+| **F. OnlyOffice JWT** | JWT enforcement works | Unsigned request to OnlyOffice command endpoint → rejected |
+
+Uses `kubectl run curlimages/curl` for in-cluster testing.
+
+**2.4 Integration test registration** — add to `VERIFY_SERVICES` in `integration-testing.sh`:
+```bash
+nextcloud:nextcloud verify
+```
+
+**2.5 CLI verify command** — add `nextcloud` to `cmd_verify()` in `uis-cli.sh`, enabling `./uis verify nextcloud`.
+
+### Validation
+
+User reviews the playbook structure.
+
+---
+
+## Phase 3: Build, Deploy, and Test
+
+Build the provision host container, deploy, and verify with the tester. This must pass before writing documentation.
+
+### Tasks
+
+- [x] 3.1 Run `./uis build` to build new provision host container ✓
+- [x] 3.2 Rename existing `talk/talk.md` to `talk/talk20.md` and create new `talk/talk.md` with test instructions ✓
+- [ ] 3.3 Wait for tester results
+- [ ] 3.4 Fix any issues found during testing
+
+### Implementation Details
+
+**3.2 Test instructions** — rename existing `talk.md` → `talk20.md`, then create new `talk.md` for the tester:
+1. Restart with new container: `UIS_IMAGE=uis-provision-host:local ./uis restart`
+2. Generate and apply secrets: `./uis secrets generate && ./uis secrets apply`
+3. Ensure PostgreSQL and Redis are running: `./uis deploy postgresql && ./uis deploy redis`
+4. Deploy Nextcloud: `./uis deploy nextcloud`
+5. Run verification: `./uis verify nextcloud` (runs all 6 E2E tests)
+6. Check `http://nextcloud.localhost` in browser — should show Nextcloud login page
+7. Login with `admin` / password from `./uis secrets show NEXTCLOUD_ADMIN_PASSWORD`
+8. Check `http://onlyoffice.localhost` in browser — should show OnlyOffice welcome page
+9. Create a DOCX file in Nextcloud — should open in OnlyOffice editor
+10. Undeploy: `./uis undeploy nextcloud`
+11. Confirm cleanup: `kubectl get all -n nextcloud` (should show nothing)
+
+### Validation
+
+All 6 verify tests pass. Deploy and undeploy both succeed. Admin login works in browser. Document editing via OnlyOffice works.
+
+---
+
+## Phase 4: Registration and Documentation
+
+Register the service and create documentation. Only after deployment is verified working.
+
+### Tasks
+
+- [ ] 4.1 Add `nextcloud` to `provision-host/uis/templates/uis.extend/enabled-services.conf.default` (commented out)
+- [ ] 4.2 Add `packages/management/nextcloud` to `website/sidebars.ts`
+- [ ] 4.3 Update `website/docs/packages/management/index.md` — add Nextcloud to services table
+- [ ] 4.4 Create documentation page `website/docs/packages/management/nextcloud.md`
+- [ ] 4.5 Update `website/src/data/services.json` — add Nextcloud entry
+
+### Implementation Details
+
+**4.4 Documentation** — follow OpenMetadata docs page pattern:
+- Service info table (category, deploy/undeploy/verify commands, namespace, URLs)
+- What It Does section (file sync, document editing via OnlyOffice, calendar, contacts)
+- Deploy / Verify / Undeploy sections
+- Configuration section (manifests, secrets, key files)
+- OnlyOffice section (what it provides, JWT authentication)
+- Troubleshooting section (first boot slow, PVC cleanup, Redis connection, upload limits)
+
+### Validation
+
+```bash
+cd website && npm run build
+```
+
+User confirms documentation builds and sidebar entry appears.
+
+---
+
+## Phase 5: Cleanup and Status Updates
+
+Update investigation, roadmap, and complete the plan.
+
+### Tasks
+
+- [ ] 5.1 Update `INVESTIGATE-nextcloud-deployment.md` — mark next step as done
+- [ ] 5.2 Update `STATUS-platform-roadmap.md` — mark #7 as Complete, add to Completed Investigations table
+- [ ] 5.3 Move plan and investigation to `completed/`
+
+### Validation
+
+User confirms all status updates are correct.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Nextcloud 33 pod is running in the `nextcloud` namespace
+- [ ] Admin login with `admin` / `NEXTCLOUD_ADMIN_PASSWORD` works
+- [ ] `./uis deploy nextcloud` works end-to-end (creates database, deploys Helm, configures OnlyOffice)
+- [ ] `./uis undeploy nextcloud` cleans up all resources
+- [ ] `./uis verify nextcloud` passes all 6 tests
+- [ ] Service appears in `./uis list`
+- [ ] `./uis test-all --dry-run` includes nextcloud with verify step
+- [ ] `http://nextcloud.localhost` shows Nextcloud login page
+- [ ] `http://onlyoffice.localhost` shows OnlyOffice welcome page
+- [ ] Document editing via OnlyOffice works (create/edit DOCX in browser)
+- [ ] File upload works with files up to 512MB
+- [ ] Documentation page exists at the correct sidebar location
+- [ ] Website builds without errors
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `provision-host/uis/services/management/service-nextcloud.sh` | Service definition |
+| `manifests/620-nextcloud-config.yaml` | Helm values |
+| `manifests/621-nextcloud-ingressroute.yaml` | Nextcloud IngressRoute |
+| `manifests/622-onlyoffice-config.yaml` | OnlyOffice Deployment + Service |
+| `manifests/623-onlyoffice-ingressroute.yaml` | OnlyOffice IngressRoute |
+| `ansible/playbooks/620-setup-nextcloud.yml` | Deployment playbook |
+| `ansible/playbooks/620-remove-nextcloud.yml` | Removal playbook |
+| `ansible/playbooks/620-test-nextcloud.yml` | E2E verification (6 tests) |
+| `website/docs/packages/management/nextcloud.md` | Documentation page |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `provision-host/uis/templates/secrets-templates/00-common-values.env.template` | Add Nextcloud + OnlyOffice section |
+| `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` | Add `nextcloud` namespace block |
+| `provision-host/uis/lib/integration-testing.sh` | Add `nextcloud` to `VERIFY_SERVICES` |
+| `provision-host/uis/manage/uis-cli.sh` | Add `nextcloud` to `cmd_verify()` |
+| `provision-host/uis/templates/uis.extend/enabled-services.conf.default` | Add `nextcloud` (commented out) |
+| `website/sidebars.ts` | Add to Management items |
+| `website/docs/packages/management/index.md` | Add Nextcloud to services table |
+| `website/src/data/services.json` | Add Nextcloud entry |
+| `website/docs/ai-development/ai-developer/plans/backlog/INVESTIGATE-nextcloud-deployment.md` | Mark next step done |
+| `website/docs/ai-development/ai-developer/plans/backlog/STATUS-platform-roadmap.md` | Update #7 status |

--- a/website/docs/packages/applications/_category_.json
+++ b/website/docs/packages/applications/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Applications",
+  "position": 7,
+  "link": {
+    "type": "doc",
+    "id": "packages/applications/index"
+  }
+}

--- a/website/docs/packages/applications/index.md
+++ b/website/docs/packages/applications/index.md
@@ -1,0 +1,19 @@
+---
+title: Applications
+sidebar_label: Applications
+description: End-user applications and collaboration platforms
+---
+
+# Applications
+
+End-user applications and collaboration platforms deployed on the UIS platform.
+
+## Services
+
+| Service | Description | Deploy |
+|---------|-------------|--------|
+| [Nextcloud](./nextcloud.md) | File collaboration and document editing | `./uis deploy nextcloud` |
+
+## Overview
+
+- **Nextcloud** provides file sync, sharing, and browser-based document editing via OnlyOffice

--- a/website/docs/packages/applications/nextcloud.md
+++ b/website/docs/packages/applications/nextcloud.md
@@ -1,0 +1,144 @@
+---
+title: Nextcloud
+sidebar_label: Nextcloud
+---
+
+# Nextcloud
+
+Self-hosted collaboration platform with file sync, sharing, and browser-based document editing via OnlyOffice.
+
+| | |
+|---|---|
+| **Category** | Applications |
+| **Deploy** | `./uis deploy nextcloud` |
+| **Undeploy** | `./uis undeploy nextcloud` |
+| **Verify** | `./uis verify nextcloud` |
+| **Depends on** | PostgreSQL, Redis |
+| **Helm chart** | `nextcloud/nextcloud` (pinned: 9.0.3) |
+| **Default namespace** | `nextcloud` |
+
+## What It Does
+
+Nextcloud provides a self-hosted collaboration platform with:
+- **File Sync and Sharing** -- upload, organize, and share files via browser or desktop client
+- **Document Editing** -- browser-based editing of DOCX, XLSX, PPTX, and PDF via OnlyOffice Document Server
+- **Calendar and Contacts** -- CalDAV and CardDAV support
+- **Cron** -- background jobs run via sidecar container
+
+OnlyOffice Document Server is deployed alongside Nextcloud in the same namespace, connected via JWT-authenticated API.
+
+## Deploy
+
+```bash
+# Deploy dependencies first (if not already running)
+./uis deploy postgresql
+./uis deploy redis
+
+# Deploy Nextcloud + OnlyOffice
+./uis deploy nextcloud
+```
+
+First boot takes 1-5 minutes (database migrations, file copy). The playbook waits for readiness.
+
+## Verify
+
+```bash
+# Run all 8 E2E tests
+./uis verify nextcloud
+
+# Manual checks
+kubectl get pods -n nextcloud
+curl -H "Host: nextcloud.localhost" http://nextcloud.localhost/status.php
+```
+
+The verify playbook tests:
+- Health endpoint, admin WebDAV login, wrong credentials rejected
+- Traefik routing, OnlyOffice health, JWT enforcement
+- OnlyOffice editor endpoint (file handlers registered), config clean (no errors)
+
+## Access
+
+| URL | Description |
+|-----|-------------|
+| `http://nextcloud.localhost` | Nextcloud web UI |
+| `http://onlyoffice.localhost` | OnlyOffice Document Server |
+
+Login with `admin` and the password from `./uis secrets show` (look for `NEXTCLOUD_ADMIN_PASSWORD`).
+
+## Configuration
+
+Nextcloud configuration is in `manifests/620-nextcloud-config.yaml`. Key settings:
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Image | `nextcloud:33-apache` | Pinned version |
+| Database | PostgreSQL (existing UIS instance) | Database: `nextcloud` |
+| Cache | Redis (existing UIS instance) | Session locking and caching |
+| Document editing | OnlyOffice Document Server 9.3.1 | JWT-authenticated |
+| Upload limit | 512M | PHP `upload_max_filesize` |
+| Storage | 10Gi PVC (local-path) | File storage |
+| Cron | Sidecar container | Runs `/cron.sh` alongside main container |
+| Service port | 80 | Required for OnlyOffice connector compatibility |
+
+### Secrets
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
+| `NEXTCLOUD_ADMIN_USER` | `admin` | Admin login username |
+| `NEXTCLOUD_ADMIN_PASSWORD` | Generated | Admin login password |
+| `NEXTCLOUD_DATABASE_USER` | `postgres` | PostgreSQL username |
+| `NEXTCLOUD_DATABASE_PASSWORD` | `PGPASSWORD` | PostgreSQL password |
+| `REDIS_PASSWORD` | `REDIS_PASSWORD` | Redis authentication |
+| `ONLYOFFICE_JWT_SECRET` | Generated | Shared JWT secret for OnlyOffice |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `manifests/620-nextcloud-config.yaml` | Helm values (database, redis, probes, PHP) |
+| `manifests/621-nextcloud-ingressroute.yaml` | Nextcloud IngressRoute |
+| `manifests/622-onlyoffice-config.yaml` | OnlyOffice Deployment + Service |
+| `manifests/623-onlyoffice-ingressroute.yaml` | OnlyOffice IngressRoute |
+| `ansible/playbooks/620-setup-nextcloud.yml` | Deployment playbook |
+| `ansible/playbooks/620-remove-nextcloud.yml` | Removal playbook |
+| `ansible/playbooks/620-test-nextcloud.yml` | E2E verification (8 tests) |
+
+## Undeploy
+
+```bash
+./uis undeploy nextcloud
+```
+
+Note: The PostgreSQL database `nextcloud` is NOT deleted. On redeploy, the setup playbook detects and drops any stale database automatically.
+
+## Troubleshooting
+
+**First boot is slow (1-5 minutes):**
+Nextcloud runs database migrations and copies files on first boot. The startup probe allows up to 5 minutes. Check progress:
+```bash
+kubectl logs -n nextcloud -l app.kubernetes.io/name=nextcloud --tail=50
+```
+
+**OnlyOffice image pull takes several minutes:**
+The OnlyOffice Document Server image is ~1.5 GB. First pull may take 3-5 minutes.
+
+**Documents download instead of opening in OnlyOffice:**
+File handlers may not be registered. Re-run deploy or visit `http://nextcloud.localhost/settings/admin/onlyoffice` and click Save.
+
+**Database permission errors on redeploy:**
+The deploy playbook handles this automatically by dropping stale databases. If you encounter `permission denied for table oc_migrations`, redeploy:
+```bash
+./uis undeploy nextcloud && ./uis deploy nextcloud
+```
+
+**Pod won't start:**
+```bash
+kubectl describe pod -n nextcloud -l app.kubernetes.io/name=nextcloud
+kubectl logs -n nextcloud -l app.kubernetes.io/name=nextcloud --tail=50
+```
+
+## Learn More
+
+- [Nextcloud documentation](https://docs.nextcloud.com)
+- [Nextcloud Helm chart](https://github.com/nextcloud/helm)
+- [OnlyOffice Document Server](https://helpcenter.onlyoffice.com/installation/docs-community-install-docker.aspx)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -122,6 +122,17 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Applications',
+          link: {
+            type: 'doc',
+            id: 'packages/applications/index',
+          },
+          items: [
+            'packages/applications/nextcloud',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Networking',
           link: {
             type: 'generated-index',

--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -408,6 +408,28 @@
 ,
   {
     "@type": "SoftwareApplication",
+    "id": "nextcloud",
+    "name": "Nextcloud",
+    "description": "Self-hosted collaboration platform with file sync and document editing",
+    "category": "APPLICATIONS",
+    "tags": ["collaboration", "file-sync", "document-editing", "calendar", "contacts", "onlyoffice"],
+    "abstract": "Self-hosted collaboration platform — file sync, document editing, calendar, and contacts",
+    "logo": "nextcloud-logo.webp",
+    "website": "https://nextcloud.com"
+    ,"summary": "Nextcloud is a self-hosted content collaboration platform providing file sync and sharing, browser-based document editing via OnlyOffice, calendar, contacts, and more. Deployed with the official Helm chart, reusing existing UIS PostgreSQL and Redis services."
+    ,"docs": "/docs/packages/applications/nextcloud"
+    ,"playbook": "620-setup-nextcloud.yml"
+    ,"priority": 620
+    ,"checkCommand": "kubectl get pods -n nextcloud -l app.kubernetes.io/name=nextcloud --no-headers 2>/dev/null | grep -q Running"
+    ,"removePlaybook": "620-remove-nextcloud.yml"
+    ,"requires": ["postgresql", "redis"]
+    ,"helmChart": "nextcloud/nextcloud"
+    ,"namespace": "nextcloud"
+    ,"image": "nextcloud:33-apache"
+  }
+,
+  {
+    "@type": "SoftwareApplication",
     "id": "cloudflare-tunnel",
     "name": "Cloudflare Tunnel",
     "description": "Secure tunnel to Cloudflare network",


### PR DESCRIPTION
## Summary
- Deploy Nextcloud 33 collaboration platform with OnlyOffice Document Server 9.3.1 for browser-based document editing
- Uses official Helm chart v9.0.3, reusing existing PostgreSQL and Redis — no new backing services
- 8 E2E verify tests (health, auth, routing, OnlyOffice health, JWT, editor endpoint, config clean)
- New APPLICATIONS category for end-user applications (separate from infrastructure management tools)
- Added INVESTIGATE-docs-markdown-update-logic.md to backlog for future docs generator improvements

## Test plan
- [x] `./uis deploy nextcloud` succeeds (7 rounds of testing)
- [x] `./uis verify nextcloud` — all 8 tests pass
- [x] `./uis undeploy nextcloud` cleans up all resources
- [x] Browser: nextcloud.localhost shows login page
- [x] Browser: .docx opens in OnlyOffice editor without manual admin intervention
- [x] Browser: + New menu shows document/spreadsheet/presentation options
- [x] Website builds with no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)