### PR TITLE
docs: add How Deployment Works page

### DIFF
--- a/website/docs/advanced/how-deployment-works.md
+++ b/website/docs/advanced/how-deployment-works.md
@@ -1,0 +1,265 @@
+# How Deployment Works
+
+This page explains what happens under the hood when you run `./uis deploy`. If you just want to deploy services, see the [Deploy System overview](../contributors/architecture/deploy-system.md). If you want to add a new service, see the [Adding a Service guide](../contributors/guides/adding-a-service.md).
+
+## The Deploy Flow
+
+When you run `./uis deploy <service>`, the system follows these steps:
+
+```
+./uis deploy postgresql
+    |
+    +-- 1. Service discovery
+    |     Find service-postgresql.sh in provision-host/uis/services/
+    |
+    +-- 2. Load metadata
+    |     Source the file to read all SCRIPT_* variables
+    |
+    +-- 3. Check dependencies
+    |     For each service in SCRIPT_REQUIRES, verify it's running
+    |     (fail fast if any dependency is missing)
+    |
+    +-- 4. Execute deployment
+    |     If SCRIPT_PLAYBOOK: run ansible-playbook
+    |     If SCRIPT_MANIFEST: run kubectl apply
+    |
+    +-- 5. Health check
+    |     Wait 2 seconds, then run SCRIPT_CHECK_COMMAND
+    |     (failure is a warning, not an error)
+    |
+    +-- 6. Auto-enable
+          Add service to enabled-services.conf
+```
+
+### Step 1: Service Discovery
+
+The service scanner (`lib/service-scanner.sh`) finds services by walking `provision-host/uis/services/` recursively for `*.sh` files. Files starting with `_` (helper scripts) are skipped.
+
+During discovery, the scanner parses each file **line by line** — it does not `source` the scripts. This is a safety measure so that unknown scripts can't execute code during a scan. Only when you actually deploy does the system `source` the metadata file.
+
+Results are cached in memory for performance.
+
+### Step 2: Load Metadata
+
+When deploying, the system sources the service script to load all `SCRIPT_*` variables. For example, `service-postgresql.sh` sets:
+
+```bash
+SCRIPT_ID="postgresql"
+SCRIPT_NAME="PostgreSQL"
+SCRIPT_CATEGORY="DATABASES"
+SCRIPT_PLAYBOOK="040-database-postgresql.yml"
+SCRIPT_CHECK_COMMAND="kubectl get pods -n default -l app.kubernetes.io/name=postgresql --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REQUIRES=""
+SCRIPT_PRIORITY="30"
+```
+
+See [Service metadata fields](#service-metadata-fields) below for the key fields and a link to the complete reference.
+
+### Step 3: Check Dependencies
+
+If `SCRIPT_REQUIRES` lists other service IDs (space-separated), each dependency is verified before deployment begins. Verification runs each dependency's `SCRIPT_CHECK_COMMAND` — if the command exits 0, the dependency is considered deployed.
+
+If any dependency is missing, deployment **fails immediately** with an error message telling you which service needs to be deployed first.
+
+Example: OpenWebUI requires PostgreSQL:
+
+```bash
+# In service-openwebui.sh
+SCRIPT_REQUIRES="postgresql"
+```
+
+Running `./uis deploy openwebui` without PostgreSQL deployed will fail with:
+```
+Required service 'postgresql' is not deployed
+```
+
+### Step 4: Execute Deployment
+
+Two deployment methods exist (mutually exclusive — if both are set, playbook wins):
+
+| Method | Field | What happens |
+|--------|-------|-------------|
+| **Ansible playbook** | `SCRIPT_PLAYBOOK` | `ansible-playbook <playbook> -e "target_host=<host>"` |
+| **Direct manifest** | `SCRIPT_MANIFEST` | `kubectl apply -f <manifest>` |
+
+All current services use Ansible playbooks. The playbook filename refers to a file in `ansible/playbooks/`.
+
+The **target host** (which Kubernetes cluster to deploy to) is read from `.uis.extend/cluster-config.sh`. The default is `rancher-desktop` (local development). Other supported values: `azure-aks`, `azure-microk8s`, `multipass-microk8s`, `raspberry-microk8s`.
+
+### Step 5: Health Check
+
+After deployment, if `SCRIPT_CHECK_COMMAND` is set, the system:
+
+1. Waits 2 seconds for the service to start
+2. Runs the check command
+3. If it exits 0: reports success
+4. If it fails: reports a **warning** (not an error) — the service may need more time to start
+
+Most health checks look for Running pods:
+
+```bash
+SCRIPT_CHECK_COMMAND="kubectl get pods -n default -l app.kubernetes.io/name=postgresql --no-headers 2>/dev/null | grep -q Running"
+```
+
+### Step 6: Auto-Enable
+
+After a successful deployment, the service is automatically added to `enabled-services.conf`. This means running `./uis deploy` (without arguments) in the future will include this service.
+
+---
+
+## Deploy-All Flow
+
+Running `./uis deploy` with no argument deploys all services listed in `.uis.extend/enabled-services.conf`, in the order they appear in the file. It **stops on the first failure** — if service 3 of 10 fails, services 4–10 are skipped.
+
+```bash
+# Deploy all enabled services
+./uis deploy
+
+# See what's enabled
+./uis list-enabled
+```
+
+---
+
+## Priority Ordering
+
+Each service has a `SCRIPT_PRIORITY` value (default: 50). Lower numbers deploy first. This matters when deploying multiple services — infrastructure services like storage and databases should deploy before services that depend on them.
+
+| Priority Range | Typical Use |
+|:---:|---|
+| 10–20 | Core infrastructure (storage, ingress) |
+| 25–30 | Databases and caches |
+| 40–50 | Application services (default) |
+| 60+ | Management and monitoring tools |
+
+Example priorities from actual services:
+
+| Service | Priority | Why |
+|---------|:---:|---|
+| PostgreSQL | 30 | Database — many services depend on it |
+| Redis | 30 | Cache — Authentik depends on it |
+| Authentik | 50 | Needs PostgreSQL and Redis first |
+| Grafana | 50 | Needs Prometheus, Loki, Tempo for full functionality |
+| pgAdmin | 50 | Needs PostgreSQL |
+
+---
+
+## Dependency Resolution
+
+Dependencies are declared in `SCRIPT_REQUIRES` as a space-separated list of service IDs:
+
+```bash
+# Authentik requires both PostgreSQL and Redis
+SCRIPT_REQUIRES="postgresql redis"
+```
+
+When deploying, the system checks each dependency by running its `SCRIPT_CHECK_COMMAND`. This is a **runtime check** — it verifies the service is actually running in the cluster, not just that it's listed in the enabled config.
+
+Dependencies are **not transitive**. If service A requires B, and B requires C, deploying A only checks that B is running — it doesn't check C. The assumption is that B wouldn't be running if C weren't already deployed.
+
+Current dependency chain:
+
+```
+postgresql ← pgAdmin, OpenWebUI, LiteLLM, Unity Catalog, Authentik, OpenMetadata
+redis ← Authentik, RedisInsight
+postgresql + redis ← Authentik
+postgresql + elasticsearch ← OpenMetadata
+```
+
+---
+
+## Stacks
+
+Stacks are pre-defined bundles of services that work together. They deploy multiple services with a single command.
+
+### Available Stacks
+
+| Stack | Services | Optional |
+|-------|----------|----------|
+| **observability** | Prometheus, Tempo, Loki, OTel Collector, Grafana | OTel Collector |
+| **ai-local** | LiteLLM, OpenWebUI | — |
+| **analytics** | Spark, JupyterHub, Unity Catalog | Unity Catalog |
+
+### How Stacks Work
+
+- **Install** (`./uis stack install <name>`): deploys services left-to-right in the defined order (dependencies first)
+- **Remove** (`./uis stack remove <name>`): removes services in **reverse** order (dependents first)
+- **`--skip-optional`**: skips services marked as optional for that stack
+
+Each service installed via a stack is automatically added to `enabled-services.conf`, just like a regular deploy.
+
+Stacks are defined in `provision-host/uis/lib/stacks.sh`.
+
+---
+
+## Undeploy Flow
+
+When you run `./uis undeploy <service>`, the system uses a three-tier removal strategy:
+
+1. **Removal playbook** (`SCRIPT_REMOVE_PLAYBOOK`): if set, runs the Ansible playbook. The field can include extra parameters after the filename (e.g., `085-remove-enonic.yml -e "operation=delete"`)
+2. **Manifest deletion** (`SCRIPT_MANIFEST`): if no removal playbook, runs `kubectl delete -f <manifest> --ignore-not-found`
+3. **No method**: if neither is set, prints a warning that manual cleanup may be required
+
+:::note
+Undeploy does **not** delete PersistentVolumeClaims (PVCs) by default. Your data is preserved. To fully clean up, delete PVCs manually:
+```bash
+kubectl delete pvc -n <namespace> -l app=<service>
+```
+:::
+
+---
+
+## Autostart Configuration
+
+The file `.uis.extend/enabled-services.conf` controls which services deploy when running `./uis deploy` without arguments.
+
+```bash
+# Enable a service (adds to enabled-services.conf)
+./uis enable postgresql
+
+# Disable a service (removes from enabled-services.conf)
+./uis disable postgresql
+
+# List what's enabled
+./uis list-enabled
+
+# Sync enabled list with what's actually running in the cluster
+./uis sync
+```
+
+The `sync` command scans the cluster for running services and updates the enabled list to match — useful after manual deployments or when the list gets out of sync.
+
+Note: `./uis deploy <service>` automatically enables the service, so you rarely need to run `./uis enable` separately.
+
+---
+
+## Service Metadata Fields
+
+Each service is defined by a metadata file in `provision-host/uis/services/<category>/service-<id>.sh`. The key fields that control deployment are:
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `SCRIPT_ID` | Unique identifier used in CLI commands | `"postgresql"` |
+| `SCRIPT_NAME` | Human-readable display name | `"PostgreSQL"` |
+| `SCRIPT_CATEGORY` | Category grouping (must match a category ID) | `"DATABASES"` |
+| `SCRIPT_PLAYBOOK` | Ansible playbook filename in `ansible/playbooks/` | `"040-database-postgresql.yml"` |
+| `SCRIPT_MANIFEST` | Kubernetes manifest (alternative to playbook) | `""` |
+| `SCRIPT_REMOVE_PLAYBOOK` | Ansible playbook for removal | `"040-remove-database-postgresql.yml"` |
+| `SCRIPT_CHECK_COMMAND` | Shell command that exits 0 if service is healthy | `"kubectl get pods ... \| grep -q Running"` |
+| `SCRIPT_REQUIRES` | Space-separated service IDs this service depends on | `"postgresql redis"` |
+| `SCRIPT_PRIORITY` | Deploy order — lower numbers deploy first (default: 50) | `"30"` |
+
+These are just the deployment-related fields. Services also have extended metadata for Backstage catalog generation, website documentation, and more.
+
+For the **complete field reference** with all metadata groups (deployment, extended, website), constraints, and examples, see:
+- **[Kubernetes Deployment Rules](../contributors/rules/kubernetes-deployment.md)** — full metadata specification
+- **[Adding a Service Guide](../contributors/guides/adding-a-service.md)** — step-by-step guide with field descriptions
+
+---
+
+## Related Documentation
+
+- **[Deploy System Overview](../contributors/architecture/deploy-system.md)** — High-level overview of deploying and managing services
+- **[UIS CLI Reference](../reference/uis-cli-reference.md)** — Complete command reference
+- **[Kubernetes Deployment Rules](../contributors/rules/kubernetes-deployment.md)** — Service metadata specification and deployment conventions
+- **[Adding a Service Guide](../contributors/guides/adding-a-service.md)** — How to create a new service

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-old-system-cleanup.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-old-system-cleanup.md
@@ -158,17 +158,27 @@ This investigation will produce multiple plans, each tackling a different part:
 
 **Implemented**: [PLAN-delete-old-deployment-system](../completed/PLAN-delete-old-deployment-system.md) (2026-03-17, PR #90)
 
-### Plan area: "How Deployment Works" documentation
-- Write page in `advanced/` covering:
-  - The execution flow: `./uis deploy` → service scanner discovers `uis/services/` → reads metadata → resolves dependencies and priority order → runs Ansible playbooks → verifies with health checks
-  - How `SCRIPT_PRIORITY` controls deployment order (lower = earlier)
-  - How `SCRIPT_REQUIRES` resolves dependency chains
-  - How `SCRIPT_PLAYBOOK` and `SCRIPT_REMOVE_PLAYBOOK` map to Ansible playbooks in `ansible/playbooks/`
-  - How `SCRIPT_CHECK_COMMAND` verifies deployment success
-  - How stacks group services and `enabled-services.conf` controls what gets deployed
-  - Reference the service metadata specification in `contributors/guides/adding-a-service.md` and `contributors/rules/kubernetes-deployment.md`
+### ~~Plan area: "How Deployment Works" documentation~~ — COMPLETED
+
+**Implemented**: [PLAN-how-deployment-works](../completed/PLAN-how-deployment-works.md) (2026-03-17)
 
 ### Plan area: Documentation gap filling
 - Review and fill gaps in service override customization docs
 - Review and fill gaps in stack creation docs
 - Ensure the getting-started path (install → first deploy → understand the system) is complete and consistent
+- **CI/CD pipelines and generator scripts** — contributor-facing documentation for the repo's own GitHub Actions workflows and the generator scripts they call. Currently undocumented:
+  - `generate-uis-docs.yml` — runs `uis-docs.sh`, `uis-docs-markdown.sh`, `uis-docs-plan-indexes.sh` on push to main; auto-commits generated files
+  - `test-uis.yml` — runs static tests, unit tests, JSON validation on PRs
+  - `docs.yml` — builds and deploys Docusaurus to GitHub Pages
+  - `build-uis-container.yml` — builds provision-host container image (multi-arch)
+  - `build-postgresql-container.yml` — builds PostgreSQL container image
+  - Generator scripts in `provision-host/uis/manage/`: `uis-docs.sh` (JSON), `uis-docs-markdown.sh` (Markdown pages), `uis-backstage-catalog.sh` (Backstage catalog YAML, not yet in CI/CD), `uis-docs-plan-indexes.sh` (plan indexes)
+  - Should go in `contributors/` — contributors need to know what's automated, what triggers it, and what files are auto-generated (so they don't manually edit them)
+- **Full system testing guide** — contributor-facing documentation for `./uis test-all` and the integration testing framework. Currently only mentioned briefly in the CLI reference and adding-a-service guide. No dedicated page explaining:
+  - How `test-all` works: deploy → verify → undeploy flow for every service
+  - How `integration-testing.sh` orchestrates the test suite
+  - How `./uis verify <service>` runs per-service E2E tests (Ansible verify playbooks)
+  - How to add verify tests for a new service (registering in `integration-testing.sh` and `uis-cli.sh`)
+  - Available flags: `--dry-run`, `--clean`, `--only <svc>`
+  - Current test coverage: which services have verify playbooks, which don't
+  - Should go in `contributors/guides/` — contributors need to know how to test their changes

--- a/website/docs/ai-developer/plans/backlog/STATUS-platform-roadmap.md
+++ b/website/docs/ai-developer/plans/backlog/STATUS-platform-roadmap.md
@@ -20,7 +20,7 @@ Items that still need work, grouped by priority.
 
 | # | Investigation | Status | Summary |
 |---|--------------|--------|---------|
-| 20 | [Old system cleanup & documentation gaps](INVESTIGATE-old-system-cleanup.md) | In Progress | ~~Delete dead `provision-host/kubernetes/`~~, ~~rename packages→services~~, write "How Deployment Works" page, fill doc gaps. Rename: [PLAN](../completed/PLAN-rename-packages-to-services.md). Deletion: [PLAN](../completed/PLAN-delete-old-deployment-system.md). |
+| 20 | [Old system cleanup & documentation gaps](INVESTIGATE-old-system-cleanup.md) | In Progress | ~~Delete dead `provision-host/kubernetes/`~~, ~~rename packages→services~~, ~~write "How Deployment Works" page~~, fill doc gaps. Rename: [PLAN](../completed/PLAN-rename-packages-to-services.md). Deletion: [PLAN](../completed/PLAN-delete-old-deployment-system.md). How Deployment Works: [PLAN](../completed/PLAN-how-deployment-works.md). |
 
 ### Priority 1: Infrastructure Hardening
 
@@ -87,6 +87,7 @@ Items where the work has been implemented.
 | — | [Backstage investigation](INVESTIGATE-backstage.md) | 2026-03-11 | Initial investigation — led to PLAN-001/002/004. |
 | — | [Rename packages→services](../completed/PLAN-rename-packages-to-services.md) | 2026-03-17 | Renamed `docs/packages/` → `docs/services/`, updated all links, scripts, and config. Part of [#20 Old system cleanup](INVESTIGATE-old-system-cleanup.md). |
 | — | [Delete old deployment system](../completed/PLAN-delete-old-deployment-system.md) | 2026-03-17 | Deleted `provision-host/kubernetes/` (60 scripts, ~6,149 lines), `scripts/packages/`, and `./uis provision` command. Part of [#20 Old system cleanup](INVESTIGATE-old-system-cleanup.md). |
+| — | [How Deployment Works](../completed/PLAN-how-deployment-works.md) | 2026-03-17 | User-facing doc page in `advanced/` covering deploy flow, dependencies, health checks, stacks, and metadata fields. Part of [#20 Old system cleanup](INVESTIGATE-old-system-cleanup.md). |
 
 ---
 

--- a/website/docs/ai-developer/plans/completed/PLAN-how-deployment-works.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-how-deployment-works.md
@@ -1,0 +1,172 @@
+# PLAN: "How Deployment Works" Documentation Page
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+**Created**: 2026-03-17
+**Status**: Completed (2026-03-17)
+**Parent**: [INVESTIGATE: Old System Cleanup & Documentation Gaps](../backlog/INVESTIGATE-old-system-cleanup.md)
+
+## Goal
+
+Write a user-facing "How Deployment Works" page in `docs/advanced/` that explains the full execution flow from `./uis deploy` to running pods — bridging the gap between the high-level overview in `contributors/architecture/deploy-system.md` and the contributor-level rules in `contributors/rules/kubernetes-deployment.md`.
+
+---
+
+## Why
+
+Users who want to understand what happens when they run `./uis deploy` have no single page that explains the flow end-to-end. The contributor docs cover the rules and conventions, but a user who just wants to understand the system (without contributing) has to piece it together from multiple files. This page gives them one place to read.
+
+---
+
+## What Exists Today
+
+| Document | Audience | What it covers |
+|----------|----------|---------------|
+| `contributors/architecture/deploy-system.md` | Users | High-level overview: commands, categories, dependencies, debugging. No internals. |
+| `contributors/rules/kubernetes-deployment.md` | Contributors | Full technical spec: metadata fields, scanner, deploy flow diagram, stacks, autostart. |
+| `contributors/guides/adding-a-service.md` | Contributors | 11-step guide for adding a service. |
+
+**The gap:** No user-facing page explains the execution flow, priority ordering, dependency resolution, health checks, or how stacks work under the hood.
+
+---
+
+## What the New Page Will Cover
+
+The page goes in `website/docs/advanced/how-deployment-works.md` and covers:
+
+1. **The execution flow** — what happens step-by-step when you run `./uis deploy <service>`:
+   - Service scanner discovers `provision-host/uis/services/` and locates the service definition
+   - Metadata file is sourced to load all `SCRIPT_*` variables
+   - Dependencies checked via `SCRIPT_REQUIRES` (each dependency verified with its `SCRIPT_CHECK_COMMAND`)
+   - Deployment executed: `SCRIPT_PLAYBOOK` → `ansible-playbook` or `SCRIPT_MANIFEST` → `kubectl apply`
+   - Post-deploy health check via `SCRIPT_CHECK_COMMAND`
+   - Service auto-enabled in `enabled-services.conf`
+
+2. **Deploy-all flow** — what `./uis deploy` (no argument) does:
+   - Reads `enabled-services.conf`
+   - Deploys each service in listed order
+   - Stops on first failure
+
+3. **Priority ordering** — how `SCRIPT_PRIORITY` controls deployment order (lower = earlier, default 50)
+
+4. **Dependency resolution** — how `SCRIPT_REQUIRES` works:
+   - Space-separated list of service IDs
+   - Each dependency is verified by running its `SCRIPT_CHECK_COMMAND`
+   - Deployment fails fast if any dependency is missing
+
+5. **Health checks** — how `SCRIPT_CHECK_COMMAND` verifies deployment:
+   - Runs after a 2-second delay post-deploy
+   - Failure is a warning, not a hard error
+   - Typically checks for Running pods via kubectl
+
+6. **Stacks** — how stacks group services:
+   - Defined in `lib/stacks.sh`
+   - Install deploys left-to-right (dependencies first)
+   - Remove undeploys in reverse order
+   - `--skip-optional` flag for optional services
+   - Available stacks: observability, ai-local, analytics
+
+7. **Undeploy flow** — three-tier removal strategy:
+   - `SCRIPT_REMOVE_PLAYBOOK` if set
+   - `SCRIPT_MANIFEST` kubectl delete if set
+   - Warning if no removal method found
+
+8. **Autostart** — how `enabled-services.conf` works with `enable`, `disable`, `sync`
+
+9. **Service metadata field reference** — brief explanation of the key deployment fields (`SCRIPT_ID`, `SCRIPT_PLAYBOOK`, `SCRIPT_REQUIRES`, `SCRIPT_PRIORITY`, `SCRIPT_CHECK_COMMAND`) with a prominent link to the complete field reference in `contributors/rules/kubernetes-deployment.md` (which has the full table of all metadata fields, constraints, and groups)
+
+10. **Cross-references** to:
+    - `contributors/rules/kubernetes-deployment.md` for the complete service metadata specification
+    - `contributors/guides/adding-a-service.md` for creating new services
+    - `reference/uis-cli-reference.md` for command details
+
+---
+
+## Scope
+
+### What changes
+
+| Area | What |
+|------|------|
+| New file | `website/docs/advanced/how-deployment-works.md` |
+| Sidebar | Add entry in `advanced/` section (via `_category_.json` or `sidebars.ts`) |
+| Cross-links | Add link from `contributors/architecture/deploy-system.md` "Related Documentation" section |
+| Cross-links | Add link from `getting-started/overview.md` if appropriate |
+
+### What does NOT change
+
+- No code changes — this is pure documentation
+- No changes to contributor docs (they stay as the authoritative reference)
+- No changes to CLI or deployment system
+
+---
+
+## Phases
+
+### Phase 1: Write the documentation page
+
+#### Tasks
+
+- [x] 1.1 Create `website/docs/advanced/how-deployment-works.md` with all sections listed above
+- [x] 1.2 Include a flow diagram (text-based, using code blocks) showing the deploy sequence
+- [x] 1.3 Include a table of current stacks with their services
+- [x] 1.4 Include examples showing real service metadata (e.g., PostgreSQL) to illustrate concepts
+
+#### Validation
+
+`cd website && npm run build` passes with no broken links. User confirms content is accurate and complete.
+
+---
+
+### Phase 2: Add cross-references
+
+#### Tasks
+
+- [x] 2.1 Add sidebar entry for the new page in `docs/advanced/` (check `_category_.json` or `sidebars.ts`)
+- [x] 2.2 Add link to the new page from `contributors/architecture/deploy-system.md` "Related Documentation" section
+- [x] 2.3 Check if `getting-started/overview.md` or `getting-started/architecture.md` should link to this page — architecture.md has no Related section and is high-level; left as-is
+
+#### Validation
+
+`cd website && npm run build` passes. All cross-links work. User confirms.
+
+---
+
+### Phase 3: Update investigation and roadmap
+
+#### Tasks
+
+- [x] 3.1 Mark "Plan area: How Deployment Works documentation" as COMPLETED in `INVESTIGATE-old-system-cleanup.md` with link to this plan
+- [x] 3.2 Update `STATUS-platform-roadmap.md` — added strikethrough, plan link in Priority 0, and entry in Completed table
+
+#### Validation
+
+User confirms updates are correct.
+
+---
+
+## Acceptance Criteria
+
+- [x] `website/docs/advanced/how-deployment-works.md` exists and covers all 10 topics listed above
+- [x] Page is accessible in the docs sidebar under "Advanced"
+- [x] `npm run build` passes with zero broken links
+- [x] Cross-references added from at least `deploy-system.md`
+- [x] Investigation file updated with completion link
+
+---
+
+## Files to Create
+
+```
+website/docs/advanced/how-deployment-works.md
+```
+
+## Files to Modify
+
+```
+website/docs/contributors/architecture/deploy-system.md    # Add cross-link
+website/docs/ai-developer/plans/backlog/INVESTIGATE-old-system-cleanup.md  # Mark plan area complete
+website/docs/ai-developer/plans/backlog/STATUS-platform-roadmap.md         # Update if needed
+```

--- a/website/docs/contributors/architecture/deploy-system.md
+++ b/website/docs/contributors/architecture/deploy-system.md
@@ -112,6 +112,7 @@ k9s
 
 ## Related Documentation
 
+- **[How Deployment Works](../../advanced/how-deployment-works.md)** — Deep dive into the deploy flow, dependency resolution, health checks, and stacks
 - **[Architecture](../../getting-started/architecture.md)** — System architecture overview
 - **[Kubernetes Deployment Rules](../rules/kubernetes-deployment.md)** — Conventions for writing playbooks
 - **[Provisioning Rules](../rules/provisioning.md)** — Script and playbook standards

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -195,6 +195,7 @@ const sidebars: SidebarsConfig = {
         description: 'Host configuration, platform setup, and infrastructure details.',
       },
       items: [
+        'advanced/how-deployment-works',
         {
           type: 'category',
           label: 'Hosts & Platforms',


### PR DESCRIPTION
## Summary
- New user-facing documentation page at `docs/advanced/how-deployment-works.md` explaining the full deploy flow internals
- Covers: service discovery, dependency resolution, priority ordering, health checks, stacks, undeploy, autostart, and metadata field reference
- Added sidebar entry under Advanced, cross-link from deploy-system.md
- Updated investigation (#20) and platform roadmap — 3 of 4 plan areas now complete

## Test plan
- [x] `npm run build` passes with zero broken links
- [x] Page appears in sidebar under Advanced
- [x] All cross-links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)