### PR TITLE
Replace homepage Service Categories with shared dynamic services content

### DIFF
--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -1,82 +1,26 @@
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
+import CategoryGrid from '../CategoryGrid';
+import StackGrid from '../StackGrid';
+import ServiceGrid from '../ServiceGrid';
 import styles from './styles.module.css';
-
-type FeatureItem = {
-  title: string;
-  description: string;
-  link: string;
-  icon: string;
-};
-
-const FeatureList: FeatureItem[] = [
-  {
-    title: 'AI & Machine Learning',
-    description: 'OpenWebUI, LiteLLM, and Ollama integration for local AI development with unified API access.',
-    link: '/docs/packages/ai',
-    icon: '🤖',
-  },
-  {
-    title: 'Databases',
-    description: 'PostgreSQL, MySQL, MongoDB, Redis, and Qdrant - all pre-configured and ready to use.',
-    link: '/docs/packages/databases',
-    icon: '🗄️',
-  },
-  {
-    title: 'Observability',
-    description: 'Grafana, Prometheus, Loki, and Tempo for comprehensive monitoring, logging, and tracing.',
-    link: '/docs/packages/observability',
-    icon: '📊',
-  },
-  {
-    title: 'Identity',
-    description: 'Authentik SSO with OIDC/OAuth2 support for secure, centralized identity management.',
-    link: '/docs/packages/identity',
-    icon: '🔐',
-  },
-  {
-    title: 'Analytics',
-    description: 'Apache Spark, JupyterHub, and Unity Catalog for scalable data processing and analysis.',
-    link: '/docs/packages/analytics',
-    icon: '🔬',
-  },
-  {
-    title: 'Multi-Platform',
-    description: 'Deploy on your laptop with Rancher Desktop, Azure AKS, or Raspberry Pi clusters.',
-    link: '/docs/advanced/hosts',
-    icon: '🌐',
-  },
-];
-
-function Feature({ title, description, link, icon }: FeatureItem) {
-  return (
-    <div className={clsx('col col--4')}>
-      <Link to={link} className={styles.featureLink}>
-        <div className={styles.featureCard}>
-          <div className={styles.featureIcon}>{icon}</div>
-          <h3 className={styles.featureTitle}>{title}</h3>
-          <p className={styles.featureDescription}>{description}</p>
-        </div>
-      </Link>
-    </div>
-  );
-}
 
 export default function HomepageFeatures(): React.JSX.Element {
   return (
-    <section className={styles.features}>
-      <div className="container">
-        <div className={styles.sectionHeader}>
-          <h2>Service Categories</h2>
-          <p>Everything you need for a complete development infrastructure</p>
-        </div>
-        <div className="row">
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
-          ))}
-        </div>
-      </div>
-    </section>
+    <div className={styles.servicesShowcase}>
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Categories</h2>
+        <CategoryGrid excludeEmpty />
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Pre-configured Stacks</h2>
+        <StackGrid />
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>All Services</h2>
+        <ServiceGrid />
+      </section>
+    </div>
   );
 }

--- a/website/src/components/HomepageFeatures/styles.module.css
+++ b/website/src/components/HomepageFeatures/styles.module.css
@@ -1,80 +1,28 @@
-.features {
-  padding: 4rem 0;
-  background-color: var(--ifm-background-surface-color);
+.servicesShowcase {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
 }
 
-.sectionHeader {
-  text-align: center;
-  margin-bottom: 3rem;
+.section {
+  margin-bottom: 4rem;
 }
 
-.sectionHeader h2 {
-  font-size: 2rem;
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-}
-
-.sectionHeader p {
-  color: var(--ifm-color-emphasis-600);
-  font-size: 1.1rem;
-}
-
-.featureLink {
-  text-decoration: none;
-  color: inherit;
-  display: block;
-  height: 100%;
-}
-
-.featureLink:hover {
-  text-decoration: none;
-}
-
-.featureCard {
-  padding: 1.5rem;
-  border-radius: 12px;
-  background: var(--ifm-card-background-color);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  height: 100%;
-  margin-bottom: 1.5rem;
-}
-
-.featureCard:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-}
-
-.featureIcon {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-}
-
-.featureTitle {
-  font-size: 1.25rem;
+.sectionTitle {
+  font-size: 1.75rem;
   font-weight: 600;
-  margin-bottom: 0.5rem;
-  color: var(--ifm-color-primary);
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--ifm-color-emphasis-200);
+  color: var(--ifm-heading-color);
 }
 
-.featureDescription {
-  color: var(--ifm-color-emphasis-700);
-  font-size: 0.95rem;
-  line-height: 1.6;
-  margin: 0;
-}
+@media (max-width: 768px) {
+  .section {
+    margin-bottom: 3rem;
+  }
 
-[data-theme='dark'] .featureCard {
-  background: var(--ifm-background-surface-color);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
-}
-
-[data-theme='dark'] .featureCard:hover {
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
-}
-
-@media screen and (max-width: 996px) {
-  .features {
-    padding: 2rem 0;
+  .sectionTitle {
+    font-size: 1.5rem;
   }
 }


### PR DESCRIPTION
Replace the hardcoded 6-card feature grid on the homepage with the same CategoryGrid, StackGrid, and ServiceGrid components used on /services. This ensures the homepage stays in sync with the services page automatically without any manual maintenance of duplicate content.

https://claude.ai/code/session_01SgvuTUciNtfuBT9C4bz2sg