### PR TITLE
chore: update all refs from terchris to helpers-no

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
     // DevContainer Toolbox — pre-built image mode
-    // Docs: https://github.com/terchris/devcontainer-toolbox
+    // Docs: https://github.com/helpers-no/devcontainer-toolbox
     //
     // overrideCommand: false is REQUIRED so VS Code doesn't bypass the ENTRYPOINT.
     // The entrypoint handles all startup — no lifecycle hooks needed.
-    "image": "ghcr.io/terchris/devcontainer-toolbox:latest",
+    "image": "ghcr.io/helpers-no/devcontainer-toolbox:latest",
     "overrideCommand": false,
 
     // VPN capabilities

--- a/.github/workflows/build-postgresql-container.yml
+++ b/.github/workflows/build-postgresql-container.yml
@@ -12,7 +12,7 @@
 #   - Manual dispatch with custom version
 #   - Release tags
 #
-# Registry: ghcr.io/terchris/urbalurba-postgresql
+# Registry: ghcr.io/helpers-no/urbalurba-postgresql
 # Supported Architectures: linux/amd64, linux/arm64
 
 name: 🐘 Build PostgreSQL Container

--- a/containers/postgresql/Dockerfile
+++ b/containers/postgresql/Dockerfile
@@ -44,8 +44,8 @@ FROM bitnami/postgresql:16
 LABEL org.opencontainers.image.title="Urbalurba PostgreSQL"
 LABEL org.opencontainers.image.description="PostgreSQL with pgvector, PostGIS, hstore, and ltree for Urbalurba Infrastructure"
 LABEL org.opencontainers.image.vendor="Urbalurba Infrastructure"
-LABEL org.opencontainers.image.source="https://github.com/terchris/urbalurba-infrastructure"
-LABEL org.opencontainers.image.documentation="https://github.com/terchris/urbalurba-infrastructure/blob/main/containers/postgresql/readme-postgres-container.md"
+LABEL org.opencontainers.image.source="https://github.com/helpers-no/urbalurba-infrastructure"
+LABEL org.opencontainers.image.documentation="https://github.com/helpers-no/urbalurba-infrastructure/blob/main/containers/postgresql/readme-postgres-container.md"
 
 # ------------------------------------------------------------------------------
 # SYSTEM PACKAGE INSTALLATION

--- a/containers/postgresql/build.sh
+++ b/containers/postgresql/build.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-IMAGE_NAME="ghcr.io/terchris/urbalurba-postgresql"
+IMAGE_NAME="ghcr.io/helpers-no/urbalurba-postgresql"
 VERSION=${VERSION:-"latest"}
 PUSH=${PUSH:-"false"}
 PLATFORM=${PLATFORM:-"linux/amd64,linux/arm64"}

--- a/manifests/042-database-postgresql-config.yaml
+++ b/manifests/042-database-postgresql-config.yaml
@@ -4,7 +4,7 @@
 # PostgreSQL Helm chart configuration using custom Urbalurba PostgreSQL container
 # with pre-built AI and geospatial extensions for modern data-intensive applications.
 #
-# Custom Container: ghcr.io/terchris/urbalurba-postgresql:latest
+# Custom Container: ghcr.io/helpers-no/urbalurba-postgresql:latest
 # - Based on Bitnami PostgreSQL 16 with additional extensions
 # - Pre-built with pgvector, PostGIS, hstore, ltree, and other essential extensions
 # - Multi-architecture support (amd64/arm64) with security scanning
@@ -64,7 +64,7 @@ global:
 
 image:
   registry: ghcr.io
-  repository: terchris/urbalurba-postgresql
+  repository: helpers-no/urbalurba-postgresql
   tag: latest
   pullPolicy: Always
 

--- a/provision-host/uis/manage/uis-backstage-catalog.sh
+++ b/provision-host/uis/manage/uis-backstage-catalog.sh
@@ -281,7 +281,7 @@ metadata:
     - url: https://uis.sovereignsky.no/docs
       title: UIS Documentation
       icon: docs
-    - url: https://github.com/terchris/urbalurba-infrastructure
+    - url: https://github.com/helpers-no/urbalurba-infrastructure
       title: GitHub Repository
       icon: github
 spec:

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -1274,7 +1274,7 @@ cmd_argocd_register() {
         echo "  <repo-url>  Full GitHub repository URL (https://...)" >&2
         echo "" >&2
         echo "Examples:" >&2
-        echo "  uis argocd register hello-world https://github.com/terchris/urb-dev-typescript-hello-world" >&2
+        echo "  uis argocd register hello-world https://github.com/helpers-no/urb-dev-typescript-hello-world" >&2
         echo "  uis argocd register my-app https://github.com/myorg/my-k8s-app" >&2
         exit "$EXIT_GENERAL_ERROR"
     fi

--- a/uis
+++ b/uis
@@ -9,7 +9,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_NAME="uis-provision-host"
-IMAGE="${UIS_IMAGE:-ghcr.io/terchris/uis-provision-host:latest}"
+IMAGE="${UIS_IMAGE:-ghcr.io/helpers-no/uis-provision-host:latest}"
 KUBECONFIG_DIR="${UIS_KUBECONFIG_DIR:-$HOME/.kube}"
 
 # Detect if we have a TTY for interactive commands
@@ -48,7 +48,7 @@ check_image() {
     fi
 
     log_info "Build it with: docker build -f Dockerfile.uis-provision-host -t uis-provision-host:local ."
-    log_info "Or pull from registry: export UIS_IMAGE=ghcr.io/terchris/uis-provision-host:latest"
+    log_info "Or pull from registry: export UIS_IMAGE=ghcr.io/helpers-no/uis-provision-host:latest"
     exit 1
 }
 
@@ -208,7 +208,7 @@ show_usage() {
     echo "  ./uis exec kubectl get pods    # Run kubectl command"
     echo ""
     echo "Environment variables:"
-    echo "  UIS_IMAGE          Override the container image (default: ghcr.io/terchris/uis-provision-host:latest)"
+    echo "  UIS_IMAGE          Override the container image (default: ghcr.io/helpers-no/uis-provision-host:latest)"
     echo "  UIS_KUBECONFIG_DIR Override kubeconfig directory (default: \$HOME/.kube)"
 }
 

--- a/uis.ps1
+++ b/uis.ps1
@@ -6,7 +6,7 @@
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ContainerName = "uis-provision-host"
-$Image = if ($env:UIS_IMAGE) { $env:UIS_IMAGE } else { "ghcr.io/terchris/uis-provision-host:latest" }
+$Image = if ($env:UIS_IMAGE) { $env:UIS_IMAGE } else { "ghcr.io/helpers-no/uis-provision-host:latest" }
 $KubeconfigDir = if ($env:UIS_KUBECONFIG_DIR) { $env:UIS_KUBECONFIG_DIR } else { Join-Path $HOME ".kube" }
 
 # Detect if we have an interactive terminal
@@ -33,7 +33,7 @@ function Check-Image {
     }
 
     Log-Info "Build it with: docker build -f Dockerfile.uis-provision-host -t uis-provision-host:local ."
-    Log-Info "Or pull from registry: `$env:UIS_IMAGE = 'ghcr.io/terchris/uis-provision-host:latest'"
+    Log-Info "Or pull from registry: `$env:UIS_IMAGE = 'ghcr.io/helpers-no/uis-provision-host:latest'"
     exit 1
 }
 

--- a/website/docs/about.md
+++ b/website/docs/about.md
@@ -35,7 +35,7 @@ UIS packages 26+ open-source services into deployable categories:
 Install the UIS CLI and deploy your first service in minutes:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+curl -fsSL https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis -o uis
 chmod +x uis
 ./uis start
 ./uis deploy postgresql
@@ -45,7 +45,7 @@ See the [Getting Started guide](./getting-started/overview.md) for full instruct
 
 ## Connect With Us
 
-- **GitHub**: [terchris/urbalurba-infrastructure](https://github.com/terchris/urbalurba-infrastructure)
+- **GitHub**: [helpers-no/urbalurba-infrastructure](https://github.com/helpers-no/urbalurba-infrastructure)
 - **SovereignSky**: [sovereignsky.no](https://sovereignsky.no)
 - **Helpers.no**: [helpers.no](https://helpers.no)
 

--- a/website/docs/ai-developer/README.md
+++ b/website/docs/ai-developer/README.md
@@ -71,7 +71,7 @@ plans/
 
 ## Related Documentation
 
-- [CLAUDE.md](https://github.com/terchris/urbalurba-infrastructure/blob/main/CLAUDE.md) - Project-specific Claude Code instructions (in repo root)
+- [CLAUDE.md](https://github.com/helpers-no/urbalurba-infrastructure/blob/main/CLAUDE.md) - Project-specific Claude Code instructions (in repo root)
 - [Adding a Service Guide](../contributors/guides/adding-a-service.md) - Complete walkthrough for adding a new service to UIS
 - [Services documentation](../services/ai/index.md) - Service documentation
 - [Hosts documentation](../advanced/hosts/index.md) - Infrastructure host setup

--- a/website/docs/ai-developer/plans/backlog/PLAN-transfer-to-helpers-no.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-transfer-to-helpers-no.md
@@ -1,0 +1,142 @@
+# Plan: Transfer urbalurba-infrastructure to helpers-no
+
+## Status: Backlog
+
+**Goal**: Transfer this repo from `terchris/urbalurba-infrastructure` to `helpers-no/urbalurba-infrastructure` with zero downtime.
+
+**Priority**: Medium
+
+**Last Updated**: 2026-03-18
+
+**Overall plan**: See `/Users/terje.christensen/learn/projects-2026/testing/github-helpers-no/INVESTIGATE-move-repos-to-helpers-no.md`
+
+**Report back**: After completing each phase, update the overall plan's checklist in the file above. Mark the urbalurba-infrastructure line as complete when all phases are done.
+
+---
+
+## Prerequisites
+
+- **PLAN-transfer-to-helpers-no** in devcontainer-toolbox must be complete (container image at `ghcr.io/helpers-no/`)
+- Recommended: sovereignsky-site and dev-templates transfers complete first
+
+**This repo transfers last** — it is the most complex and depends on devcontainer-toolbox.
+
+---
+
+## Problem
+
+The repo lives under `terchris/urbalurba-infrastructure`. There are 85 references to `terchris` across 41 files. This repo also publishes its own container images (postgresql) to `ghcr.io/terchris/` and has GitHub Actions workflows that need updating.
+
+---
+
+## Phase 1: Create branch and fix references
+
+### Tasks
+
+- [x] 1.1 Create branch `move-to-helpers-no`
+- [x] 1.2 Replace `ghcr.io/terchris/devcontainer-toolbox` → `ghcr.io/helpers-no/devcontainer-toolbox` in:
+  - `.devcontainer/devcontainer.json`
+- [x] 1.3 Replace `ghcr.io/terchris/urbalurba-` → `ghcr.io/helpers-no/urbalurba-` in own container images:
+  - `containers/postgresql/build.sh`
+  - `containers/postgresql/Dockerfile`
+  - `manifests/042-database-postgresql-config.yaml`
+- [x] 1.4 Update GitHub Actions workflow:
+  - `.github/workflows/build-postgresql-container.yml` — update image registry path
+- [x] 1.5 Replace `terchris/urbalurba-infrastructure` → `helpers-no/urbalurba-infrastructure` in install/CLI scripts:
+  - `uis` script
+  - `uis.ps1`
+  - `website/static/install.sh`
+  - `website/static/install.ps1`
+  - `website/static/uis` and `website/static/uis.ps1`
+  - `provision-host/uis/manage/uis-cli.sh`
+  - `provision-host/uis/manage/uis-backstage-catalog.sh`
+- [x] 1.6 Update docs/website references (~15 active doc files):
+  - `website/docusaurus.config.ts`
+  - `website/docs/` — about, index, getting-started, contributors, services, developing, reference, ai-developer/README
+- [x] 1.7 `.gitignore` — `/terchris` entry kept (contains local secrets folder)
+- [ ] 1.8 Commit all changes to branch (do NOT merge)
+
+### Validation
+
+User confirms all references are updated. Run: `grep -r "terchris" --include="*.sh" --include="*.ps1" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.ts" .` should return zero critical hits.
+
+---
+
+## Phase 2: Transfer repo and update container images
+
+### Tasks
+
+- [ ] 2.1 Transfer repo on GitHub: Settings → Transfer → `helpers-no`
+- [ ] 2.2 Verify GitHub redirect works
+- [ ] 2.3 Check GH Actions has permissions to publish to `ghcr.io/helpers-no/` (postgresql image)
+- [ ] 2.4 Merge `move-to-helpers-no` branch
+- [ ] 2.5 Trigger container image builds — verify postgresql image publishes under `ghcr.io/helpers-no/`
+
+### Validation
+
+Repo is at `https://github.com/helpers-no/urbalurba-infrastructure`. Container images publish correctly.
+
+---
+
+## Phase 3: Re-enable GitHub Pages
+
+### Tasks
+
+- [ ] 3.1 Re-enable GitHub Pages in repo settings
+- [ ] 3.2 Re-add custom domain: `dct.sovereignsky.no`
+- [ ] 3.3 Verify site is live at https://dct.sovereignsky.no/
+
+### Validation
+
+User confirms website loads correctly.
+
+---
+
+## Phase 4: Update local clone and Kubernetes manifests
+
+### Tasks
+
+- [ ] 4.1 Update local git remote: `git remote set-url origin https://github.com/helpers-no/urbalurba-infrastructure.git`
+- [ ] 4.2 If any running Kubernetes clusters reference `ghcr.io/terchris/urbalurba-` images, update the manifests and redeploy
+
+### Validation
+
+`git remote -v` shows `helpers-no/urbalurba-infrastructure`. Running services use new image paths.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Repo is at `https://github.com/helpers-no/urbalurba-infrastructure`
+- [ ] Container images publish to `ghcr.io/helpers-no/`
+- [ ] Website is live at `dct.sovereignsky.no`
+- [ ] Install scripts (`uis`, `uis.ps1`) work from new location
+- [ ] GitHub Actions workflows run successfully
+- [ ] No remaining `terchris` references in critical scripts/manifests
+- [ ] Old URL redirects work
+
+---
+
+## Files to Modify
+
+**Container image refs:**
+- `.devcontainer/devcontainer.json`
+- `containers/postgresql/build.sh`
+- `containers/postgresql/Dockerfile`
+- `manifests/042-database-postgresql-config.yaml`
+
+**GitHub Actions:**
+- `.github/workflows/build-postgresql-container.yml`
+
+**Install/CLI scripts:**
+- `uis`
+- `uis.ps1`
+- `website/static/install.sh`
+- `website/static/install.ps1`
+- `provision-host/uis/manage/uis-cli.sh`
+- `provision-host/uis/manage/uis-backstage-catalog.sh`
+
+**Config/docs:**
+- `.gitignore`
+- `website/docusaurus.config.ts`
+- ~25 website doc files

--- a/website/docs/contributors/index.md
+++ b/website/docs/contributors/index.md
@@ -7,7 +7,7 @@ Welcome! UIS is an open-source project and we appreciate contributions of all ki
 | Contribution | Description | Good first step |
 |-------------|-------------|-----------------|
 | **Add a service** | Package a new open-source service for UIS | Read the [Adding a Service Guide](./guides/adding-a-service.md) |
-| **Fix bugs** | Fix deployment issues, broken configs, or edge cases | Check [GitHub Issues](https://github.com/terchris/urbalurba-infrastructure/issues) |
+| **Fix bugs** | Fix deployment issues, broken configs, or edge cases | Check [GitHub Issues](https://github.com/helpers-no/urbalurba-infrastructure/issues) |
 | **Improve docs** | Fix errors, add examples, clarify instructions | Read [Documentation Standards](./rules/documentation.md) |
 | **File issues** | Report bugs or suggest features | Open an issue on GitHub |
 

--- a/website/docs/developing/argocd-commands.md
+++ b/website/docs/developing/argocd-commands.md
@@ -21,7 +21,7 @@ uis argocd register <name> <repo-url>
 **Example:**
 
 ```bash
-uis argocd register hello-world https://github.com/terchris/urb-dev-typescript-hello-world
+uis argocd register hello-world https://github.com/helpers-no/urb-dev-typescript-hello-world
 ```
 
 ### What happens during registration
@@ -40,7 +40,7 @@ The app name is independent of the repository name. This lets you use short, mea
 
 ```bash
 # Repo has a long name, but you access it as "hello-world"
-uis argocd register hello-world https://github.com/terchris/urb-dev-typescript-hello-world
+uis argocd register hello-world https://github.com/helpers-no/urb-dev-typescript-hello-world
 
 # Access at: http://hello-world.localhost
 ```
@@ -83,7 +83,7 @@ Shows all registered ArgoCD applications with their health and sync status:
 ArgoCD Applications (2 registered)
 ===============================================
 Name:   hello-world
-Repo:   https://github.com/terchris/urb-dev-typescript-hello-world
+Repo:   https://github.com/helpers-no/urb-dev-typescript-hello-world
 Health: Healthy
 Sync:   Synced
 ---

--- a/website/docs/developing/template-catalog.md
+++ b/website/docs/developing/template-catalog.md
@@ -41,4 +41,4 @@ Templates use two build approaches depending on the language:
 
 ## Full list
 
-The templates are maintained in the [urbalurba-dev-templates](https://github.com/terchris/urbalurba-dev-templates) repository. Check there for the latest templates and detailed README files for each one.
+The templates are maintained in the [urbalurba-dev-templates](https://github.com/helpers-no/dev-templates) repository. Check there for the latest templates and detailed README files for each one.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -38,14 +38,14 @@ The `uis` script is the only file you need. The container image with all tools i
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+curl -fsSL https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis -o uis
 chmod +x uis
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
 ```
 
 ## Step 3: Start UIS
@@ -101,14 +101,14 @@ If you need new CLI commands that were added after your initial install, update 
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+curl -fsSL https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis -o uis
 chmod +x uis
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
 ```
 
 Then run `./uis pull` to update the container.

--- a/website/docs/getting-started/overview.md
+++ b/website/docs/getting-started/overview.md
@@ -23,14 +23,14 @@ Download the `uis` CLI script — this is the only file you need:
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+curl -fsSL https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis -o uis
 chmod +x uis
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
 ```
 
 ## Start the Provision Host

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -71,7 +71,7 @@ Download the `uis` script and start — the container image is pulled automatica
 
 ```bash
 # Download the UIS CLI
-curl -fsSL https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis -o uis
+curl -fsSL https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis -o uis
 chmod +x uis
 
 # Start the UIS provision host (pulls the container image automatically)
@@ -88,7 +88,7 @@ chmod +x uis
 
 ```powershell
 # Download the UIS CLI
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/terchris/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/helpers-no/urbalurba-infrastructure/main/uis.ps1" -OutFile "uis.ps1"
 
 # Start the UIS provision host (pulls the container image automatically)
 .\uis.ps1 start

--- a/website/docs/reference/uis-cli-reference.md
+++ b/website/docs/reference/uis-cli-reference.md
@@ -145,5 +145,5 @@ Manage configurations for different deployment targets.
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `UIS_IMAGE` | Override container image | `ghcr.io/terchris/uis-provision-host:latest` |
+| `UIS_IMAGE` | Override container image | `ghcr.io/helpers-no/uis-provision-host:latest` |
 | `UIS_KUBECONFIG_DIR` | Override kubeconfig directory | `$HOME/.kube` |

--- a/website/docs/services/databases/index.md
+++ b/website/docs/services/databases/index.md
@@ -32,4 +32,4 @@ Other databases are deployed on demand when specific applications need them.
 
 ## Custom PostgreSQL Container
 
-UIS uses a custom PostgreSQL container (`ghcr.io/terchris/urbalurba-postgresql`) with 8 pre-built extensions including pgvector (AI embeddings), PostGIS (geospatial), and more. See [PostgreSQL container details](./postgresql-container.md).
+UIS uses a custom PostgreSQL container (`ghcr.io/helpers-no/urbalurba-postgresql`) with 8 pre-built extensions including pgvector (AI embeddings), PostGIS (geospatial), and more. See [PostgreSQL container details](./postgresql-container.md).

--- a/website/docs/services/databases/postgresql-container.md
+++ b/website/docs/services/databases/postgresql-container.md
@@ -36,7 +36,7 @@ The standard Bitnami PostgreSQL image doesn't include certain extensions that ar
 ## Container Details
 
 - **Base Image**: `bitnami/postgresql:16`
-- **Registry**: `ghcr.io/terchris/urbalurba-postgresql`
+- **Registry**: `ghcr.io/helpers-no/urbalurba-postgresql`
 - **Architectures**: `linux/amd64`, `linux/arm64`
 - **Security**: Runs as non-root user (UID 1001)
 - **Optimization**: Multi-stage build for minimal size
@@ -121,7 +121,7 @@ docker run -d --name postgres-test \
   -e POSTGRESQL_POSTGRES_PASSWORD=testpass123 \
   -e POSTGRESQL_DATABASE=testdb \
   -p 5432:5432 \
-  ghcr.io/terchris/urbalurba-postgresql:latest
+  ghcr.io/helpers-no/urbalurba-postgresql:latest
 
 # Wait for PostgreSQL to be ready
 docker exec postgres-test pg_isready -U postgres
@@ -164,7 +164,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: ghcr.io/terchris/urbalurba-postgresql:latest
+        image: ghcr.io/helpers-no/urbalurba-postgresql:latest
 ```
 
 ### In Ansible Playbooks
@@ -178,7 +178,7 @@ Reference in `ansible/playbooks/040-database-postgresql.yml`:
         template:
           spec:
             containers:
-            - image: ghcr.io/terchris/urbalurba-postgresql:latest
+            - image: ghcr.io/helpers-no/urbalurba-postgresql:latest
 ```
 
 ## 🔄 CI/CD Pipeline with GitHub Actions
@@ -335,9 +335,9 @@ Each workflow run generates:
 
 ## Image Tags
 
-- `ghcr.io/terchris/urbalurba-postgresql:latest` - Latest stable build
-- `ghcr.io/terchris/urbalurba-postgresql:v1.0.0` - Specific version
-- `ghcr.io/terchris/urbalurba-postgresql:pr-123` - Pull request builds
+- `ghcr.io/helpers-no/urbalurba-postgresql:latest` - Latest stable build
+- `ghcr.io/helpers-no/urbalurba-postgresql:v1.0.0` - Specific version
+- `ghcr.io/helpers-no/urbalurba-postgresql:pr-123` - Pull request builds
 
 ## Multi-Architecture Support
 
@@ -393,7 +393,7 @@ For ARM64 production deployments, validate manually:
 docker run --rm \
   -e POSTGRESQL_PASSWORD=testpass \
   -e POSTGRESQL_DATABASE=testdb \
-  ghcr.io/terchris/urbalurba-postgresql:latest \
+  ghcr.io/helpers-no/urbalurba-postgresql:latest \
   psql -U postgres -d testdb -c "CREATE EXTENSION vector; SELECT version();"
 ```
 

--- a/website/docs/services/databases/postgresql.md
+++ b/website/docs/services/databases/postgresql.md
@@ -21,7 +21,7 @@ Open-source relational database with pre-built AI and geospatial extensions.
 
 PostgreSQL is the primary database in UIS. It powers Authentik (identity), Open WebUI (AI chat), LiteLLM (API gateway), Unity Catalog (data governance), and pgAdmin (database management).
 
-UIS deploys a custom PostgreSQL container (`ghcr.io/terchris/urbalurba-postgresql`) that includes 8 pre-built extensions:
+UIS deploys a custom PostgreSQL container (`ghcr.io/helpers-no/urbalurba-postgresql`) that includes 8 pre-built extensions:
 
 - **pgvector** — vector similarity search for AI embeddings
 - **PostGIS** — geospatial data types and queries
@@ -63,7 +63,7 @@ PostgreSQL configuration is in `manifests/042-database-postgresql-config.yaml`. 
 
 | Setting | Value | Notes |
 |---------|-------|-------|
-| Image | `ghcr.io/terchris/urbalurba-postgresql` | Custom container with extensions |
+| Image | `ghcr.io/helpers-no/urbalurba-postgresql` | Custom container with extensions |
 | Storage | `8Gi` PVC | Persistent data across restarts |
 | Port | `5432` | Standard PostgreSQL port |
 | Memory | `240Mi` request, `512Mi` limit | |
@@ -101,7 +101,7 @@ kubectl logs -l app.kubernetes.io/name=postgresql
 ```
 
 **Custom image pull fails:**
-The custom container is pulled from `ghcr.io/terchris/urbalurba-postgresql`. Check that the image is accessible:
+The custom container is pulled from `ghcr.io/helpers-no/urbalurba-postgresql`. Check that the image is accessible:
 ```bash
 kubectl get pod postgresql-0 -o yaml | grep -A 3 "image:"
 ```

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 // GitHub organization and repository from environment or defaults
-const GITHUB_ORG = process.env.GITHUB_ORG || 'terchris';
+const GITHUB_ORG = process.env.GITHUB_ORG || 'helpers-no';
 const GITHUB_REPO = process.env.GITHUB_REPO || 'urbalurba-infrastructure';
 
 const config: Config = {

--- a/website/static/install.ps1
+++ b/website/static/install.ps1
@@ -68,7 +68,7 @@ if (-not (Test-DockerRunning)) {
 Write-Info "Docker is available"
 
 # Pull container image
-$Image = "ghcr.io/terchris/uis-provision-host:latest"
+$Image = "ghcr.io/helpers-no/uis-provision-host:latest"
 Write-Info "Pulling UIS container image..."
 Write-Host "  This may take a few minutes (~2GB download)"
 Write-Host ""

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -137,7 +137,7 @@ check_docker_running
 check_disk_space
 
 # Pull container image
-IMAGE="ghcr.io/terchris/uis-provision-host:latest"
+IMAGE="ghcr.io/helpers-no/uis-provision-host:latest"
 log_info "Pulling UIS container image..."
 echo "  This may take a few minutes (~2GB download)"
 echo ""

--- a/website/static/uis
+++ b/website/static/uis
@@ -24,7 +24,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_NAME="uis-provision-host"
-IMAGE="${UIS_IMAGE:-ghcr.io/terchris/uis-provision-host:latest}"
+IMAGE="${UIS_IMAGE:-ghcr.io/helpers-no/uis-provision-host:latest}"
 
 # Colors for output
 RED='\033[0;31m'

--- a/website/static/uis.ps1
+++ b/website/static/uis.ps1
@@ -14,7 +14,7 @@ param(
 )
 
 $ContainerName = "uis-provision-host"
-$Image = if ($env:UIS_IMAGE) { $env:UIS_IMAGE } else { "ghcr.io/terchris/uis-provision-host:latest" }
+$Image = if ($env:UIS_IMAGE) { $env:UIS_IMAGE } else { "ghcr.io/helpers-no/uis-provision-host:latest" }
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # Helper functions


### PR DESCRIPTION
## Summary
- Replace all `ghcr.io/terchris/` container image references with `ghcr.io/helpers-no/`
- Update GitHub repo URLs from `terchris/urbalurba-infrastructure` to `helpers-no/urbalurba-infrastructure`
- Update install scripts, CLI wrappers, docs, and config for new org location
- 26 files updated across container configs, scripts, docs, and website

## Test plan
- [x] `npm run build` passes with zero broken links
- [x] `grep -r "ghcr.io/terchris"` returns zero hits in active source files
- [ ] Container image builds publish to `ghcr.io/helpers-no/`
- [ ] GitHub Pages re-enabled with custom domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)