### PR TITLE
chore(postgrest): bump pinned image v12.2.3 → v14.10

### DIFF
--- a/ansible/playbooks/templates/088-postgrest-config.yml.j2
+++ b/ansible/playbooks/templates/088-postgrest-config.yml.j2
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: postgrest
-          image: postgrest/postgrest:v12.2.3
+          image: postgrest/postgrest:v14.10
           imagePullPolicy: IfNotPresent
           ports:
             - name: api

--- a/provision-host/uis/services/integration/service-postgrest.sh
+++ b/provision-host/uis/services/integration/service-postgrest.sh
@@ -29,8 +29,11 @@ SCRIPT_CONFIGURABLE="true"
 SCRIPT_PRIORITY="50"
 
 # === Deployment Details (Optional) ===
-# Image pinned 2026-04-29 per INVESTIGATE-version-pinning.md
-SCRIPT_IMAGE="postgrest/postgrest:v12.2.3"
+# Image pinned to latest stable 2026-04-29 per INVESTIGATE-version-pinning.md.
+# v14.x still emits Swagger 2.0 (a.k.a. OpenAPI 2.0) at GET /; v15+ may switch
+# to OpenAPI 3.x. PostgREST follows MAJOR.PATCH versioning; only even majors
+# are released. Upgrade by bumping this tag and re-running Phase 6 validation.
+SCRIPT_IMAGE="postgrest/postgrest:v14.10"
 SCRIPT_NAMESPACE="postgrest"
 
 # === Extended Metadata (Optional) ===

--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -336,7 +336,7 @@
     ,"removePlaybook": "088-remove-postgrest.yml"
     ,"requires": ["postgresql"]
     ,"namespace": "postgrest"
-    ,"image": "postgrest/postgrest:v12.2.3"
+    ,"image": "postgrest/postgrest:v14.10"
     ,"configurable": true
     ,"multiInstance": true
   }


### PR DESCRIPTION
## Summary

Follow-up to [#132](https://github.com/helpers-no/urbalurba-infrastructure/pull/132). PLAN-002 pinned PostgREST `v12.2.3` based on a stale read of the release page; upstream latest is `v14.10` (released 2026-04-16, two majors ahead). PostgREST follows MAJOR.PATCH versioning where only even majors ship, so v14 is the current stable line.

## Why ship now

- v12 will fall further behind security/perf fixes; v14 is two years of upstream work.
- Atlas's PostgREST integration work (their PLAN-004 `api_v1` wrapper) hasn't landed in production yet — easier to bump now than after consumers are live on v12.
- The format response wording we shipped in [`98627ab`](https://github.com/helpers-no/urbalurba-infrastructure/commit/98627ab) (Swagger 2.0 / OpenAPI 2.0, not OpenAPI 3.0) stays correct on v14 — release notes still reference "OpenAPI 2.0 format" fixes through v14.x.

## Breaking change review

v13 + v14 breaking changes that could affect us:

| Change | Affects us? |
|---|---|
| Drop PG ≤12 support | No — we run PG 16+ |
| `jwt-cache-max-lifetime` → `jwt-cache-max-entries` | No — we don't set this |
| `log-query` config: string → boolean | No — we don't set this |
| Drop `Prefer: params=single-object` | No — we don't use it |
| Drop limited updates/deletes | No — read-only via `web_anon` |
| Drop runtime-config admin endpoint | No — we don't use admin config |
| Fail to start on invalid `db-schemas` | Already works (we set `api_v1`) |
| JWT `kid` validation | No — JWT deferred to UIS PLAN-004 |

Env vars (`PGRST_DB_URI`, `PGRST_DB_SCHEMAS`, `PGRST_DB_ANON_ROLE`, `PGRST_ADMIN_SERVER_PORT`, `PGRST_SERVER_CORS_ALLOWED_ORIGINS`), `/live` + `/ready` admin endpoints, and the `pgrst` NOTIFY channel are all stable across v12 → v14. Verified by Phase 6 retest.

## Files changed

- `provision-host/uis/services/integration/service-postgrest.sh` — `SCRIPT_IMAGE` bumped, comment expanded with PostgREST's MAJOR.PATCH versioning policy.
- `ansible/playbooks/templates/088-postgrest-config.yml.j2` — image hardcode bumped to match (the template hardcodes the tag rather than reading from the metadata flag — minor wart, kept in sync manually).
- `website/src/data/services.json` — regenerated.

## Test plan

Re-ran PLAN-002 Phase 6 image-sensitive checks against `uis-provision-host:local` rebuilt with v14.10. All seven checks pass:

- [x] `./uis deploy postgrest --app testapp` reaches Available 2/2 within 120s
- [x] `kubectl get pod ...` reports image `postgrest/postgrest:v14.10`
- [x] `curl http://api-testapp.localhost/ | jq` returns `{"swagger":"2.0","openapi":null,"version":"14.10"}` — `.info.version` is the smoking gun
- [x] `GET /kommune` returns 3 rows from `api_v1.kommune`
- [x] `GET /_internal_secrets` returns 404 (hidden table outside `api_v1`)
- [x] CORS preflight returns `Access-Control-Allow-Origin: *`
- [x] `NOTIFY pgrst, 'reload schema'` exposes a newly-added view without restart
- [x] Teardown clean: namespace empty, no leftover roles, test database dropped

Transcript: `helpers-no/testing/uis1/talk/talk.md` (current session).

## Out of scope (follow-ups)

- **Single source of truth for image tag.** The Jinja template hardcodes the tag; it should read from `SCRIPT_IMAGE` (or a separate template var). Tracked as tech debt.
- **Purge UX nit.** `./uis configure postgrest --app X --purge` exits 2 (instead of 0) when there's no prior state and no `--database` flag — the database fallback resolves to the app name itself. Cosmetic; doesn't affect normal lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)