### PR TITLE
fix: correct SCRIPT_LOGO references to match actual image files

### DIFF
--- a/provision-host/uis/schemas/service.schema.json
+++ b/provision-host/uis/schemas/service.schema.json
@@ -45,7 +45,7 @@
     "logo": {
       "type": "string",
       "description": "Logo filename (SVG preferred, WebP fallback). Empty string if no logo available.",
-      "pattern": "^([a-z0-9-]+-logo\\.(svg|webp))?$"
+      "pattern": "^([a-z0-9-]+-logo\\.(svg|png|webp))?$"
     },
     "website": {
       "type": "string",

--- a/provision-host/uis/services/ai/service-litellm.sh
+++ b/provision-host/uis/services/ai/service-litellm.sh
@@ -30,7 +30,7 @@ SCRIPT_CONSUMES_APIS=""
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Call 100+ LLM APIs using OpenAI format"
-SCRIPT_LOGO="litellm-logo.webp"
+SCRIPT_LOGO="litellm-logo.svg"
 SCRIPT_WEBSITE="https://litellm.ai"
 SCRIPT_TAGS="ai,llm,api-gateway,openai,proxy,unified-api"
 SCRIPT_SUMMARY="LiteLLM is a unified API gateway that allows you to call 100+ LLM APIs using the OpenAI format. It provides load balancing, fallbacks, spend tracking, and virtual keys."

--- a/provision-host/uis/services/ai/service-openwebui.sh
+++ b/provision-host/uis/services/ai/service-openwebui.sh
@@ -30,7 +30,7 @@ SCRIPT_CONSUMES_APIS="litellm-api"
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Self-hosted AI interface supporting multiple model providers"
-SCRIPT_LOGO="openwebui-logo.webp"
+SCRIPT_LOGO="openwebui-logo.png"
 SCRIPT_WEBSITE="https://openwebui.com"
 SCRIPT_TAGS="ai,llm,chat,interface,openai,ollama"
 SCRIPT_SUMMARY="Open WebUI is an extensible, feature-rich, and user-friendly self-hosted AI interface. It supports various LLM runners including Ollama and OpenAI-compatible APIs."

--- a/provision-host/uis/services/analytics/service-jupyterhub.sh
+++ b/provision-host/uis/services/analytics/service-jupyterhub.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="app-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Multi-user server for Jupyter notebooks enabling collaborative data science"
-SCRIPT_LOGO="jupyterhub-logo.webp"
+SCRIPT_LOGO="jupyterhub-logo.svg"
 SCRIPT_WEBSITE="https://jupyter.org/hub"
 SCRIPT_TAGS="notebooks,jupyter,python,data-science,collaboration"
 SCRIPT_SUMMARY="JupyterHub is a multi-user server that manages and proxies multiple instances of Jupyter notebooks. It enables teams to share computational environments and collaborate on data science projects."

--- a/provision-host/uis/services/analytics/service-openmetadata.sh
+++ b/provision-host/uis/services/analytics/service-openmetadata.sh
@@ -31,7 +31,7 @@ SCRIPT_CONSUMES_APIS=""
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Open-source metadata platform for data discovery, governance, and observability"
-SCRIPT_LOGO="openmetadata-logo.webp"
+SCRIPT_LOGO=""
 SCRIPT_WEBSITE="https://open-metadata.org"
 SCRIPT_TAGS="data-governance,metadata,data-discovery,data-lineage,data-quality,data-catalog"
 SCRIPT_SUMMARY="OpenMetadata is an open-source metadata platform for data discovery, data observability, and data governance. It provides unified metadata management with 100+ connectors, column-level lineage, data quality checks, and collaboration features."

--- a/provision-host/uis/services/analytics/service-spark.sh
+++ b/provision-host/uis/services/analytics/service-spark.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="app-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Fast and general-purpose cluster computing system for big data processing"
-SCRIPT_LOGO="spark-logo.webp"
+SCRIPT_LOGO="spark-logo.svg"
 SCRIPT_WEBSITE="https://spark.apache.org"
 SCRIPT_TAGS="big-data,analytics,distributed-computing,etl,machine-learning"
 SCRIPT_SUMMARY="Apache Spark is a unified analytics engine for large-scale data processing. It provides high-level APIs in Java, Scala, Python, and R, and supports SQL queries, streaming data, machine learning, and graph processing."

--- a/provision-host/uis/services/analytics/service-unity-catalog.sh
+++ b/provision-host/uis/services/analytics/service-unity-catalog.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="app-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Open-source data catalog for unified governance across data and AI assets"
-SCRIPT_LOGO="unity-catalog-logo.webp"
+SCRIPT_LOGO="unity-catalog-logo.png"
 SCRIPT_WEBSITE="https://www.unitycatalog.io"
 SCRIPT_TAGS="data-catalog,governance,metadata,lakehouse,data-lineage"
 SCRIPT_SUMMARY="Unity Catalog is an open-source data catalog that provides unified governance for data and AI assets. It enables fine-grained access control, data lineage tracking, and metadata management across your data lakehouse."

--- a/provision-host/uis/services/databases/service-elasticsearch.sh
+++ b/provision-host/uis/services/databases/service-elasticsearch.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="RESTful search and analytics engine for all types of data"
-SCRIPT_LOGO="elasticsearch-logo.webp"
+SCRIPT_LOGO="elasticsearch-logo.svg"
 SCRIPT_WEBSITE="https://www.elastic.co/elasticsearch"
 SCRIPT_TAGS="search,full-text,analytics,indexing,distributed"
 SCRIPT_SUMMARY="Elasticsearch is a distributed, RESTful search and analytics engine capable of addressing a growing number of use cases. It centrally stores your data for lightning fast search and fine-tuned relevancy."

--- a/provision-host/uis/services/databases/service-mongodb.sh
+++ b/provision-host/uis/services/databases/service-mongodb.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="General purpose document database"
-SCRIPT_LOGO="mongodb-logo.webp"
+SCRIPT_LOGO="mongodb-logo.svg"
 SCRIPT_WEBSITE="https://www.mongodb.com"
 SCRIPT_TAGS="database,nosql,document,json,flexible-schema"
 SCRIPT_SUMMARY="MongoDB is a document-oriented NoSQL database designed for high-volume data storage. It stores data in flexible, JSON-like documents, meaning fields can vary from document to document."

--- a/provision-host/uis/services/databases/service-mysql.sh
+++ b/provision-host/uis/services/databases/service-mysql.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Popular open-source relational database for web applications"
-SCRIPT_LOGO="mysql-logo.webp"
+SCRIPT_LOGO="mysql-logo.svg"
 SCRIPT_WEBSITE="https://www.mysql.com"
 SCRIPT_TAGS="database,sql,relational,mysql,rdbms"
 SCRIPT_SUMMARY="MySQL is the world's most popular open-source relational database management system. It powers many of the most accessed applications including Facebook, Twitter, and YouTube."

--- a/provision-host/uis/services/databases/service-postgresql.sh
+++ b/provision-host/uis/services/databases/service-postgresql.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="World's most advanced open-source relational database"
-SCRIPT_LOGO="postgresql-logo.webp"
+SCRIPT_LOGO="postgresql-logo.svg"
 SCRIPT_WEBSITE="https://www.postgresql.org"
 SCRIPT_TAGS="database,sql,relational,postgres,rdbms"
 SCRIPT_SUMMARY="PostgreSQL is a powerful, open-source object-relational database system with over 35 years of active development. It has earned a strong reputation for reliability, feature robustness, and performance."

--- a/provision-host/uis/services/databases/service-qdrant.sh
+++ b/provision-host/uis/services/databases/service-qdrant.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="High-performance vector database for AI applications"
-SCRIPT_LOGO="qdrant-logo.webp"
+SCRIPT_LOGO="qdrant-logo.svg"
 SCRIPT_WEBSITE="https://qdrant.tech"
 SCRIPT_TAGS="vector-database,ai,embeddings,similarity-search,semantic-search"
 SCRIPT_SUMMARY="Qdrant is a vector similarity search engine and database designed for AI applications. It provides extended filtering support, making it useful for neural network or semantic-based matching."

--- a/provision-host/uis/services/databases/service-redis.sh
+++ b/provision-host/uis/services/databases/service-redis.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="In-memory data structure store for caching and messaging"
-SCRIPT_LOGO="redis-logo.webp"
+SCRIPT_LOGO="redis-logo.svg"
 SCRIPT_WEBSITE="https://redis.io"
 SCRIPT_TAGS="cache,in-memory,key-value,message-broker,session"
 SCRIPT_SUMMARY="Redis is an open-source, in-memory data structure store used as a database, cache, message broker, and streaming engine. It supports various data structures like strings, hashes, lists, and sets."

--- a/provision-host/uis/services/identity/service-authentik.sh
+++ b/provision-host/uis/services/identity/service-authentik.sh
@@ -30,7 +30,7 @@ SCRIPT_CONSUMES_APIS=""
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Open-source identity provider with SSO, MFA, and user management"
-SCRIPT_LOGO="authentik-logo.webp"
+SCRIPT_LOGO="authentik-logo.svg"
 SCRIPT_WEBSITE="https://goauthentik.io"
 SCRIPT_TAGS="authentication,sso,identity,oauth,saml,ldap,mfa"
 SCRIPT_SUMMARY="Authentik is an open-source Identity Provider focused on flexibility and versatility. It supports SAML, OAuth/OIDC, LDAP, and proxy authentication with built-in MFA support."

--- a/provision-host/uis/services/integration/service-enonic.sh
+++ b/provision-host/uis/services/integration/service-enonic.sh
@@ -30,7 +30,7 @@ SCRIPT_OWNER="app-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Headless CMS platform with embedded storage, Content Studio, and 100+ integrations"
-SCRIPT_LOGO="enonic-logo.webp"
+SCRIPT_LOGO=""
 SCRIPT_WEBSITE="https://enonic.com"
 SCRIPT_TAGS="cms,headless-cms,content-management,content-studio,graphql,enonic-xp"
 SCRIPT_SUMMARY="Enonic XP is a Java/GraalVM-based headless CMS platform with embedded Elasticsearch and NoSQL storage. It provides Content Studio for editorial work, headless APIs (GraphQL/REST), and a composable architecture for building content-driven applications."

--- a/provision-host/uis/services/integration/service-gravitee.sh
+++ b/provision-host/uis/services/integration/service-gravitee.sh
@@ -30,7 +30,7 @@ SCRIPT_CONSUMES_APIS=""
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Open-source API management platform for designing, deploying, and managing APIs"
-SCRIPT_LOGO="gravitee-logo.webp"
+SCRIPT_LOGO="gravitee-logo.svg"
 SCRIPT_WEBSITE="https://www.gravitee.io"
 SCRIPT_TAGS="api-gateway,api-management,rest,graphql,security"
 SCRIPT_SUMMARY="Gravitee is an open-source API management platform that helps you design, deploy, and manage APIs. It provides a gateway, management console, and developer portal for comprehensive API lifecycle management."

--- a/provision-host/uis/services/integration/service-rabbitmq.sh
+++ b/provision-host/uis/services/integration/service-rabbitmq.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Reliable message broker supporting multiple messaging protocols"
-SCRIPT_LOGO="rabbitmq-logo.webp"
+SCRIPT_LOGO="rabbitmq-logo.svg"
 SCRIPT_WEBSITE="https://www.rabbitmq.com"
 SCRIPT_TAGS="message-queue,amqp,messaging,async,pubsub"
 SCRIPT_SUMMARY="RabbitMQ is a reliable and mature messaging broker that supports multiple messaging protocols including AMQP. It provides features like message persistence, delivery acknowledgment, and flexible routing."

--- a/provision-host/uis/services/management/service-argocd.sh
+++ b/provision-host/uis/services/management/service-argocd.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Declarative GitOps CD for Kubernetes"
-SCRIPT_LOGO="argocd-logo.webp"
+SCRIPT_LOGO="argocd-logo.svg"
 SCRIPT_WEBSITE="https://argo-cd.readthedocs.io"
 SCRIPT_TAGS="gitops,cd,continuous-delivery,kubernetes,deployment"
 SCRIPT_SUMMARY="ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes. It automates the deployment of applications to specified target environments, keeping them synchronized with their Git repository definitions."

--- a/provision-host/uis/services/management/service-backstage.sh
+++ b/provision-host/uis/services/management/service-backstage.sh
@@ -29,7 +29,7 @@ SCRIPT_OWNER="platform-team"
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Developer portal for software catalog and service visibility"
-SCRIPT_LOGO="backstage-logo.webp"
+SCRIPT_LOGO=""
 SCRIPT_WEBSITE="https://backstage.io"
 SCRIPT_TAGS="developer-portal,catalog,backstage,rhdh,kubernetes"
 SCRIPT_SUMMARY="Backstage (via Red Hat Developer Hub) provides a centralized developer portal with a software catalog showing all UIS services, their relationships, Kubernetes pod status, and Grafana dashboard links."

--- a/provision-host/uis/services/management/service-nextcloud.sh
+++ b/provision-host/uis/services/management/service-nextcloud.sh
@@ -30,7 +30,7 @@ SCRIPT_OWNER="app-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Self-hosted collaboration platform — file sync, document editing, calendar, and contacts"
-SCRIPT_LOGO="nextcloud-logo.webp"
+SCRIPT_LOGO=""
 SCRIPT_WEBSITE="https://nextcloud.com"
 SCRIPT_TAGS="collaboration,file-sync,document-editing,calendar,contacts,onlyoffice"
 SCRIPT_SUMMARY="Nextcloud is a self-hosted content collaboration platform providing file sync and sharing, browser-based document editing via OnlyOffice, calendar, contacts, and more. Deployed with the official Helm chart, reusing existing UIS PostgreSQL and Redis services."

--- a/provision-host/uis/services/management/service-nginx.sh
+++ b/provision-host/uis/services/management/service-nginx.sh
@@ -29,7 +29,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="High-performance web server and reverse proxy"
-SCRIPT_LOGO="nginx-logo.webp"
+SCRIPT_LOGO="nginx-logo.svg"
 SCRIPT_WEBSITE="https://nginx.org"
 SCRIPT_TAGS="webserver,proxy,reverse-proxy,load-balancer,http"
 SCRIPT_SUMMARY="Nginx is a high-performance HTTP server and reverse proxy, known for its stability, rich feature set, simple configuration, and low resource consumption."

--- a/provision-host/uis/services/management/service-pgadmin.sh
+++ b/provision-host/uis/services/management/service-pgadmin.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Web administration interface for PostgreSQL"
-SCRIPT_LOGO="pgadmin-logo.webp"
+SCRIPT_LOGO="pgadmin-logo.png"
 SCRIPT_WEBSITE="https://www.pgadmin.org"
 SCRIPT_TAGS="postgresql,database,admin,management,web-ui"
 SCRIPT_SUMMARY="pgAdmin is a feature-rich open source administration and development platform for PostgreSQL. It provides a graphical interface for managing databases, running queries, and monitoring server activity."

--- a/provision-host/uis/services/management/service-redisinsight.sh
+++ b/provision-host/uis/services/management/service-redisinsight.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Visual management interface for Redis"
-SCRIPT_LOGO="redisinsight-logo.webp"
+SCRIPT_LOGO="redisinsight-logo.svg"
 SCRIPT_WEBSITE="https://redis.io/insight/"
 SCRIPT_TAGS="redis,database,admin,management,web-ui,cache"
 SCRIPT_SUMMARY="RedisInsight is a visual tool for managing Redis databases. It provides a graphical interface for browsing keys, running commands, monitoring performance, and managing Redis data structures."

--- a/provision-host/uis/services/networking/service-cloudflare-tunnel.sh
+++ b/provision-host/uis/services/networking/service-cloudflare-tunnel.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Secure outbound-only tunnel to expose services via Cloudflare"
-SCRIPT_LOGO="cloudflare-logo.webp"
+SCRIPT_LOGO="cloudflare-logo.svg"
 SCRIPT_WEBSITE="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/"
 SCRIPT_TAGS="tunnel,cloudflare,cdn,ddos-protection,reverse-proxy"
 SCRIPT_SUMMARY="Cloudflare Tunnel creates a secure, outbound-only connection between your origin and Cloudflare's edge. No need to open public inbound ports - traffic is routed through Cloudflare's network."

--- a/provision-host/uis/services/networking/service-tailscale-tunnel.sh
+++ b/provision-host/uis/services/networking/service-tailscale-tunnel.sh
@@ -28,7 +28,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Zero-config WireGuard-based mesh VPN for secure remote access"
-SCRIPT_LOGO="tailscale-logo.webp"
+SCRIPT_LOGO="tailscale-logo.svg"
 SCRIPT_WEBSITE="https://tailscale.com"
 SCRIPT_TAGS="vpn,wireguard,mesh-network,remote-access,zero-trust"
 SCRIPT_SUMMARY="Tailscale creates a secure, private network between your servers, computers, and cloud instances using WireGuard encryption. It provides zero-config networking with built-in NAT traversal."

--- a/provision-host/uis/services/observability/service-grafana.sh
+++ b/provision-host/uis/services/observability/service-grafana.sh
@@ -31,7 +31,7 @@ SCRIPT_CONSUMES_APIS=""
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Observability platform for metrics, logs, and distributed tracing"
-SCRIPT_LOGO="grafana-logo.webp"
+SCRIPT_LOGO="grafana-logo.svg"
 SCRIPT_WEBSITE="https://grafana.com"
 SCRIPT_TAGS="monitoring,dashboards,visualization,observability,metrics,logs"
 SCRIPT_SUMMARY="Grafana is the open-source analytics and monitoring solution for every database. Create, explore, and share dashboards with your team and foster a data-driven culture."

--- a/provision-host/uis/services/observability/service-loki.sh
+++ b/provision-host/uis/services/observability/service-loki.sh
@@ -29,7 +29,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Horizontally-scalable log aggregation system"
-SCRIPT_LOGO="loki-logo.webp"
+SCRIPT_LOGO="loki-logo.png"
 SCRIPT_WEBSITE="https://grafana.com/oss/loki/"
 SCRIPT_TAGS="logging,logs,aggregation,observability,monitoring"
 SCRIPT_SUMMARY="Loki is a horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus. It indexes labels, not log content, making it cost-effective and easy to operate."

--- a/provision-host/uis/services/observability/service-otel-collector.sh
+++ b/provision-host/uis/services/observability/service-otel-collector.sh
@@ -29,7 +29,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Vendor-agnostic telemetry collection and processing"
-SCRIPT_LOGO="opentelemetry-logo.webp"
+SCRIPT_LOGO="otel-collector-logo.svg"
 SCRIPT_WEBSITE="https://opentelemetry.io"
 SCRIPT_TAGS="telemetry,opentelemetry,otel,observability,traces,metrics,logs"
 SCRIPT_SUMMARY="The OpenTelemetry Collector offers a vendor-agnostic implementation to receive, process, and export telemetry data. It removes the need to run multiple agents/collectors."

--- a/provision-host/uis/services/observability/service-prometheus.sh
+++ b/provision-host/uis/services/observability/service-prometheus.sh
@@ -29,7 +29,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Time-series database for metrics collection, storage, and alerting"
-SCRIPT_LOGO="prometheus-logo.webp"
+SCRIPT_LOGO="prometheus-logo.svg"
 SCRIPT_WEBSITE="https://prometheus.io"
 SCRIPT_TAGS="monitoring,metrics,alerting,time-series,observability"
 SCRIPT_SUMMARY="Prometheus is a systems monitoring and alerting toolkit that collects metrics from configured targets, stores them locally, and provides a powerful query language (PromQL) for analysis and alerting."

--- a/provision-host/uis/services/observability/service-tempo.sh
+++ b/provision-host/uis/services/observability/service-tempo.sh
@@ -29,7 +29,7 @@ SCRIPT_OWNER="platform-team"   # platform-team | app-team
 
 # === Website Metadata (Optional) ===
 SCRIPT_ABSTRACT="Open source distributed tracing backend"
-SCRIPT_LOGO="tempo-logo.webp"
+SCRIPT_LOGO="tempo-logo.svg"
 SCRIPT_WEBSITE="https://grafana.com/oss/tempo/"
 SCRIPT_TAGS="tracing,distributed-tracing,observability,monitoring,spans"
 SCRIPT_SUMMARY="Tempo is an open source, easy-to-use, high-scale distributed tracing backend. It requires only object storage to operate and integrates seamlessly with Grafana, Prometheus, and Loki."

--- a/website/src/data/schemas/service.schema.json
+++ b/website/src/data/schemas/service.schema.json
@@ -45,7 +45,7 @@
     "logo": {
       "type": "string",
       "description": "Logo filename (SVG preferred, WebP fallback). Empty string if no logo available.",
-      "pattern": "^([a-z0-9-]+-logo\\.(svg|webp))?$"
+      "pattern": "^([a-z0-9-]+-logo\\.(svg|png|webp))?$"
     },
     "website": {
       "type": "string",


### PR DESCRIPTION
All 29 service metadata files referenced .webp logos that don't exist. Updated to match actual files in website/static/img/services/:
- 20 services: .webp -> .svg
- 4 services: .webp -> .png (loki, openwebui, pgadmin, unity-catalog)
- 1 name fix: opentelemetry-logo -> otel-collector-logo
- 4 missing logos set to empty (backstage, enonic, nextcloud, openmetadata)
- Updated schema pattern to accept .png in both schema copies

https://claude.ai/code/session_01SgvuTUciNtfuBT9C4bz2sg