### PR TITLE
feat(gravitee): deploy APIM 4.11 on PostgreSQL (no MongoDB/ES/Redis)

### DIFF
--- a/ansible/playbooks/090-remove-gravitee.yml
+++ b/ansible/playbooks/090-remove-gravitee.yml
@@ -1,0 +1,213 @@
+---
+# file: ansible/playbooks/090-remove-gravitee.yml
+# Description:
+#   Remove Gravitee APIM from the cluster.
+#
+#   Default mode (no extra-var):
+#     - Uninstall the Helm release
+#     - Remove the four Traefik IngressRoutes
+#     - Wait for pods to terminate
+#     KEEPS: PVCs, gravitee/urbalurba-secrets, namespace, PostgreSQL graviteedb
+#     A subsequent ./uis deploy gravitee re-installs without re-bootstrap.
+#
+#   Purge mode (-e _purge=true, set by `./uis undeploy gravitee --purge`):
+#     - Everything default mode does, plus:
+#     - DROP DATABASE graviteedb on PostgreSQL
+#     - DROP ROLE gravitee_user
+#     - Delete all PVCs in gravitee namespace
+#     - Delete the gravitee/urbalurba-secrets Secret
+#     - Delete the gravitee namespace
+#     User-level confirmation is enforced by uis-cli.sh before this playbook runs.
+#
+# Usage:
+#   ansible-playbook playbooks/090-remove-gravitee.yml
+#   ansible-playbook playbooks/090-remove-gravitee.yml -e _purge=true
+
+- name: Remove Gravitee APIM from Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    manifests_folder: "/mnt/urbalurbadisk/manifests"
+    gravitee_namespace: "gravitee"
+    gravitee_release_name: "gravitee-apim"
+    gravitee_ingress_file: "{{ manifests_folder }}/091-gravitee-ingress.yaml"
+    purge_mode: "{{ _purge | default(false) | bool }}"
+
+  tasks:
+    - name: 1. Print removal context
+      ansible.builtin.debug:
+        msg: |
+          Removing Gravitee APIM
+          Namespace:    {{ gravitee_namespace }}
+          Release name: {{ gravitee_release_name }}
+          Mode:         {{ 'PURGE — drops database, role, secret, PVCs, namespace' if purge_mode else 'default — keeps PVCs, secret, database, namespace' }}
+
+    # ============= ALWAYS: KUBERNETES OBJECTS =============
+
+    - name: 2. Delete Traefik IngressRoutes
+      kubernetes.core.k8s:
+        src: "{{ gravitee_ingress_file }}"
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      ignore_errors: true
+
+    - name: 3. Check for Gravitee Helm release
+      ansible.builtin.shell: helm list -n {{ gravitee_namespace }} | grep -w {{ gravitee_release_name }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: helm_check
+      changed_when: false
+      ignore_errors: true
+
+    - name: 4. Uninstall Gravitee Helm release
+      ansible.builtin.command: helm uninstall {{ gravitee_release_name }} -n {{ gravitee_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: helm_check.rc == 0
+      changed_when: true
+      ignore_errors: true
+
+    - name: 5. Wait for APIM pods to terminate
+      ansible.builtin.shell: |
+        kubectl wait --for=delete pod -l app.kubernetes.io/instance={{ gravitee_release_name }} -n {{ gravitee_namespace }} --timeout=120s 2>/dev/null || true
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: false
+
+    # ============= PURGE MODE ONLY: DATABASE + PERSISTENT STATE =============
+
+    - name: 6. Get PostgreSQL pod name (purge only)
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ merged_kubeconf_file }}"
+        kind: Pod
+        namespace: default
+        label_selectors:
+          - app.kubernetes.io/name=postgresql
+      register: postgres_pods
+      when: purge_mode
+
+    - name: 7. Set PostgreSQL pod name (purge only)
+      ansible.builtin.set_fact:
+        postgres_pod_name: "{{ postgres_pods.resources[0].metadata.name }}"
+      when: purge_mode and postgres_pods.resources is defined and postgres_pods.resources | length > 0
+
+    - name: 8. Read postgres admin password (purge only)
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n default
+        -o jsonpath='{.data.PGPASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: postgres_password
+      when: purge_mode and postgres_pod_name is defined
+      changed_when: false
+      no_log: true
+
+    - name: 9. Read Gravitee DB user / database name from secrets (purge only)
+      ansible.builtin.shell: |
+        echo "user=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_POSTGRES_USER}' 2>/dev/null | base64 -d)"
+        echo "db=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_POSTGRES_DATABASE}' 2>/dev/null | base64 -d)"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: gravitee_db_meta
+      when: purge_mode and postgres_pod_name is defined
+      changed_when: false
+
+    - name: 10. Parse user / database vars (purge only)
+      ansible.builtin.set_fact:
+        gravitee_db_user: "{{ (gravitee_db_meta.stdout_lines | select('match', '^user=') | first).split('=', 1)[1] | default('gravitee_user') }}"
+        gravitee_db_name: "{{ (gravitee_db_meta.stdout_lines | select('match', '^db=') | first).split('=', 1)[1] | default('graviteedb') }}"
+      when: purge_mode and gravitee_db_meta is defined and gravitee_db_meta.stdout_lines is defined
+
+    - name: 11. Drop Gravitee database (purge only)
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -c
+        \"DROP DATABASE IF EXISTS {{ gravitee_db_name }};\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: purge_mode and postgres_pod_name is defined and gravitee_db_name is defined
+      changed_when: true
+      ignore_errors: true
+      no_log: true
+
+    - name: 12. Drop Gravitee role (purge only)
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -c
+        \"DROP ROLE IF EXISTS {{ gravitee_db_user }};\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: purge_mode and postgres_pod_name is defined and gravitee_db_user is defined
+      changed_when: true
+      ignore_errors: true
+      no_log: true
+
+    - name: 13. Delete all PVCs in gravitee namespace (purge only)
+      ansible.builtin.shell: >-
+        kubectl delete pvc -n {{ gravitee_namespace }} --all --ignore-not-found
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: purge_mode
+      changed_when: true
+      ignore_errors: true
+
+    - name: 14. Delete urbalurba-secrets in gravitee namespace (purge only)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: urbalurba-secrets
+        namespace: "{{ gravitee_namespace }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      when: purge_mode
+      ignore_errors: true
+
+    - name: 15. Delete gravitee namespace (purge only)
+      kubernetes.core.k8s:
+        name: "{{ gravitee_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: absent
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      when: purge_mode
+      ignore_errors: true
+
+    # ============= STATUS =============
+
+    - name: 16. Display removal status
+      ansible.builtin.debug:
+        msg: |
+          ======================================================
+          Gravitee APIM Removal Status
+          ======================================================
+
+          Mode: {{ 'PURGE' if purge_mode else 'default' }}
+
+          {% if purge_mode %}
+          Removed:
+            - Helm release ({{ gravitee_release_name }})
+            - 4 IngressRoutes
+            - PostgreSQL database ({{ gravitee_db_name | default('graviteedb') }}) and role ({{ gravitee_db_user | default('gravitee_user') }})
+            - All PVCs in namespace
+            - gravitee/urbalurba-secrets
+            - gravitee namespace
+
+          A subsequent ./uis deploy gravitee will fully bootstrap from scratch.
+          {% else %}
+          Removed:
+            - Helm release ({{ gravitee_release_name }})
+            - 4 IngressRoutes
+
+          KEPT (use --purge to remove):
+            - PostgreSQL database ({{ gravitee_db_name | default('graviteedb') }}) and role
+            - All PVCs in {{ gravitee_namespace }} namespace
+            - gravitee/urbalurba-secrets
+            - {{ gravitee_namespace }} namespace
+
+          A subsequent ./uis deploy gravitee re-installs without re-bootstrap.
+          {% endif %}
+
+          ======================================================

--- a/ansible/playbooks/090-setup-gravitee.yml
+++ b/ansible/playbooks/090-setup-gravitee.yml
@@ -224,7 +224,77 @@
         state: present
         kubeconfig: "{{ merged_kubeconf_file }}"
 
-    # ============= PHASE 4: HELM REPO + DEPLOY =============
+    # ============= PHASE 4: ADMIN-USER WIRING =============
+    # The chart's gravitee.yml ships with a hardcoded in-memory user
+    # `admin` whose bcrypted password is the well-known plaintext "admin".
+    # We override it with a bcrypt of GRAVITEE_ADMIN_PASSWORD from the
+    # namespace secret so the Console actually honors the secret-stored
+    # credentials. Bcrypt is salted, so we cache the result back into the
+    # secret to keep helm-upgrade idempotent — a fresh hash every deploy
+    # would change the api-configmap checksum and force pod rollouts.
+
+    - name: 20a. Read admin credentials from gravitee/urbalurba-secrets
+      ansible.builtin.shell: |
+        echo "email=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_ADMIN_EMAIL}' 2>/dev/null | base64 -d)"
+        echo "password=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_ADMIN_PASSWORD}' 2>/dev/null | base64 -d)"
+        echo "bcrypt=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_ADMIN_PASSWORD_BCRYPT}' 2>/dev/null | base64 -d)"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: admin_creds_raw
+      changed_when: false
+      no_log: true
+
+    - name: 20b. Parse admin credentials
+      ansible.builtin.set_fact:
+        gravitee_admin_email: "{{ (admin_creds_raw.stdout_lines | select('match', '^email=') | first | default('email=')).split('=', 1)[1] }}"
+        gravitee_admin_password: "{{ (admin_creds_raw.stdout_lines | select('match', '^password=') | first | default('password=')).split('=', 1)[1] }}"
+        gravitee_admin_bcrypt_existing: "{{ (admin_creds_raw.stdout_lines | select('match', '^bcrypt=') | first | default('bcrypt=')).split('=', 1)[1] }}"
+      no_log: true
+
+    - name: 20c. Fail if admin password is empty
+      ansible.builtin.fail:
+        msg: |
+          gravitee/urbalurba-secrets has empty GRAVITEE_ADMIN_PASSWORD. The api pod's
+          in-memory admin user can't be configured. Verify your secrets template has
+          DEFAULT_ADMIN_PASSWORD set, then ./uis secrets generate && ./uis secrets apply.
+      when: gravitee_admin_password | length == 0
+
+    - name: 20d. Verify cached bcrypt or compute a fresh one
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import bcrypt, os, sys
+        pw = os.environ['ADMIN_PW'].encode()
+        existing = os.environ['EXISTING_BCRYPT'].encode()
+        if existing and existing.startswith((b'$2a$', b'$2b$', b'$2y$')):
+            try:
+                if bcrypt.checkpw(pw, existing):
+                    print(existing.decode(), end='')
+                    sys.exit(0)
+            except Exception:
+                pass
+        # No usable cached bcrypt — compute fresh
+        h = bcrypt.hashpw(pw, bcrypt.gensalt(rounds=10, prefix=b'2a'))
+        print(h.decode(), end='')
+        PY
+      environment:
+        ADMIN_PW: "{{ gravitee_admin_password }}"
+        EXISTING_BCRYPT: "{{ gravitee_admin_bcrypt_existing }}"
+      register: admin_bcrypt
+      changed_when: admin_bcrypt.stdout != gravitee_admin_bcrypt_existing
+      no_log: true
+
+    - name: 20e. Cache bcrypt back into gravitee/urbalurba-secrets (so helm upgrade is idempotent)
+      ansible.builtin.shell: >-
+        kubectl patch secret urbalurba-secrets -n {{ gravitee_namespace }}
+        --type=merge -p
+        '{"data":{"GRAVITEE_ADMIN_PASSWORD_BCRYPT":"{{ admin_bcrypt.stdout | b64encode }}"}}'
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: admin_bcrypt.stdout != gravitee_admin_bcrypt_existing
+      changed_when: true
+      no_log: true
+
+    # ============= PHASE 5: HELM REPO + DEPLOY =============
 
     - name: 21. Check existing Helm repositories
       ansible.builtin.command: helm repo list
@@ -247,6 +317,8 @@
         helm upgrade --install {{ gravitee_release_name }} {{ gravitee_helm_chart }}
         --version {{ gravitee_chart_version }}
         -f {{ gravitee_config_file }}
+        --set-string adminPasswordBcrypt={{ admin_bcrypt.stdout }}
+        --set-string adminEmail={{ gravitee_admin_email }}
         --namespace {{ gravitee_namespace }}
         --timeout {{ installation_timeout }}s
         --wait
@@ -254,6 +326,7 @@
         KUBECONFIG: "{{ merged_kubeconf_file }}"
       register: gravitee_install
       changed_when: true
+      no_log: true
 
     - name: 25. Display Helm install summary
       ansible.builtin.debug:

--- a/ansible/playbooks/090-setup-gravitee.yml
+++ b/ansible/playbooks/090-setup-gravitee.yml
@@ -1,465 +1,360 @@
 ---
-# file: /mnt/urbalurbadisk/ansible/playbooks/090-setup-gravitee.yml
-# Set up Gravitee APIM on kubernetes cluster using Helm in the default namespace
+# file: ansible/playbooks/090-setup-gravitee.yml
+# Description:
+#   Deploy Gravitee API Management 4.11 on Kubernetes using PostgreSQL
+#   as the management/config store. No MongoDB, no Elasticsearch, no Redis.
+#
+# Prerequisites:
+# - Kubernetes cluster up and accessible
+# - PostgreSQL deployed (./uis deploy postgresql)
+# - urbalurba-secrets applied to the gravitee namespace (carries
+#   GRAVITEE_POSTGRES_USER/PASSWORD/DATABASE and admin credentials)
+# - Helm 3.x installed
+#
 # Usage:
-# ansible-playbook playbooks/090-setup-gravitee.yml -e kube_context="rancher-desktop"
+#   ansible-playbook playbooks/090-setup-gravitee.yml -e kube_context="rancher-desktop"
 
-- name: Set up Gravitee APIM on Kubernetes
+- name: Set up Gravitee APIM 4.11 (PostgreSQL backend) on Kubernetes
   hosts: localhost
   gather_facts: false
   vars:
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
-    elasticsearch_password_secret: "urbalurba-secrets"
-    elasticsearch_password_key: "ELASTICSEARCH_PASSWORD"
+    gravitee_namespace: "gravitee"
     gravitee_config_file: "{{ manifests_folder }}/090-gravitee-config.yaml"
-    gravitee_ingress_file: "{{ manifests_folder }}/091-gravitee-ingress.yaml" # New ingress file
-    gravitee_pod_readiness_timeout: 300
+    gravitee_ingress_file: "{{ manifests_folder }}/091-gravitee-ingress.yaml"
+    gravitee_helm_repo_url: "https://helm.gravitee.io"
+    gravitee_helm_chart: "graviteeio/apim"
+    gravitee_chart_version: "4.11.3"
     gravitee_release_name: "gravitee-apim"
-    gravitee_namespace: "default"  # Set to default namespace
+    installation_timeout: 600
 
   tasks:
-    - name: 1. Get current Kubernetes context if kube_context not provided
-      ansible.builtin.shell: |
-        kubectl config current-context
+    - name: 1. Print playbook description
+      ansible.builtin.debug:
+        msg: |
+          Setting up Gravitee APIM on Kubernetes
+          Namespace:     {{ gravitee_namespace }}
+          Chart:         {{ gravitee_helm_chart }} @ {{ gravitee_chart_version }}
+          Release name:  {{ gravitee_release_name }}
+          Database:      graviteedb on shared postgresql.default
+          No MongoDB / Elasticsearch / Redis
+
+    # ============= PHASE 1: PREREQUISITES =============
+
+    - name: 2. Ensure gravitee namespace exists
+      kubernetes.core.k8s:
+        name: "{{ gravitee_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 3. Verify PostgreSQL service is reachable
+      ansible.builtin.shell: >-
+        kubectl get service postgresql -n default --no-headers 2>/dev/null | wc -l
       environment:
         KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: current_context
+      register: postgres_check
       changed_when: false
-      when: kube_context is not defined
-      
-    - name: 2. Set kube_context from current context if not provided
-      ansible.builtin.set_fact:
-        kube_context: "{{ current_context.stdout }}"
-      when: kube_context is not defined
 
-    - name: 3. Print playbook description
-      ansible.builtin.debug:
-        msg: "Setting up Gravitee APIM 4.8.4 on Kubernetes context: {{ kube_context }}"
-    
-    - name: 4a. Check if urbalurba-secrets exists
-      ansible.builtin.command: kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }}
+    - name: 4. Fail if PostgreSQL is missing
+      ansible.builtin.fail:
+        msg: "PostgreSQL is required for Gravitee. Deploy it first: ./uis deploy postgresql"
+      when: postgres_check.stdout | int == 0
+
+    - name: 5. Verify gravitee/urbalurba-secrets exists with required keys
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }}
+        -o jsonpath='{.data.GRAVITEE_POSTGRES_PASSWORD}' 2>/dev/null | wc -c
       environment:
         KUBECONFIG: "{{ merged_kubeconf_file }}"
       register: secret_check
-      ignore_errors: true
       changed_when: false
-    
-    - name: 4b. Fail if urbalurba-secrets does not exist
-      ansible.builtin.fail:
-        msg: "The urbalurba-secrets secret does not exist. It must be created before running this playbook."
-      when: secret_check.rc != 0
-    
-    - name: 5. Check if all required MongoDB, Elasticsearch, and Gravitee secret keys exist
-      ansible.builtin.shell: |
-        SECRET_DATA=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o json | jq -r '.data | keys[]')
-        MISSING_KEYS=""
-        for KEY in "GRAVITEE_MONGODB_DATABASE_USER" "GRAVITEE_MONGODB_DATABASE_PASSWORD" "GRAVITEE_MONGODB_DATABASE_NAME" "ELASTICSEARCH_PASSWORD"; do
-          if ! echo "$SECRET_DATA" | grep -q "$KEY"; then
-            MISSING_KEYS="${MISSING_KEYS}${KEY} "
-          fi
-        done
-        if [ -n "$MISSING_KEYS" ]; then
-          echo "Missing required secret keys: $MISSING_KEYS"
-          exit 1
-        fi
-        echo "All required secret keys found"
-        exit 0
-      args:
-        executable: /bin/bash
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: secret_keys_check
-      changed_when: false
-      failed_when: secret_keys_check.rc != 0
-  
-    - name: 6. Fail with clear error message if MongoDB secrets are not properly set
+
+    - name: 6. Fail if Gravitee secret keys missing
       ansible.builtin.fail:
         msg: |
-          ERROR: MongoDB secret keys are not properly set in urbalurba-secrets.
-          Please ensure the following keys are set before running this playbook:
-          - ELASTICSEARCH_PASSWORD
-          - GRAVITEE_MONGODB_DATABASE_USER
-          - GRAVITEE_MONGODB_DATABASE_PASSWORD
-          - GRAVITEE_MONGODB_DATABASE_NAME
-      when: secret_keys_check.rc != 0
+          gravitee/urbalurba-secrets is missing GRAVITEE_POSTGRES_PASSWORD.
+          Run: ./uis secrets generate && ./uis secrets apply
+      when: secret_check.stdout | int == 0
 
-    - name: 7a. Get MongoDB user from Kubernetes secrets
-      ansible.builtin.shell: |
-        set -o pipefail
-        kubectl get secret --namespace {{ gravitee_namespace }} {{ elasticsearch_password_secret }} \
-        -o jsonpath="{.data.GRAVITEE_MONGODB_DATABASE_USER}" \
-        --kubeconfig {{ merged_kubeconf_file }} | base64 -d
-      args:
-        executable: /bin/bash
-      register: mongodb_user
-      changed_when: false
+    # ============= PHASE 2: DATABASE BOOTSTRAP =============
 
-    - name: 7b. Get MongoDB password from Kubernetes secrets
-      ansible.builtin.shell: |
-        set -o pipefail
-        kubectl get secret --namespace {{ gravitee_namespace }} {{ elasticsearch_password_secret }} \
-        -o jsonpath="{.data.GRAVITEE_MONGODB_DATABASE_PASSWORD}" \
-        --kubeconfig {{ merged_kubeconf_file }} | base64 -d
-      args:
-        executable: /bin/bash
-      register: mongodb_password
-      changed_when: false
+    - name: 7. Get PostgreSQL pod name
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ merged_kubeconf_file }}"
+        kind: Pod
+        namespace: default
+        label_selectors:
+          - app.kubernetes.io/name=postgresql
+      register: postgres_pods
 
-    - name: 7c. Set MongoDB user facts
+    - name: 8. Set PostgreSQL pod name
       ansible.builtin.set_fact:
-        mongodb_user_fact: "{{ mongodb_user.stdout }}"
-        mongodb_password_fact: "{{ mongodb_password.stdout }}"
+        postgres_pod_name: "{{ postgres_pods.resources[0].metadata.name }}"
+      when: postgres_pods.resources | length > 0
 
-    - name: 7d. Debug MongoDB credentials (password masked)
-      ansible.builtin.debug:
-        msg: 
-          - "MongoDB user: {{ mongodb_user_fact }}"
-          - "MongoDB password: {{ mongodb_password_fact | regex_replace('.', '*') }}"
-
-    - name: 8. Verify MongoDB connectivity
-      ansible.builtin.shell: |
-        kubectl exec -n {{ gravitee_namespace }} $(kubectl get pods -n {{ gravitee_namespace }} -l app=mongodb -o jsonpath='{.items[0].metadata.name}') -- \
-        mongosh --quiet --eval "db.adminCommand('ping')" --username "{{ mongodb_user_fact }}" --password "{{ mongodb_password_fact }}" --authenticationDatabase admin 
+    - name: 9. Read postgres admin password from default/urbalurba-secrets
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n default
+        -o jsonpath='{.data.PGPASSWORD}' | base64 -d
       environment:
         KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: mongodb_ping
+      register: postgres_password
       changed_when: false
-      ignore_errors: true
-      
-    - name: 9. Display MongoDB connectivity status
-      ansible.builtin.debug:
-        msg: "MongoDB connectivity: {{ 'SUCCESS' if mongodb_ping.rc == 0 else 'FAILED - ' + mongodb_ping.stderr }}"
-        
-    - name: 10. Fail if MongoDB connectivity test failed
-      ansible.builtin.fail:
-        msg: "Failed to connect to MongoDB. Please check MongoDB status and credentials."
-      when: mongodb_ping.rc != 0
-        
-    - name: 11. Get Elasticsearch password from Kubernetes secrets
-      ansible.builtin.shell: |
-        set -o pipefail
-        kubectl get secret --namespace {{ gravitee_namespace }} {{ elasticsearch_password_secret }} \
-        -o jsonpath="{.data.{{ elasticsearch_password_key }}}" \
-        --kubeconfig {{ merged_kubeconf_file }} | base64 -d
-      args:
-        executable: /bin/bash
-      register: elasticsearch_password
-      changed_when: false
+      no_log: true
 
-    - name: 12. Set Elasticsearch password fact
-      ansible.builtin.set_fact:
-        elasticsearch_password_fact: "{{ elasticsearch_password.stdout }}"
-
-    - name: 13. Debug Elasticsearch password (masked)
-      ansible.builtin.debug:
-        msg: "Elasticsearch password: {{ elasticsearch_password_fact | regex_replace('.', '*') }}"
-        
-    - name: 14a. Verify Elasticsearch connectivity
-      ansible.builtin.shell: |
-        kubectl exec -n default $(kubectl get pods -n default -l app=elasticsearch-master -o jsonpath='{.items[0].metadata.name}') -- \
-        curl -s -X GET "http://localhost:9200/_cluster/health?pretty"
+    - name: 10. Read Gravitee DB password from gravitee/urbalurba-secrets
+      ansible.builtin.shell: >-
+        kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }}
+        -o jsonpath='{.data.GRAVITEE_POSTGRES_PASSWORD}' | base64 -d
       environment:
         KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: elasticsearch_health
+      register: gravitee_db_password
+      changed_when: false
+      no_log: true
+
+    - name: 11. Read Gravitee DB user / database name from secrets
+      ansible.builtin.shell: |
+        echo "user=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_POSTGRES_USER}' | base64 -d)"
+        echo "db=$(kubectl get secret urbalurba-secrets -n {{ gravitee_namespace }} -o jsonpath='{.data.GRAVITEE_POSTGRES_DATABASE}' | base64 -d)"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: gravitee_db_meta
+      changed_when: false
+
+    - name: 12. Parse user / database vars
+      ansible.builtin.set_fact:
+        gravitee_db_user: "{{ (gravitee_db_meta.stdout_lines | select('match', '^user=') | first).split('=', 1)[1] }}"
+        gravitee_db_name: "{{ (gravitee_db_meta.stdout_lines | select('match', '^db=') | first).split('=', 1)[1] }}"
+
+    - name: 13. Check if Gravitee role exists
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -tAc
+        \"SELECT 1 FROM pg_roles WHERE rolname='{{ gravitee_db_user }}';\"" | grep -q 1
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: role_check
       changed_when: false
       ignore_errors: true
-      
-    - name: 14b. Display Elasticsearch health status
-      ansible.builtin.debug:
-        var: elasticsearch_health.stdout_lines
-        
-    - name: 14c. Fail if Elasticsearch connectivity test failed
-      ansible.builtin.fail:
-        msg: "Failed to connect to Elasticsearch. Please check Elasticsearch status and credentials."
-      when: elasticsearch_health.rc != 0 or elasticsearch_health.stdout | length == 0
+      no_log: true
 
-    - name: 15. Check if Helm repo exists
+    - name: 14. Create Gravitee role if missing
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -c
+        \"CREATE ROLE {{ gravitee_db_user }} WITH LOGIN PASSWORD '{{ gravitee_db_password.stdout }}' CREATEDB;\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: role_check.rc != 0
+      changed_when: true
+      no_log: true
+
+    - name: 15. Update Gravitee role password (idempotent on re-deploy)
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -c
+        \"ALTER ROLE {{ gravitee_db_user }} WITH PASSWORD '{{ gravitee_db_password.stdout }}';\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: role_check.rc == 0
+      changed_when: true
+      no_log: true
+
+    - name: 16. Check if Gravitee database exists
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -lqt" | cut -d \| -f 1 | grep -qw {{ gravitee_db_name }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: db_check
+      changed_when: false
+      ignore_errors: true
+      no_log: true
+
+    - name: 17. Create Gravitee database if missing
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -c
+        \"CREATE DATABASE {{ gravitee_db_name }} OWNER {{ gravitee_db_user }};\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: db_check.rc != 0
+      changed_when: true
+      no_log: true
+
+    - name: 18. Grant privileges on database and public schema
+      ansible.builtin.shell: >-
+        kubectl exec -n default {{ postgres_pod_name }} --
+        bash -c "PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -c
+        \"GRANT ALL PRIVILEGES ON DATABASE {{ gravitee_db_name }} TO {{ gravitee_db_user }};\"
+        && PGPASSWORD='{{ postgres_password.stdout }}'
+        psql -h postgresql.default -U postgres -d {{ gravitee_db_name }} -c
+        \"GRANT ALL ON SCHEMA public TO {{ gravitee_db_user }};\""
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      changed_when: true
+      no_log: true
+
+    - name: 19. Display database bootstrap status
+      ansible.builtin.debug:
+        msg: |
+          PostgreSQL bootstrap complete:
+            Database: {{ gravitee_db_name }}
+            Owner:    {{ gravitee_db_user }}
+            Role:     {{ 'created' if role_check.rc != 0 else 'existing (password rotated)' }}
+            DB:       {{ 'created' if db_check.rc != 0 else 'existing' }}
+          Liquibase will auto-apply schema migrations on first Management API start.
+
+    # ============= PHASE 3: APPLY INGRESS EARLY =============
+    # Apply IngressRoute before helm install so routing exists
+    # even if the chart install times out.
+
+    - name: 20. Apply Gravitee IngressRoutes (4 routes)
+      kubernetes.core.k8s:
+        src: "{{ gravitee_ingress_file }}"
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    # ============= PHASE 4: HELM REPO + DEPLOY =============
+
+    - name: 21. Check existing Helm repositories
       ansible.builtin.command: helm repo list
       register: helm_repo_list
       changed_when: false
+      ignore_errors: true
 
-    - name: 16. Add Gravitee Helm repo if not already added
-      ansible.builtin.command: helm repo add graviteeio https://helm.gravitee.io
+    - name: 22. Add graviteeio Helm repository if missing
+      kubernetes.core.helm_repository:
+        name: graviteeio
+        repo_url: "{{ gravitee_helm_repo_url }}"
       when: "'graviteeio' not in helm_repo_list.stdout"
-      changed_when: true
 
-    - name: 17. Update Helm repositories
-      ansible.builtin.command: helm repo update
+    - name: 23. Update Helm repositories
+      ansible.builtin.command: helm repo update graviteeio
       changed_when: false
-      
-    - name: 18a. Verify Gravitee Helm chart version 4.8.4 is available
-      ansible.builtin.shell: |
-        helm search repo graviteeio/apim --version 4.8.4
-      register: chart_version_check
-      changed_when: false
-      failed_when: chart_version_check.rc != 0
 
-    - name: 18b. Display available chart version
-      ansible.builtin.debug:
-        var: chart_version_check.stdout_lines
-      
-    # We'll just proceed with the installation attempt directly
-    - name: 18c. Prepare for Gravitee APIM 4.8.4 installation
-      ansible.builtin.debug:
-        msg: "Proceeding with Gravitee APIM 4.8.4 installation or update..."
-
-    # Deploy Gravitee APIM (or upgrade if it exists)
-    - name: 19. Deploy Gravitee APIM 4.8.4 using Helm
+    - name: 24. Deploy Gravitee APIM via Helm
       ansible.builtin.command: >
-        helm upgrade --install {{ gravitee_release_name }} graviteeio/apim
-        --version 4.8.4
+        helm upgrade --install {{ gravitee_release_name }} {{ gravitee_helm_chart }}
+        --version {{ gravitee_chart_version }}
         -f {{ gravitee_config_file }}
         --namespace {{ gravitee_namespace }}
-        --timeout 10m
+        --timeout {{ installation_timeout }}s
+        --wait
       environment:
         KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: helm_result
-      changed_when: true
-    
-    # Apply the custom Gravitee ingress configuration
-    - name: 19a. Apply custom Gravitee ingress configuration
-      ansible.builtin.command: >
-        kubectl apply -f {{ gravitee_ingress_file }}
-        --namespace {{ gravitee_namespace }}
-        --kubeconfig {{ merged_kubeconf_file }}
-      register: ingress_apply_result
+      register: gravitee_install
       changed_when: true
 
-    - name: 19b. Display ingress apply result
+    - name: 25. Display Helm install summary
       ansible.builtin.debug:
-        var: ingress_apply_result.stdout_lines
-        
-    # Get all the deployments/statefulsets created by the Helm chart
-    - name: 20a. Get Gravitee deployments
-      ansible.builtin.shell: |
-        kubectl get deployment -n {{ gravitee_namespace }} | grep {{ gravitee_release_name }} | awk '{print $1}'
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: gravitee_deployments
-      changed_when: false
-      ignore_errors: true
-      
-    - name: 20b. Set proper wait timeout
-      ansible.builtin.set_fact:
-        wait_timeout: 600  # 10 minutes
-        
-    # Wait for the deployments to be ready
-    - name: 20c. Wait for Gravitee deployments to be ready
-      ansible.builtin.shell: |
-        kubectl rollout status deployment/{{ item }} -n {{ gravitee_namespace }} --timeout={{ wait_timeout }}s
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: deployment_status
-      with_items: "{{ gravitee_deployments.stdout_lines }}"
-      when: gravitee_deployments.stdout_lines is defined and gravitee_deployments.stdout_lines | length > 0
-      ignore_errors: true
-      changed_when: false
-      
-    - name: 20d. Display deployment rollout status
-      ansible.builtin.debug:
-        msg: "{{ item.cmd }} - {{ 'Success' if item.rc == 0 else 'Failed with error: ' + item.stderr }}"
-      with_items: "{{ deployment_status.results | default([]) }}"
-      when: deployment_status is defined and deployment_status.results is defined
-        
-    - name: 21a. Get all Gravitee pods
-      ansible.builtin.shell: |
-        kubectl get pods -n {{ gravitee_namespace }} | grep gravitee
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: gravitee_pods
-      changed_when: false
-      ignore_errors: true
-      
-    - name: 21b. Display Gravitee pods
-      ansible.builtin.debug:
-        var: gravitee_pods.stdout_lines
-      when: gravitee_pods.stdout is defined and gravitee_pods.stdout != ""
-      
-    # Count running pods
-    - name: 21c. Count running Gravitee pods
-      ansible.builtin.shell: |
-        kubectl get pods -n {{ gravitee_namespace }} | grep gravitee | grep Running | wc -l
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: running_pods_count
-      changed_when: false
-      ignore_errors: true
-      
-    # Verify correct image versions are deployed
-    - name: 21d. Verify correct image versions are deployed
-      ansible.builtin.shell: |
-        kubectl get pods -n {{ gravitee_namespace }} -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}' | grep gravitee
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: deployed_images
-      changed_when: false
-      ignore_errors: true
-      
-    - name: 21e. Display deployed image versions
-      ansible.builtin.debug:
-        var: deployed_images.stdout_lines
-      when: deployed_images.stdout is defined
-      
-    - name: 21f. Verify 4.8.4 images are used
-      ansible.builtin.fail:
-        msg: "Not all containers are using 4.8.4 images. Check deployment."
-      when: deployed_images.stdout is defined and "4.8.4" not in deployed_images.stdout
-      
-    # Get any Gravitee API pod name
-    - name: 22a. Get Gravitee API pod name
-      ansible.builtin.shell: |
-        kubectl get pods -n {{ gravitee_namespace }} | grep -E 'gravitee.*api' | awk '{print $1}' | head -1
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: api_pod_name
-      changed_when: false
-      ignore_errors: true
-      
-    # Get any Gravitee Gateway pod name
-    - name: 22b. Get Gravitee Gateway pod name
-      ansible.builtin.shell: |
-        kubectl get pods -n {{ gravitee_namespace }} | grep -E 'gravitee.*gateway' | awk '{print $1}' | head -1
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: gateway_pod_name
-      changed_when: false
-      ignore_errors: true
-    
-    # Check Gateway health if pod exists
-    - name: 23a. Check Gateway health
-      ansible.builtin.command: >
-        kubectl exec -n {{ gravitee_namespace }} {{ gateway_pod_name.stdout }}
-        --kubeconfig {{ merged_kubeconf_file }}
-        -- curl -s http://localhost:8082/_node/health
-      register: gateway_health
-      changed_when: false
-      ignore_errors: true
-      when: gateway_pod_name.stdout is defined and gateway_pod_name.stdout != ""
+        msg: "{{ gravitee_install.stdout_lines | default(['Helm install completed.']) }}"
+      when: gravitee_install.stdout_lines is defined
 
-    # Display Gateway health status
-    - name: 23b. Display Gateway health status
-      ansible.builtin.debug:
-        var: gateway_health.stdout_lines
-      when: gateway_health is defined and gateway_health.stdout is defined
+    # ============= PHASE 5: WAIT FOR READINESS =============
 
-    # Check Management API health if pod exists
-    - name: 23c. Check Management API health
-      ansible.builtin.command: >
-        kubectl exec -n {{ gravitee_namespace }} {{ api_pod_name.stdout }}
-        --kubeconfig {{ merged_kubeconf_file }}
-        -- curl -s http://localhost:8083/management/health
+    - name: 26. Wait for all four APIM components to reach Ready
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ gravitee_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/instance={{ gravitee_release_name }}"
+          - "app.kubernetes.io/component={{ item }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: component_pods
+      until: >
+        component_pods.resources | length > 0 and
+        component_pods.resources[0].status.containerStatuses is defined and
+        component_pods.resources[0].status.containerStatuses | length > 0 and
+        component_pods.resources[0].status.containerStatuses[0].ready == true
+      retries: 60
+      delay: 10
+      loop:
+        - api
+        - gateway
+        - ui
+        - portal
+
+    # ============= PHASE 6: HEALTH PROBES =============
+
+    - name: 27. Health-check Management API from inside the cluster
+      ansible.builtin.shell: |
+        kubectl run gravitee-health-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ gravitee_namespace }} -- \
+          curl -sS -o /dev/null -w "HTTP_CODE:%{http_code}" \
+          http://{{ gravitee_release_name }}-api.{{ gravitee_namespace }}.svc.cluster.local:83/management/health
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
       register: api_health
+      retries: 6
+      delay: 10
+      until: "'HTTP_CODE:200' in api_health.stdout"
+      failed_when: false
       changed_when: false
-      ignore_errors: true
-      when: api_pod_name.stdout is defined and api_pod_name.stdout != ""
 
-    # Display Management API health status
-    - name: 23d. Display Management API health status
-      ansible.builtin.debug:
-        var: api_health.stdout_lines
-      when: api_health is defined and api_health.stdout is defined
-      
-    # Get Gravitee services
-    - name: 24. Get all services that might be related to Gravitee
+    - name: 28. Health-check Gateway from inside the cluster
       ansible.builtin.shell: |
-        kubectl get svc -n {{ gravitee_namespace }} --kubeconfig {{ merged_kubeconf_file }} | grep gravitee-apim
-      register: gravitee_services
+        kubectl run gravitee-gw-health-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ gravitee_namespace }} -- \
+          curl -sS -o /dev/null -w "HTTP_CODE:%{http_code}" \
+          http://{{ gravitee_release_name }}-gateway.{{ gravitee_namespace }}.svc.cluster.local:82/_node/health
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: gw_health
+      retries: 6
+      delay: 10
+      until: "'HTTP_CODE:200' in gw_health.stdout"
+      failed_when: false
       changed_when: false
-      ignore_errors: true
 
-    # Display Gravitee service details
-    - name: 25. Display Gravitee service details
-      ansible.builtin.debug:
-        var: gravitee_services.stdout_lines
-      when: gravitee_services.stdout is defined and gravitee_services.stdout != ""
-      
-    # Get Gravitee ingress resources
-    - name: 26. Get all ingress resources that might be related to Gravitee
-      ansible.builtin.shell: |
-        kubectl get ingress -n {{ gravitee_namespace }} --kubeconfig {{ merged_kubeconf_file }} | grep gravitee-apim
-      register: gravitee_ingresses
+    # ============= PHASE 7: STATUS =============
+
+    - name: 29. Get Gravitee pods
+      ansible.builtin.shell: kubectl get pods -n {{ gravitee_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: gravitee_pod_status
       changed_when: false
-      ignore_errors: true
-      
-    # Display Gravitee ingress details
-    - name: 27. Display Gravitee ingress details
-      ansible.builtin.debug:
-        var: gravitee_ingresses.stdout_lines
-      when: gravitee_ingresses.stdout is defined and gravitee_ingresses.stdout != ""
-      
-    # Determine if the installation was successful - IMPROVED LOGIC
-    - name: 28. Determine installation success
-      ansible.builtin.set_fact:
-        services_setup_successful: "{{ (gravitee_pods.stdout_lines|default([])|length >= 3) }}"
-        ingress_setup_successful: "{{ (gravitee_ingresses.stdout_lines|default([])|length >= 3) }}"
-      
-    - name: 29. Display installation success status
-      ansible.builtin.debug:
-        msg: 
-          - "Gravitee APIM 4.8.4 services installation status: {{ 'Successful' if services_setup_successful else 'FAILED' }}"
-          - "Gravitee APIM ingress setup status: {{ 'Successful' if ingress_setup_successful else 'FAILED' }}"
-        
-    # Display warning if installation was not successful
-    - name: 30. Display warning if installation failed
+
+    - name: 30. Display final deployment status
       ansible.builtin.debug:
         msg: |
-          WARNING: The Gravitee APIM 4.8.4 installation appears to have FAILED!
-          
-          Troubleshooting steps:
-          1. Check Helm release status: helm status {{ gravitee_release_name }} -n {{ gravitee_namespace }}
-          2. Check for any error pods: kubectl get pods -n {{ gravitee_namespace }}
-          3. Check pod logs: kubectl logs <pod-name> -n {{ gravitee_namespace }}
-          4. Check Helm chart values: helm get values {{ gravitee_release_name }} -n {{ gravitee_namespace }}
-          5. Check ingress resources: kubectl get ingress -n {{ gravitee_namespace }}
-          6. Try uninstalling and reinstalling: helm uninstall {{ gravitee_release_name }} -n {{ gravitee_namespace }}
-          
-          Possible issues:
-          - Network issues between services
-          - Resource constraints (insufficient CPU or memory)
-          - Configuration errors in the values file
-          - Connectivity issues with MongoDB or Elasticsearch
-          - Ingress configuration errors
-      when: not services_setup_successful or not ingress_setup_successful
-        
-    # Find available service names for port forwarding
-    - name: 31. Find available service names for port forwarding
-      ansible.builtin.shell: |
-        kubectl get svc -n {{ gravitee_namespace }} | grep -E '{{ gravitee_release_name }}' | awk '{print $1}' | tr '\n' ',' | sed 's/,$//'
-      environment:
-        KUBECONFIG: "{{ merged_kubeconf_file }}"
-      register: available_services
-      changed_when: false
-      ignore_errors: true
-      
-    - name: 32. Display available services for port forwarding
-      ansible.builtin.debug:
-        msg: "Available services for port forwarding: {{ available_services.stdout|default('None found') }}"
-        
-    # Display final status with appropriate port-forwarding commands
-    - name: 33. Display final status
-      ansible.builtin.debug:
-        msg:
-          - "Gravitee APIM 4.8.4 setup {{ 'completed successfully' if services_setup_successful and ingress_setup_successful else 'FAILED' }} in the {{ gravitee_namespace }} namespace."
-          - "Version: 4.8.4 (released August 14, 2025)"
-          - "Default admin credentials: admin / adminadmin"
-          - "Running pods found: {{ running_pods_count.stdout|default('0') }}"
-          - ""
-          - "Available services: {{ available_services.stdout|default('None found') }}"
-          - ""
-          - "To access Gravitee components, use the following URI paths:"
-          - "  - Management UI: /apim/console/"
-          - "  - Portal UI: /apim/portal-ui/"
-          - "  - Gateway API: /apim/gateway"
-          - "  - Management API: /apim/management"
-          - "  - Portal API: /apim/portal"
-          - ""
-          - "These are accessible via your Tailscale funnel hostname: rancher-traefik.dog-pence.ts.net"
-          - ""
-          - "For local testing, you can also use port forwarding:"
-          - "  kubectl port-forward svc/gravitee-apim-ui 8084:8084 -n {{ gravitee_namespace }} # Management UI"
-          - "  kubectl port-forward svc/gravitee-apim-portal 8085:8085 -n {{ gravitee_namespace }} # Portal UI"
-          - "  kubectl port-forward svc/gravitee-apim-gateway 8082:8082 -n {{ gravitee_namespace }} # Gateway API"
-          - "  kubectl port-forward svc/gravitee-apim-api 8083:8083 -n {{ gravitee_namespace }} # Management API"
-          - ""
-          - "{{ 'INSTALLATION SUCCESSFUL' if services_setup_successful and ingress_setup_successful else 'INSTALLATION STATUS: See details above for actual status' }}"
+          ======================================================
+          Gravitee APIM Deployment Status
+          ======================================================
+
+          {{ 'SUCCESS' if 'HTTP_CODE:200' in api_health.stdout and 'HTTP_CODE:200' in gw_health.stdout else 'DEPLOYED — health checks pending; pods may still be starting' }}
+
+          Chart:        {{ gravitee_helm_chart }} @ {{ gravitee_chart_version }}
+          Namespace:    {{ gravitee_namespace }}
+          Database:     {{ gravitee_db_name }} on postgresql.default
+          Routing:      Traefik IngressRoute (HostRegexp)
+
+          Pods:
+          {{ gravitee_pod_status.stdout }}
+
+          Health:
+            Management API: {{ 'OK' if 'HTTP_CODE:200' in api_health.stdout else 'pending' }}
+            Gateway:        {{ 'OK' if 'HTTP_CODE:200' in gw_health.stdout else 'pending' }}
+
+          Access:
+            Console:        http://gravitee.localhost
+            Management API: http://gravitee-api.localhost
+            Gateway:        http://gravitee-gw.localhost
+            Portal:         http://gravitee-portal.localhost
+
+          Admin login (sourced from gravitee/urbalurba-secrets):
+            email:    GRAVITEE_ADMIN_EMAIL    (=DEFAULT_ADMIN_EMAIL)
+            password: GRAVITEE_ADMIN_PASSWORD (=DEFAULT_ADMIN_PASSWORD)
+
+          Verify:
+            ./uis verify gravitee
+
+          ======================================================

--- a/manifests/090-gravitee-config.yaml
+++ b/manifests/090-gravitee-config.yaml
@@ -65,12 +65,6 @@ jdbc:
 ratelimit:
   type: none
 
-# Analytics (request counts, latency, status-code distributions, log
-# search) require Elasticsearch. Disabling here means the analytics
-# tab in the Console is empty; everything else works.
-analytics:
-  enabled: false
-
 # ---------------------------------------------------------------
 # External URLs for Console / Portal SPAs
 # ---------------------------------------------------------------
@@ -111,15 +105,32 @@ api:
   autoscaling:
     enabled: false
 
-  # JDBC password is provided at runtime as an env var sourced from
-  # the gravitee/urbalurba-secrets Secret. The chart honors
-  # GRAVITEE_MANAGEMENT_JDBC_PASSWORD for management.jdbc.password.
-  extraEnvs:
+  # Analytics (request counts, latency, status-code distributions, log
+  # search) require Elasticsearch. Setting type: none here disables the
+  # analytics repository at gravitee.yml render time. The chart's default
+  # is "elasticsearch", which leaves a stale ES endpoint baked into the
+  # ConfigMap and causes the api pod to loop on DNS resolution failures
+  # for graviteeio-apim-elasticsearch-ingest-hl.
+  analytics:
+    type: none
+
+  # Secret-backed env vars. The chart key is `env` (singular list), not
+  # `extraEnvs`. Spring Boot env-var override convention maps these to
+  # gravitee.yml keys: GRAVITEE_MANAGEMENT_JDBC_PASSWORD overrides
+  # management.jdbc.password; GRAVITEE_API_PROPERTIES_ENCRYPTION_SECRET
+  # overrides api.properties.encryption.secret (without it, gravitee logs
+  # "You still use the default secret" on every start).
+  env:
     - name: GRAVITEE_MANAGEMENT_JDBC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: urbalurba-secrets
           key: GRAVITEE_POSTGRES_PASSWORD
+    - name: GRAVITEE_API_PROPERTIES_ENCRYPTION_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: urbalurba-secrets
+          key: GRAVITEE_ENCRYPTION_KEY
 
   # Disable chart-managed Kubernetes Ingress; UIS routes via Traefik
   # IngressRoute (manifests/091-gravitee-ingress.yaml).
@@ -146,14 +157,29 @@ gateway:
   autoscaling:
     enabled: false
 
-  # Gateway also reads API definitions from the management database
-  # via JDBC, so it needs the same password.
-  extraEnvs:
+  # Disable the Elasticsearch reporter on the gateway side. Without this,
+  # the gateway's gravitee.yml ConfigMap still has a reporters.elasticsearch
+  # block targeting graviteeio-apim-elasticsearch-ingest-hl, which the
+  # gateway tries to push request metrics to. Same shape as the api-side
+  # analytics override above.
+  reporters:
+    elasticsearch:
+      enabled: false
+
+  # Gateway reads API definitions from the management database via JDBC,
+  # so it needs the same password. Same chart-key correction as api: env,
+  # not extraEnvs.
+  env:
     - name: GRAVITEE_MANAGEMENT_JDBC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: urbalurba-secrets
           key: GRAVITEE_POSTGRES_PASSWORD
+    - name: GRAVITEE_API_PROPERTIES_ENCRYPTION_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: urbalurba-secrets
+          key: GRAVITEE_ENCRYPTION_KEY
 
   ingress:
     enabled: false

--- a/manifests/090-gravitee-config.yaml
+++ b/manifests/090-gravitee-config.yaml
@@ -215,6 +215,18 @@ ui:
   portal:
     entrypoint: http://gravitee-portal.localhost/
 
+  # Force the Console SPA to serve assets from the URL root. The chart's default
+  # is to derive CONSOLE_BASE_HREF from ui.ingress.path (which contains "/console"),
+  # baking <base href="/console/"> into the served HTML. UIS routes via Traefik
+  # IngressRoute on a dedicated subdomain (gravitee.localhost) without a sub-path,
+  # so the SPA must serve assets from / or every <script src="..."> resolves to
+  # /console/<asset> and 404s. Setting CONSOLE_BASE_HREF here also short-circuits
+  # the chart's $base_href_defined check (templates/_helpers.tpl line 467) and
+  # suppresses the auto-emit.
+  env:
+    - name: CONSOLE_BASE_HREF
+      value: /
+
   ingress:
     enabled: false
 
@@ -238,6 +250,12 @@ portal:
   # api pod serves /portal/... on the same hostname as /management/... — see
   # installation.api.proxyPath.portal in the values block above.
   baseURL: http://gravitee-api.localhost/portal
+
+  # Same fix as ui.env CONSOLE_BASE_HREF above: force assets to be served from
+  # the URL root instead of the chart's default /portal/ sub-path.
+  env:
+    - name: PORTAL_BASE_HREF
+      value: /
 
   ingress:
     enabled: false

--- a/manifests/090-gravitee-config.yaml
+++ b/manifests/090-gravitee-config.yaml
@@ -199,6 +199,22 @@ ui:
   enabled: true
   replicaCount: 1
 
+  # The Console SPA fetches /constants.json at startup to learn where the
+  # management API lives. Without explicit baseURL the chart falls back to
+  # constructing https://<api.ingress.management.hosts[0]><...path> from the
+  # chart defaults (apim.example.com) — which doesn't resolve, so the SPA
+  # silently fails on first XHR. UIS exposes the management API at
+  # http://gravitee-api.localhost/management via 091-gravitee-ingress.yaml.
+  baseURL: http://gravitee-api.localhost/management
+
+  # The Console also surfaces a "go to Developer Portal" link to users.
+  # The chart hardcodes this to https://<gateway.ingress.hosts[0]>/, which is
+  # wrong on two counts (https-only, and points at the gateway not the portal
+  # SPA). Override here. Maps under ui.portal are merged into constants.json
+  # and rendered after the chart's hardcoded entrypoint, so JSON last-wins.
+  portal:
+    entrypoint: http://gravitee-portal.localhost/
+
   ingress:
     enabled: false
 
@@ -216,6 +232,12 @@ ui:
 portal:
   enabled: true
   replicaCount: 1
+
+  # Same shape as ui.baseURL above: the Portal SPA fetches /assets/config.json
+  # and needs an explicit base for the portal-side management endpoints. The
+  # api pod serves /portal/... on the same hostname as /management/... — see
+  # installation.api.proxyPath.portal in the values block above.
+  baseURL: http://gravitee-api.localhost/portal
 
   ingress:
     enabled: false

--- a/manifests/090-gravitee-config.yaml
+++ b/manifests/090-gravitee-config.yaml
@@ -69,16 +69,21 @@ ratelimit:
 # External URLs for Console / Portal SPAs
 # ---------------------------------------------------------------
 # These are emitted into gravitee.yml on the Management API pod. The
-# Console UI and Developer Portal SPA both run in the user's browser
-# and read these values to build calls to the Management API.
-# Without correct values, the Console silently fails to authenticate
-# on first load. (Decision #16 in INVESTIGATE-gravitee-fix.md.)
+# Console SPA reads them to build calls to the Management API.
+#
+# SAME-ORIGIN ARCHITECTURE: management API and Console SPA share the
+# `gravitee.<domain>` hostname (path-based split: /management/* and
+# /portal/* go to the api pod, everything else to the ui pod — see
+# 091-gravitee-ingress.yaml). Required because Gravitee uses an HttpOnly
+# session cookie for auth and SameSite=None;Secure isn't usable on plain
+# HTTP, so cross-origin auth XHR fails. (Decisions #16, #17 in
+# INVESTIGATE-gravitee-fix.md, plus the Round 9 browser-pass finding.)
 installation:
   type: standalone
   api:
-    # The external URL of the Management API. Console and Portal SPAs
-    # both call this hostname.
-    url: http://gravitee-api.localhost
+    # External URL of the Management API. Console SPA's XHR target.
+    # Same hostname as the Console; path-based split via Traefik.
+    url: http://gravitee.localhost
     proxyPath:
       management: /management
       portal: /portal
@@ -202,10 +207,12 @@ ui:
   # The Console SPA fetches /constants.json at startup to learn where the
   # management API lives. Without explicit baseURL the chart falls back to
   # constructing https://<api.ingress.management.hosts[0]><...path> from the
-  # chart defaults (apim.example.com) — which doesn't resolve, so the SPA
-  # silently fails on first XHR. UIS exposes the management API at
-  # http://gravitee-api.localhost/management via 091-gravitee-ingress.yaml.
-  baseURL: http://gravitee-api.localhost/management
+  # chart defaults (apim.example.com) — which doesn't resolve. We point at
+  # the same hostname the SPA itself is served from (path-based split via
+  # 091-gravitee-ingress.yaml: /management/* → api pod). Same-origin keeps
+  # auth cookies travelling without SameSite=None;Secure (which would need
+  # HTTPS).
+  baseURL: http://gravitee.localhost/management
 
   # The Console also surfaces a "go to Developer Portal" link to users.
   # The chart hardcodes this to https://<gateway.ingress.hosts[0]>/, which is
@@ -245,11 +252,15 @@ portal:
   enabled: true
   replicaCount: 1
 
-  # Same shape as ui.baseURL above: the Portal SPA fetches /assets/config.json
-  # and needs an explicit base for the portal-side management endpoints. The
-  # api pod serves /portal/... on the same hostname as /management/... — see
-  # installation.api.proxyPath.portal in the values block above.
-  baseURL: http://gravitee-api.localhost/portal
+  # Portal SPA fetches /assets/config.json and uses baseURL for its REST calls.
+  # Points at the consolidated Console hostname's /portal sub-path. NOTE: this
+  # is still cross-origin from the Portal SPA's own host (gravitee-portal.<dom>),
+  # so authenticated portal-admin flows (user registration, signed-in catalog
+  # browsing) hit the same HTTP-on-different-hostname cookie issue Console used
+  # to. v1 trade-off: anonymous portal browse works; signed-in portal admin
+  # paths are scope-deferred. Fix in v2 by either consolidating portal under
+  # gravitee.<dom>/_portal/ or by switching the cluster to HTTPS.
+  baseURL: http://gravitee.localhost/portal
 
   # Same fix as ui.env CONSOLE_BASE_HREF above: force assets to be served from
   # the URL root instead of the chart's default /portal/ sub-path.

--- a/manifests/090-gravitee-config.yaml
+++ b/manifests/090-gravitee-config.yaml
@@ -1,155 +1,203 @@
 # file: /mnt/urbalurbadisk/manifests/090-gravitee-config.yaml
-# description: Updated for Gravitee APIM 4.8.4 with proper UI constants configuration
+# description: Helm values overrides for Gravitee APIM 4.11.x
 #
-# HOSTNAME STRATEGY:
-# - api.localhost → API Gateway (for developers)
-# - portal.localhost → Developer Portal  
-# - gravitee.localhost → Management Console (for admins)
-# - gravitee-api.localhost → Management API (for admins)
+# Architecture (per INVESTIGATE-gravitee-fix.md):
+# - PostgreSQL backend via the JDBC repository plugin (no MongoDB).
+# - No Elasticsearch (analytics disabled).
+# - No Redis (rate-limit disabled via ratelimit.type: none).
+# - Chart-managed Kubernetes Ingress disabled; UIS owns routing in
+#   manifests/091-gravitee-ingress.yaml.
+# - Per-component resource overrides tuned for laptop-scale clusters.
+#
+# Connection details and admin credentials are read from the
+# `gravitee/urbalurba-secrets` Secret. The setup playbook bootstraps
+# `graviteedb` + `gravitee_user` on the platform's `postgresql`
+# service before running `helm install`.
+#
+# Service names and HTTP ports referenced from this file are verified
+# against the rendered chart (e.g. `helm template graviteeio/apim
+# --version 4.11.x`):
+#   gravitee-apim-api      :83  -> 8083
+#   gravitee-apim-gateway  :82  -> 8082
+#   gravitee-apim-portal   :8003 -> 8080
+#   gravitee-apim-ui       :8002 -> 8080
 
-# Global settings
-global:
-  cluster: gravitee
-
-# Disable bundled dependencies
+# ---------------------------------------------------------------
+# Disable bundled subcharts
+# ---------------------------------------------------------------
+# All of these default to false in 4.11; we set them explicitly so
+# the intent is auditable and survives chart bumps.
 mongodb-replicaset:
   enabled: false
 elasticsearch:
   enabled: false
-
-# MongoDB configuration
-mongo:
-  uri: mongodb://gravitee_user:SecretPassword1@mongodb.default.svc.cluster.local:27017/graviteedb?authSource=admin
-
-# Elasticsearch configuration
 es:
-  endpoints:
-    - http://elasticsearch-master.default.svc.cluster.local:9200
-  security:
-    enabled: false
+  enabled: false
 
-# API Management API configuration  
+# ---------------------------------------------------------------
+# Management store: PostgreSQL via JDBC repository plugin
+# ---------------------------------------------------------------
+# The JDBC plugin is part of the official APIM distribution; the
+# PostgreSQL driver is bundled. driverSource: auto means the runtime
+# uses the bundled driver — no download or custom image needed.
+management:
+  type: jdbc
+
+jdbc:
+  driverSource: auto
+  url: jdbc:postgresql://postgresql.default.svc.cluster.local:5432/graviteedb
+  username: gravitee_user
+  # Password is provided at runtime via secret-backed env var on
+  # both the api and gateway components (see api.extraEnvs / gateway.extraEnvs
+  # below). Leaving this blank in chart values keeps the credential out
+  # of any tracked manifest. Liquibase auto-applies the schema on first
+  # start of the Management API pod.
+  password: ""
+  liquibase: true
+  schema: public
+
+# ---------------------------------------------------------------
+# Disable optional subsystems
+# ---------------------------------------------------------------
+# Rate-limit policies require a backing store (Redis recommended).
+# Setting type: none disables the rate-limit subsystem cleanly;
+# applying a rate-limit policy in the Console will not enforce limits.
+ratelimit:
+  type: none
+
+# Analytics (request counts, latency, status-code distributions, log
+# search) require Elasticsearch. Disabling here means the analytics
+# tab in the Console is empty; everything else works.
+analytics:
+  enabled: false
+
+# ---------------------------------------------------------------
+# External URLs for Console / Portal SPAs
+# ---------------------------------------------------------------
+# These are emitted into gravitee.yml on the Management API pod. The
+# Console UI and Developer Portal SPA both run in the user's browser
+# and read these values to build calls to the Management API.
+# Without correct values, the Console silently fails to authenticate
+# on first load. (Decision #16 in INVESTIGATE-gravitee-fix.md.)
+installation:
+  type: standalone
+  api:
+    # The external URL of the Management API. Console and Portal SPAs
+    # both call this hostname.
+    url: http://gravitee-api.localhost
+    proxyPath:
+      management: /management
+      portal: /portal
+  standalone:
+    # The chart template honors the `urls` array form (plural) and ignores
+    # a singular `url` here. Fallback path constructs `https://<ui.ingress.hosts[0]>...`
+    # which is wrong for our HTTP-on-localhost setup, so we always provide
+    # `urls` explicitly.
+    console:
+      urls:
+        - orgId: DEFAULT
+          url: http://gravitee.localhost
+    portal:
+      urls:
+        - envId: DEFAULT
+          url: http://gravitee-portal.localhost
+
+# ---------------------------------------------------------------
+# Management API
+# ---------------------------------------------------------------
 api:
   enabled: true
   replicaCount: 1
   autoscaling:
     enabled: false
-  
-  # Specify 4.8.4 image explicitly
-  image:
-    repository: graviteeio/apim-management-api
-    tag: 4.8.4-debian
-    pullPolicy: Always
-  
-  # Configure ingress with proper hostname
+
+  # JDBC password is provided at runtime as an env var sourced from
+  # the gravitee/urbalurba-secrets Secret. The chart honors
+  # GRAVITEE_MANAGEMENT_JDBC_PASSWORD for management.jdbc.password.
+  extraEnvs:
+    - name: GRAVITEE_MANAGEMENT_JDBC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: urbalurba-secrets
+          key: GRAVITEE_POSTGRES_PASSWORD
+
+  # Disable chart-managed Kubernetes Ingress; UIS routes via Traefik
+  # IngressRoute (manifests/091-gravitee-ingress.yaml).
   ingress:
     management:
-      enabled: true
-      path: /
-      pathType: Prefix
-      hosts:
-        - gravitee-api.localhost
-      annotations:
-        kubernetes.io/ingress.class: "traefik"
+      enabled: false
     portal:
-      enabled: true
-      path: /
-      pathType: Prefix  
-      hosts:
-        - gravitee-api.localhost
-      annotations:
-        kubernetes.io/ingress.class: "traefik"
+      enabled: false
 
-# Gateway configuration
+  resources:
+    requests:
+      cpu: 200m
+      memory: 768Mi
+    limits:
+      cpu: 1000m
+      memory: 1500Mi
+
+# ---------------------------------------------------------------
+# API Gateway
+# ---------------------------------------------------------------
 gateway:
   enabled: true
   replicaCount: 1
   autoscaling:
     enabled: false
-    
-  # Specify 4.8.4 image explicitly
-  image:
-    repository: graviteeio/apim-gateway
-    tag: 4.8.4-debian
-    pullPolicy: Always
-    
-  # Configure ingress for API access
-  ingress:
-    enabled: true
-    path: /
-    pathType: Prefix
-    hosts:
-      - api.localhost
-    annotations:
-      kubernetes.io/ingress.class: "traefik"
 
-# Management UI configuration
+  # Gateway also reads API definitions from the management database
+  # via JDBC, so it needs the same password.
+  extraEnvs:
+    - name: GRAVITEE_MANAGEMENT_JDBC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: urbalurba-secrets
+          key: GRAVITEE_POSTGRES_PASSWORD
+
+  ingress:
+    enabled: false
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1000Mi
+
+# ---------------------------------------------------------------
+# Management UI (Console SPA)
+# ---------------------------------------------------------------
 ui:
   enabled: true
   replicaCount: 1
-  autoscaling:
-    enabled: false
-    
-  # Specify 4.8.4 image explicitly  
-  image:
-    repository: graviteeio/apim-management-ui
-    tag: 4.8.4
-    pullPolicy: Always
-    
-  # Configure ingress for admin console
-  ingress:
-    enabled: true
-    path: /
-    pathType: Prefix
-    hosts:
-      - gravitee.localhost
-    annotations:
-      kubernetes.io/ingress.class: "traefik"
-  
-  # Configure constants.json for proper API URLs
-  constants: |
-    {
-      "baseURL": "http://gravitee-api.localhost/management",
-      "basePortalURL": "http://gravitee-api.localhost/portal", 
-      "production": false,
-      "defaultPortal": "classic"
-    }
 
-# Portal UI configuration
+  ingress:
+    enabled: false
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+# ---------------------------------------------------------------
+# Developer Portal (SPA)
+# ---------------------------------------------------------------
 portal:
   enabled: true
   replicaCount: 1
-  autoscaling:
-    enabled: false
-    
-  # Specify 4.8.4 image explicitly
-  image:
-    repository: graviteeio/apim-portal-ui
-    tag: 4.8.4
-    pullPolicy: Always
-    
-  # Configure ingress for developer portal
+
   ingress:
-    enabled: true
-    path: /
-    pathType: Prefix
-    hosts:
-      - portal.localhost
-    annotations:
-      kubernetes.io/ingress.class: "traefik"
-  
-  # Configure constants.json for proper API URLs
-  constants: |
-    {
-      "portalURL": "http://gravitee-api.localhost/portal"
-    }
+    enabled: false
 
-# Rate limit configuration
-ratelimit:
-  type: mongodb
-  mongodb:
-    uri: mongodb://gravitee_user:SecretPassword1@mongodb.default.svc.cluster.local:27017/graviteedb?authSource=admin
-
-# Installation type configuration (4.2+ requirement)
-installation:
-  type: standalone
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/manifests/091-gravitee-ingress.yaml
+++ b/manifests/091-gravitee-ingress.yaml
@@ -1,115 +1,88 @@
 # file: /mnt/urbalurbadisk/manifests/091-gravitee-ingress.yaml
-# description: Simple hostname-based ingress for Gravitee APIM 4.8.4
+# description: Hostname-based ingress for Gravitee APIM 4.11
 #
-# HOSTNAME STRATEGY (Simple Host-Based Routing):
-# - api.localhost → API Gateway (gravitee-apim-gateway:82)
-# - portal.localhost → Developer Portal (gravitee-apim-portal:8003)  
-# - gravitee.localhost → Management Console (gravitee-apim-ui:8002)
-# - gravitee-api.localhost → Management API (gravitee-apim-api:83)
+# HOSTNAME STRATEGY (HostRegexp-based — works on localhost, Tailscale, Cloudflare):
+# - gravitee.<domain>         → Management Console (gravitee-apim-ui:8002)
+# - gravitee-api.<domain>     → Management API     (gravitee-apim-api:83)
+# - gravitee-gw.<domain>      → API Gateway        (gravitee-apim-gateway:82)
+# - gravitee-portal.<domain>  → Developer Portal   (gravitee-apim-portal:8003)
 #
-# DESIGN PRINCIPLES:
-# - Follows same pattern as whoami-public.localhost (proven working)
-# - Uses traefik.io/v1alpha1 API (cluster standard)
-# - Simple Host() matching (no complex path routing)
-# - No middleware needed (services handle their own paths)
-# - No conflicts with existing nginx catch-all (priority: 1)
+# Service names and ports verified against `helm template graviteeio/apim --version 4.11.4`.
+# No chart-managed Kubernetes Ingress is created — UIS owns routing here.
+# All routes are public (no Authentik forward auth) for v1; SSO is a follow-up plan.
 
 ---
-# =============================================================================
-# DEVELOPER DOMAIN - API Gateway 
-# =============================================================================
-
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: gravitee-api-gateway
-  namespace: default
+  name: gravitee-console
+  namespace: gravitee
   labels:
     app: gravitee-apim
-    component: api-gateway
-    domain: developer
-    protection: none
+    component: ui
 spec:
   entryPoints:
     - web
   routes:
-    - match: Host(`api.localhost`)
-      kind: Rule
-      services:
-        - name: gravitee-apim-gateway
-          port: 82
-
----
-# =============================================================================
-# DEVELOPER DOMAIN - Portal UI
-# =============================================================================
-
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: gravitee-developer-portal
-  namespace: default
-  labels:
-    app: gravitee-apim
-    component: developer-portal
-    domain: developer
-    protection: none
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`portal.localhost`)
-      kind: Rule
-      services:
-        - name: gravitee-apim-portal
-          port: 8003
-
----
-# =============================================================================
-# ADMIN DOMAIN - Management Console
-# =============================================================================
-
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: gravitee-admin-console
-  namespace: default
-  labels:
-    app: gravitee-apim
-    component: admin-console
-    domain: admin
-    protection: none
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`gravitee.localhost`)
+    - match: HostRegexp(`gravitee\..+`)
       kind: Rule
       services:
         - name: gravitee-apim-ui
           port: 8002
 
 ---
-# =============================================================================
-# ADMIN DOMAIN - Management API
-# =============================================================================
-
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: gravitee-admin-api
-  namespace: default
+  name: gravitee-management-api
+  namespace: gravitee
   labels:
     app: gravitee-apim
-    component: admin-api
-    domain: admin
-    protection: none
+    component: api
 spec:
   entryPoints:
     - web
   routes:
-    - match: Host(`gravitee-api.localhost`)
+    - match: HostRegexp(`gravitee-api\..+`)
       kind: Rule
       services:
         - name: gravitee-apim-api
           port: 83
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: gravitee-gateway
+  namespace: gravitee
+  labels:
+    app: gravitee-apim
+    component: gateway
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`gravitee-gw\..+`)
+      kind: Rule
+      services:
+        - name: gravitee-apim-gateway
+          port: 82
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: gravitee-portal
+  namespace: gravitee
+  labels:
+    app: gravitee-apim
+    component: portal
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`gravitee-portal\..+`)
+      kind: Rule
+      services:
+        - name: gravitee-apim-portal
+          port: 8003

--- a/manifests/091-gravitee-ingress.yaml
+++ b/manifests/091-gravitee-ingress.yaml
@@ -1,15 +1,30 @@
 # file: /mnt/urbalurbadisk/manifests/091-gravitee-ingress.yaml
-# description: Hostname-based ingress for Gravitee APIM 4.11
+# description: Hostname + path routing for Gravitee APIM 4.11
 #
 # HOSTNAME STRATEGY (HostRegexp-based — works on localhost, Tailscale, Cloudflare):
-# - gravitee.<domain>         → Management Console (gravitee-apim-ui:8002)
-# - gravitee-api.<domain>     → Management API     (gravitee-apim-api:83)
-# - gravitee-gw.<domain>      → API Gateway        (gravitee-apim-gateway:82)
-# - gravitee-portal.<domain>  → Developer Portal   (gravitee-apim-portal:8003)
 #
-# Service names and ports verified against `helm template graviteeio/apim --version 4.11.4`.
-# No chart-managed Kubernetes Ingress is created — UIS owns routing here.
-# All routes are public (no Authentik forward auth) for v1; SSO is a follow-up plan.
+#   gravitee.<domain>              Console SPA (gravitee-apim-ui:8002)
+#   gravitee.<domain>/management/  Management API (gravitee-apim-api:83)
+#   gravitee.<domain>/portal/      Portal-facing API (same api pod, different sub-path)
+#   gravitee-portal.<domain>       Developer Portal SPA (gravitee-apim-portal:8003)
+#   gravitee-gw.<domain>           Public API Gateway (gravitee-apim-gateway:82)
+#
+# WHY CONSOLE + API SHARE A HOSTNAME:
+# Gravitee's auth uses an HttpOnly session cookie set by the management API on
+# login. Cross-origin XHR (Console at gravitee.<domain> calling API at a
+# different subdomain) needs SameSite=None;Secure, which requires HTTPS. On
+# plain HTTP for laptop dev, the only workable shape is same-origin: route the
+# management API under /management/ on the Console hostname so cookies travel
+# trivially. This matches the chart's default deployment shape (Console at
+# /console/, API at /management/ on the same host).
+#
+# Match priorities are explicit: PathPrefix routes have priority 100 so they
+# match before the catch-all root route on the same host.
+#
+# Service names and ports verified against `helm template graviteeio/apim
+# --version 4.11.3`. No chart-managed Kubernetes Ingress is created — UIS owns
+# routing here. All routes are public (no Authentik forward auth) for v1;
+# SSO is a follow-up plan.
 
 ---
 apiVersion: traefik.io/v1alpha1
@@ -24,30 +39,20 @@ spec:
   entryPoints:
     - web
   routes:
+    # Management + portal API endpoints share the Console hostname. Higher
+    # priority than the catch-all UI route below so PathPrefix matches first.
+    - match: HostRegexp(`gravitee\..+`) && (PathPrefix(`/management`) || PathPrefix(`/portal`))
+      kind: Rule
+      priority: 100
+      services:
+        - name: gravitee-apim-api
+          port: 83
+    # Everything else on the Console hostname → SPA shell + assets.
     - match: HostRegexp(`gravitee\..+`)
       kind: Rule
       services:
         - name: gravitee-apim-ui
           port: 8002
-
----
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: gravitee-management-api
-  namespace: gravitee
-  labels:
-    app: gravitee-apim
-    component: api
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: HostRegexp(`gravitee-api\..+`)
-      kind: Rule
-      services:
-        - name: gravitee-apim-api
-          port: 83
 
 ---
 apiVersion: traefik.io/v1alpha1

--- a/provision-host/provision-host-02-kubetools.sh
+++ b/provision-host/provision-host-02-kubetools.sh
@@ -59,13 +59,16 @@ install_ansible_kubernetes() {
         add_status "Ansible" "Status" "Already installed (${ANSIBLE_VERSION})"
     else
         echo "Installing Ansible and Kubernetes Python module"
+        # ansible-core is installed from PyPI rather than the ppa:ansible/ansible PPA.
+        # Launchpad's HTTPS layer flakes regularly (504s, SSL handshake EOF), and the
+        # add-apt-repository call goes through api.launchpad.net which is the
+        # single point of failure. PyPI is more reliable. On Python 3.10 (Ubuntu 22.04),
+        # pip auto-resolves to ansible-core 2.17.x, which matches what the PPA shipped.
+        # python3-kubernetes still comes from apt (universe), unchanged.
         sudo apt-get update -qq || return 1
-        sudo apt-get install -qq -y software-properties-common || return 1
-        sudo add-apt-repository --yes --update ppa:ansible/ansible || return 1
-
-        # Install ansible-core (slim) instead of full ansible package (~350MB savings)
-        # Then install only the collections we actually use
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ansible-core python3-kubernetes || return 1
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends \
+            python3-pip python3-kubernetes || return 1
+        sudo pip3 install --quiet ansible-core || return 1
         check_command_success "Ansible" "Installation" || return 1
 
         # Install only required Ansible collections (used in our playbooks)
@@ -177,12 +180,21 @@ install_kubectl() {
     # Check if we're in a container or if snap is available
     if [ "$RUNNING_IN_CONTAINER" = "true" ] || ! command -v snap &> /dev/null; then
         echo "Installing kubectl directly (not using snap)"
-        KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-        curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl"
-        chmod +x kubectl
-        sudo mv kubectl /usr/local/bin/
+        KUBECTL_VERSION=$(curl -fL -s https://dl.k8s.io/release/stable.txt) || { add_error "kubectl" "Failed to fetch stable version"; return 1; }
+        if [ -z "$KUBECTL_VERSION" ]; then
+            add_error "kubectl" "Empty version from dl.k8s.io/release/stable.txt"
+            return 1
+        fi
+        curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl" || { add_error "kubectl" "Failed to download kubectl binary"; return 1; }
+        chmod +x kubectl || { add_error "kubectl" "Failed to chmod kubectl"; return 1; }
+        sudo mv kubectl /usr/local/bin/ || { add_error "kubectl" "Failed to move kubectl to /usr/local/bin/"; return 1; }
+        if ! command -v kubectl &> /dev/null; then
+            add_error "kubectl" "kubectl not on PATH after install"
+            return 1
+        fi
         KUBECTL_VERSION=$(kubectl version --client --output=yaml | grep gitVersion | cut -d' ' -f4)
         add_status "kubectl" "Status" "Installed (${KUBECTL_VERSION})"
+        return 0
     else
         echo "Installing kubectl using snap"
         if sudo snap install kubectl --classic; then
@@ -324,10 +336,14 @@ main() {
         sudo apt-get install -qq -y curl snapd || return 1
     fi
 
-    install_ansible_kubernetes || return 1
+    # Install kubectl, helm, k9s first — direct downloads from k8s.io / GitHub,
+    # most resilient. Ansible install (via PyPI) also avoids launchpad now,
+    # but we keep it last so a transient PyPI hiccup can't strand the cluster
+    # tooling that other scripts depend on.
     install_kubectl || return 1
-    install_k9s || return 1
     install_helm || return 1
+    install_k9s || return 1
+    install_ansible_kubernetes || return 1
 
     print_summary
 

--- a/provision-host/provision-host-provision.sh
+++ b/provision-host/provision-host-provision.sh
@@ -171,12 +171,6 @@ main() {
 
     print_summary
 
-    # In container builds, continue even if some scripts fail (e.g., snap not available)
-    if is_container && [ "$overall_exit_code" -ne 0 ]; then
-        echo "Some scripts failed but continuing (container build mode)"
-        exit 0
-    fi
-
     exit $overall_exit_code
 }
 

--- a/provision-host/uis/lib/service-deployment.sh
+++ b/provision-host/uis/lib/service-deployment.sh
@@ -188,12 +188,15 @@ deploy_single_service() {
 }
 
 # Remove a single service by ID
-# Usage: remove_single_service <service_id> [<app_name>]
+# Usage: remove_single_service <service_id> [<app_name>] [<purge>]
 # For multi-instance services, app_name is required and is passed as _app_name
 # extra-var to the removal playbook.
+# When purge="true", _purge=true is passed as an extra-var so the removal
+# playbook can drop persistent state (databases, roles, secrets, PVCs, namespace).
 remove_single_service() {
     local service_id="$1"
     local app_name="${2:-}"
+    local purge="${3:-false}"
     local script
 
     script=$(find_service_script "$service_id")
@@ -212,6 +215,7 @@ remove_single_service() {
     else
         log_info "Removing $SCRIPT_NAME ($service_id)..."
     fi
+    [[ "$purge" == "true" ]] && log_warn "Purge mode: persistent state will be deleted"
 
     # Load cluster config for target_host
     local cluster_config="$CONFIG_DIR/cluster-config.sh"
@@ -234,6 +238,7 @@ remove_single_service() {
         if [[ -f "$remove_playbook" ]]; then
             local -a ansible_args=("-e" "target_host=$target_host")
             [[ -n "$app_name" ]] && ansible_args+=("-e" "_app_name=$app_name")
+            [[ "$purge" == "true" ]] && ansible_args+=("-e" "_purge=true")
             log_info "Running removal: $SCRIPT_REMOVE_PLAYBOOK"
             # shellcheck disable=SC2086
             if ! ansible-playbook "$remove_playbook" "${ansible_args[@]}" $extra_params; then

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -373,17 +373,21 @@ cmd_deploy() {
 cmd_undeploy() {
     local service_id=""
     local app_name=""
+    local purge="false"
+    local yes="false"
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --app) app_name="$2"; shift 2 ;;
-            -*)    log_error "Unknown option: $1"; exit "$EXIT_GENERAL_ERROR" ;;
-            *)     [[ -z "$service_id" ]] && service_id="$1"; shift ;;
+            --app)   app_name="$2"; shift 2 ;;
+            --purge) purge="true"; shift ;;
+            --yes|-y) yes="true"; shift ;;
+            -*)      log_error "Unknown option: $1"; exit "$EXIT_GENERAL_ERROR" ;;
+            *)       [[ -z "$service_id" ]] && service_id="$1"; shift ;;
         esac
     done
 
     if [[ -z "$service_id" ]]; then
-        log_error "Usage: uis undeploy <service> [--app <name>]"
+        log_error "Usage: uis undeploy <service> [--app <name>] [--purge] [--yes]"
         exit 1
     fi
 
@@ -410,8 +414,26 @@ cmd_undeploy() {
         fi
     fi
 
+    # Confirmation prompt for --purge (skipped with --yes or non-TTY stdin)
+    if [[ "$purge" == "true" && "$yes" != "true" ]]; then
+        if [[ -t 0 ]]; then
+            log_warn "--purge will delete persistent state for '$service_id' (databases, roles, secrets, PVCs, namespace)."
+            log_warn "This is irreversible. Run with --yes to skip this prompt."
+            printf "Type 'yes' to continue: "
+            local reply
+            read -r reply
+            if [[ "$reply" != "yes" ]]; then
+                log_info "Aborted."
+                exit 0
+            fi
+        else
+            log_error "--purge requires interactive confirmation or --yes; stdin is not a TTY"
+            exit "$EXIT_GENERAL_ERROR"
+        fi
+    fi
+
     # Remove from kubernetes
-    remove_single_service "$service_id" "$app_name"
+    remove_single_service "$service_id" "$app_name" "$purge"
 }
 
 cmd_enable() {

--- a/provision-host/uis/services/integration/service-gravitee.sh
+++ b/provision-host/uis/services/integration/service-gravitee.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-# service-gravitee.sh - Gravitee API Gateway service metadata
+# service-gravitee.sh - Gravitee API Management service metadata
 #
-# Gravitee is an open-source API management platform.
+# Gravitee APIM is an open-source API management platform: API gateway,
+# admin Console, and Developer Portal. UIS deploys APIM 4.11 with
+# PostgreSQL as the management/config store via the JDBC repository
+# plugin (no MongoDB). Elasticsearch and Redis are intentionally not
+# deployed; analytics dashboards and rate-limit policies are disabled.
+#
+# See PLAN-gravitee-postgresql-deployment.md and INVESTIGATE-gravitee-fix.md.
 
 # === Service Metadata (Required) ===
 SCRIPT_ID="gravitee"
@@ -11,27 +17,34 @@ SCRIPT_CATEGORY="INTEGRATION"
 
 # === UIS-Specific (Optional) ===
 SCRIPT_PLAYBOOK="090-setup-gravitee.yml"
-SCRIPT_MANIFEST=""
-SCRIPT_CHECK_COMMAND="kubectl get pods -n gravitee -l app.kubernetes.io/name=gravitee --no-headers 2>/dev/null | grep -q Running"
-SCRIPT_REMOVE_PLAYBOOK=""
-SCRIPT_REQUIRES=""
-SCRIPT_PRIORITY="81"
+SCRIPT_MANIFEST="091-gravitee-ingress.yaml"
+SCRIPT_CHECK_COMMAND="kubectl get pods -n gravitee -l app.kubernetes.io/instance=gravitee-apim --no-headers 2>/dev/null | grep -qE '\\s(Running|Completed)\\s'"
+SCRIPT_REMOVE_PLAYBOOK="090-remove-gravitee.yml"
+SCRIPT_REQUIRES="postgresql"
+SCRIPT_PRIORITY="50"
 
 # === Deployment Details (Optional) ===
+# Pinned at the latest stable 4.11.x as of 2026-04-30. The graviteeio/apim
+# chart follows APIM versioning. Bump deliberately and re-run Phase 4
+# validation; chart breakages are usually visible in Liquibase migration
+# logs on first start of the Management API pod.
+# SCRIPT_IMAGE is informational only — the chart pulls per-component images
+# (graviteeio/apim-management-api, apim-gateway, apim-management-ui, apim-portal-ui).
+SCRIPT_IMAGE="graviteeio/apim:4.11.3"
 SCRIPT_HELM_CHART="graviteeio/apim"
-SCRIPT_NAMESPACE="default"
+SCRIPT_NAMESPACE="gravitee"
 
 # === Extended Metadata (Optional) ===
-SCRIPT_KIND="Component"        # Component | Resource
-SCRIPT_TYPE="service"          # service | tool | library | database | cache | message-broker
-SCRIPT_OWNER="app-team"   # platform-team | app-team
+SCRIPT_KIND="Component"
+SCRIPT_TYPE="service"
+SCRIPT_OWNER="platform-team"
 SCRIPT_PROVIDES_APIS="gravitee-api"
-SCRIPT_CONSUMES_APIS=""
+SCRIPT_CONSUMES_APIS="postgresql"
 
 # === Website Metadata (Optional) ===
-SCRIPT_ABSTRACT="Open-source API management platform for designing, deploying, and managing APIs"
+SCRIPT_ABSTRACT="A platform service that runs Gravitee API Management with PostgreSQL as the metadata store and no Elasticsearch/Redis dependencies."
 SCRIPT_LOGO="gravitee-logo.svg"
 SCRIPT_WEBSITE="https://www.gravitee.io"
-SCRIPT_TAGS="api-gateway,api-management,rest,graphql,security"
-SCRIPT_SUMMARY="Gravitee is an open-source API management platform that helps you design, deploy, and manage APIs. It provides a gateway, management console, and developer portal for comprehensive API lifecycle management."
+SCRIPT_TAGS="api-gateway,api-management,gravitee,postgresql"
+SCRIPT_SUMMARY="Gravitee APIM is an open-source API gateway and management platform with admin Console, Developer Portal, and runtime API gateway. UIS deploys APIM 4.11 with PostgreSQL as the management store via the JDBC repository plugin (no MongoDB). Elasticsearch and Redis are not deployed; analytics dashboards and rate-limit policies are disabled. Suitable for laptop-scale development clusters."
 SCRIPT_DOCS="/docs/services/integration/gravitee"

--- a/provision-host/uis/templates/secrets-templates/00-common-values.env.template
+++ b/provision-host/uis/templates/secrets-templates/00-common-values.env.template
@@ -172,6 +172,17 @@ BACKSTAGE_SESSION_SECRET=generate-a-session-secret-here
 # OIDC secrets are in PLAN-003 (Authentik integration)
 
 # ================================================================
+# 🔧 OPTIONAL - GRAVITEE APIM
+# ================================================================
+# Gravitee uses PostgreSQL as the management/config store via the
+# JDBC repository plugin (no MongoDB). Database and user are created
+# by the Gravitee setup playbook against the shared postgresql service.
+# Schema is auto-applied by Liquibase on first start.
+GRAVITEE_POSTGRES_USER=gravitee_user
+GRAVITEE_POSTGRES_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
+GRAVITEE_POSTGRES_DATABASE=graviteedb
+
+# ================================================================
 # 🔧 OPTIONAL - APPLICATION-SPECIFIC
 # ================================================================
 # Add your own application variables here

--- a/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
+++ b/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
@@ -76,7 +76,13 @@ stringData:
   MONGODB_ROOT_USER: root
   MONGODB_ROOT_PASSWORD: "${MONGODB_ROOT_PASSWORD}"
 
-  # MongoDB is set up and initialized for use by Gravitee
+  # DEAD CODE — to be removed alongside MongoDB Gravitee bootstrap cleanup.
+  # Gravitee no longer uses MongoDB; it is configured against PostgreSQL via the
+  # gravitee/urbalurba-secrets block (see GRAVITEE_POSTGRES_* below). These three
+  # keys are kept only because 040-setup-mongodb.yml + 040-mongodb-config.yaml
+  # currently validate them on `./uis deploy mongodb`. They will be removed in
+  # the Gravitee-deployment-fix implementation, Phase 5 cleanup
+  # (see INVESTIGATE-gravitee-fix.md).
   GRAVITEE_MONGODB_DATABASE_NAME: graviteedb
   GRAVITEE_MONGODB_DATABASE_USER: gravitee_user
   GRAVITEE_MONGODB_DATABASE_PASSWORD: "${MONGODB_ROOT_PASSWORD}"
@@ -107,36 +113,6 @@ stringData:
   # QDRANT VECTOR DATABASE
   # ================================================================
   QDRANT_API_KEY: "${QDRANT_API_KEY}"
-
-  # ================================================================
-  # GRAVITEE.IO API MANAGEMENT SYSTEM
-  # ================================================================
-  
-  # Gravitee admin user
-  GRAVITEE_ADMIN_EMAIL: "${DEFAULT_ADMIN_EMAIL}"
-  GRAVITEE_ADMIN_PASSWORD: "${DEFAULT_ADMIN_PASSWORD}"
-
-  # Gravitee domain names
-  # NOTE: These reference old Cloudflare variables that are no longer used
-  # Gravitee must be refactored to use the new Cloudflare tunnel setup approach
-  # (820-cloudflare-tunnel-setup.sh and 821-cloudflare-tunnel-deploy.sh)
-  #    GRAVITEE_TEST_CLOUDFLARE_DOMAIN is a pointer to this variable
-  #GRAVITEE_TEST_CLOUDFLARE_DOMAIN: CLOUDFLARE_TEST_DOMAINNAME
-  #    GRAVITEE_TEST_CLOUDFLARE_TUNNELNAME is a pointer to this variable
-  #GRAVITEE_TEST_CLOUDFLARE_TUNNELNAME: CLOUDFLARE_TEST_TUNNELNAME
-  # The main gateway where external developers and applications send API requests to access the APIs managed by Gravitee. (eg: api.nerdmeet.org)
-  GRAVITEE_TEST_GATEWAY_SUBDOMAIN: gateway-test
-  # The backend API that handles all management operations for Gravitee APIM, used by the management UI and for programmatic administration. (eg management-api.nerdmeet.org)
-  GRAVITEE_TEST_MANAGEMENT_API_SUBDOMAIN: management-api-test
-  # The web-based developer portal where API consumers can discover, test, and subscribe to APIs, as well as access documentation and manage their accounts.( eg portal.nerdmeet.org)
-  GRAVITEE_TEST_DEV_PORTAL_SUBDOMAIN: portal-test
-  # The web-based management interface where administrators configure and manage APIs, monitor traffic, set policies, and perform other administrative tasks for the Gravitee APIM platform. (eg:  management.nerdmeet.org)
-  GRAVITEE_TEST_MANAGEMENT_CONSOLE_SUBDOMAIN: management-test
-  # The backend API that serves data to the developer portal, handling operations like API discovery, documentation retrieval, and developer account management. (eg portal-api.nerdmeet.org)
-  GRAVITEE_TEST_DEV_PORTAL_API_SUBDOMAIN: portal-api-test
-
-  # Gravitee encryption key (used for encrypting sensitive data)
-  GRAVITEE_ENCRYPTION_KEY: EncryptionKey${DEFAULT_ADMIN_PASSWORD}  # Generate a secure random string for this
 
   # ================================================================
   # GRAFANA ADMIN CREDENTIALS
@@ -511,6 +487,50 @@ stringData:
 
   # Admin password for Enonic XP superuser (user: su)
   ENONIC_ADMIN_PASSWORD: "${ENONIC_ADMIN_PASSWORD}"
+
+# ================================================================
+# GRAVITEE NAMESPACE SECRETS
+# ================================================================
+---
+# Define the gravitee namespace first
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gravitee
+
+---
+# secrets for gravitee namespace
+apiVersion: v1
+kind: Secret
+metadata:
+  name: urbalurba-secrets
+  namespace: gravitee
+type: Opaque
+stringData:
+  # ================================================================
+  # GRAVITEE APIM CONFIGURATION
+  # ================================================================
+  # Gravitee uses PostgreSQL as the management/config store via the
+  # JDBC repository plugin (the official APIM distribution bundles
+  # the PostgreSQL driver). No MongoDB, no Elasticsearch, no Redis.
+  # See: website/docs/services/integration/gravitee.md
+
+  # PostgreSQL connection (reuses the cluster's shared postgresql service)
+  GRAVITEE_POSTGRES_HOST: "${PGHOST}.svc.cluster.local"
+  GRAVITEE_POSTGRES_PORT: "5432"
+  GRAVITEE_POSTGRES_USER: "${GRAVITEE_POSTGRES_USER}"
+  GRAVITEE_POSTGRES_PASSWORD: "${GRAVITEE_POSTGRES_PASSWORD}"
+  GRAVITEE_POSTGRES_DATABASE: "${GRAVITEE_POSTGRES_DATABASE}"
+  # Pre-assembled JDBC URL for the Gravitee management.jdbc.url property
+  GRAVITEE_POSTGRES_JDBC_URL: "jdbc:postgresql://${PGHOST}.svc.cluster.local:5432/${GRAVITEE_POSTGRES_DATABASE}"
+
+  # Gravitee admin (login at the Console)
+  GRAVITEE_ADMIN_EMAIL: "${DEFAULT_ADMIN_EMAIL}"
+  GRAVITEE_ADMIN_PASSWORD: "${DEFAULT_ADMIN_PASSWORD}"
+
+  # Gravitee encryption key (used for encrypting sensitive data at rest)
+  # TODO: replace with a secure random string for non-dev environments
+  GRAVITEE_ENCRYPTION_KEY: "EncryptionKey${DEFAULT_ADMIN_PASSWORD}"
 
 # ================================================================
 # NEXTCLOUD NAMESPACE SECRETS

--- a/uis
+++ b/uis
@@ -282,6 +282,26 @@ case "${1:-help}" in
         # Clean up old temp directories
         docker exec "$CONTAINER_NAME" rm -rf /mnt/urbalurbadisk/.temp /mnt/urbalurbadisk/generate 2>/dev/null || true
 
+        # Test 0: deploy-flow binaries are present
+        # Catches silent regressions in the provision-host-02-kubetools.sh layer
+        # (e.g. a curl from dl.k8s.io failing without aborting the build, leaving
+        # an empty /usr/local/bin/kubectl). Without this, missing binaries only
+        # surface when an actual ./uis deploy runs against a cluster.
+        log_info "Test 0: deploy-flow binary presence"
+        docker exec "$CONTAINER_NAME" bash -c '
+          set -e
+          for bin in kubectl helm ansible-playbook python3; do
+            if ! command -v "$bin" >/dev/null 2>&1; then
+              echo "MISSING: $bin not found on PATH" >&2
+              exit 1
+            fi
+            echo "  $bin: $(command -v "$bin")"
+          done
+          # bcrypt is needed by 090-setup-gravitee.yml for admin-password wiring
+          python3 -c "import bcrypt" || { echo "MISSING: python3 bcrypt module" >&2; exit 1; }
+          echo "  python3 bcrypt: ok"
+        '
+
         # Test 1: uis-cli version
         log_info "Test 1: uis-cli version"
         docker exec "$CONTAINER_NAME" /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh version

--- a/website/docs/ai-developer/plans/active/PLAN-gravitee-postgresql-deployment.md
+++ b/website/docs/ai-developer/plans/active/PLAN-gravitee-postgresql-deployment.md
@@ -1,0 +1,420 @@
+# Plan: Gravitee APIM 4.11 deployment on PostgreSQL
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active
+
+**Goal**: After this plan, `./uis deploy postgresql && ./uis deploy gravitee` on a fresh local cluster produces a working Gravitee APIM 4.11 deployment with admin Console, Developer Portal, and API Gateway, backed by PostgreSQL — no MongoDB, no Elasticsearch, no Redis. `./uis undeploy gravitee --purge` cleanly tears down all Gravitee state.
+
+**Last Updated**: 2026-04-30
+
+**Investigation**: [INVESTIGATE-gravitee-fix.md](../backlog/INVESTIGATE-gravitee-fix.md) — 17 decisions resolved, 12 open checks (all empirical, handled during implementation).
+
+**Strategy**: Ships as **two PRs**:
+
+- **PR-A** (this plan, Phases 1–4) — "Make it work." Single PR; Phases 1–4 are inseparable because Phase 4 validates the others.
+- **PR-B** (Phase 5) — "Clean up MongoDB residue." Separate PR, gated on PR-A merged + verified on a fresh cluster. Removes dead code from the MongoDB-side bootstrap and the transition-stub keys.
+
+**Prerequisites**:
+- The investigation document is complete; no design questions remain that would affect plan structure.
+- The platform's PostgreSQL service (manifest 042) is already deployed and working — Gravitee is a consumer, not a provisioner.
+
+**Blocks**:
+- A future PLAN to enable Elasticsearch-backed analytics if the analytics tab becomes a real requirement.
+- A future PLAN to add Redis if rate-limit/caching policies become a real requirement.
+- A future PLAN to add Authentik forward-auth in front of Gravitee.
+
+---
+
+## Pre-conditions — what already landed during the investigation
+
+Phase 1 of this plan is **partially complete in the working tree** at the time of writing. The following changes are already in place; the implementation should NOT redo them:
+
+- `provision-host/uis/templates/secrets-templates/00-common-values.env.template` — `GRAVITEE_POSTGRES_USER`, `GRAVITEE_POSTGRES_PASSWORD`, `GRAVITEE_POSTGRES_DATABASE` first-class variables added under a new "OPTIONAL - GRAVITEE APIM" section.
+- `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template`:
+  - New `gravitee/urbalurba-secrets` block with `GRAVITEE_POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE/JDBC_URL`, `GRAVITEE_ADMIN_EMAIL`, `GRAVITEE_ADMIN_PASSWORD`, `GRAVITEE_ENCRYPTION_KEY`.
+  - Old `GRAVITEE.IO API MANAGEMENT SYSTEM` block removed from the `default` namespace.
+  - Three `GRAVITEE_MONGODB_DATABASE_*` keys retained as **transition stubs** (with deprecation comment) in the MongoDB section, because `040-setup-mongodb.yml` still validates their presence on `./uis deploy mongodb`. These are removed in PR-B / Phase 5.
+- `website/docs/services/integration/gravitee.md` — service doc rewritten around the new architecture, with an "Implementation in Progress" banner and the "What we lose by skipping ES and Redis" subsection.
+
+The implementation starts from this state.
+
+---
+
+# PR-A — Phases 1–4: Make it work
+
+Single PR, single feature branch. Merging unblocks the user-facing `./uis deploy gravitee` flow.
+
+## Phase 1: Service metadata
+
+Finishes the work the investigation started. Service-script rewrite + a regen + a dry-run-apply of the secrets block.
+
+### Tasks
+
+- [ ] 1.1 Rewrite `provision-host/uis/services/integration/service-gravitee.sh` per the target shape in [INVESTIGATE-gravitee-fix.md § Recommended Target Shape § Service metadata](../backlog/INVESTIGATE-gravitee-fix.md#recommended-target-shape). Pin `SCRIPT_IMAGE="graviteeio/apim:4.11.3"`.
+- [ ] 1.2 Add `SCRIPT_LOGO="gravitee-logo.svg"` and source the SVG from Gravitee's official brand assets into `website/static/img/services/gravitee-logo.svg`. Strip embedded CSS / scripts; ensure ~24×24 viewBox so it renders cleanly in the services table.
+- [ ] 1.3 Regenerate `services.json` and the per-service docs that depend on it:
+  ```bash
+  ./uis-docs.sh
+  ```
+  Service doc page `gravitee.md` already exists with the target content; the generator skips it (skip-if-exists). Verify the metadata table in `gravitee.md` reflects the new `SCRIPT_*` values — if it doesn't, that's because the page was hand-edited; manually update only the metadata table.
+- [ ] 1.4 Dry-run-apply the secrets:
+  ```bash
+  ./uis secrets generate
+  kubectl apply --dry-run=client -f .uis.secrets/generated/kubernetes/kubernetes-secrets.yml
+  ```
+  Expect: clean parse, gravitee namespace + secret render correctly, all `GRAVITEE_POSTGRES_*` keys populate from the env template.
+
+### Validation
+
+```bash
+# Service registers correctly
+./uis list | grep gravitee
+# Expect: namespace `gravitee`, dependencies `postgresql`, REMOVE playbook present.
+
+jq '.services[] | select(.id == "gravitee")' website/src/data/services.json
+# Expect: namespace=gravitee, requires=["postgresql"], image=graviteeio/apim:4.11.3
+```
+
+User confirms the service entry is sane before moving on.
+
+---
+
+## Phase 2: Helm values + IngressRoutes
+
+Builds the deployable configuration. No deploy yet — this phase produces files that Phase 3's playbook will apply.
+
+### Tasks
+
+- [ ] 2.1 **Verify chart resource names** before writing the IngressRoute manifest (Open Check #1):
+  ```bash
+  helm repo add graviteeio https://helm.gravitee.io 2>/dev/null
+  helm repo update graviteeio
+  helm template gravitee-apim graviteeio/apim --version 4.11.3 \
+      --namespace gravitee \
+      --set mongodb-replicaset.enabled=false \
+      --set elasticsearch.enabled=false \
+      --set ratelimit.type=none \
+      --set analytics.enabled=false \
+      --set api.ingress.management.enabled=false \
+      --set api.ingress.portal.enabled=false \
+      --set gateway.ingress.enabled=false \
+      --set ui.ingress.enabled=false \
+      --set portal.ingress.enabled=false \
+      | grep -E '^(kind: Service|  name:|  namespace:|    port:|    targetPort:)' | head -60
+  ```
+  Capture the four Service names and their HTTP ports. Use these as the source of truth for both 2.2 (IngressRoute) and 2.3 (`SCRIPT_CHECK_COMMAND`'s instance label).
+
+- [ ] 2.2 Rewrite `manifests/091-gravitee-ingress.yaml` per the target shape in [INVESTIGATE-gravitee-fix.md § Recommended Target Shape § IngressRoute](../backlog/INVESTIGATE-gravitee-fix.md#recommended-target-shape). Substitute the actual service names and ports from 2.1.
+
+- [ ] 2.3 Update `service-gravitee.sh` `SCRIPT_CHECK_COMMAND` if 2.1 reveals the instance label is different from the placeholder `app.kubernetes.io/instance=gravitee-apim`.
+
+- [ ] 2.4 Rewrite `manifests/090-gravitee-config.yaml` per the target shape in [INVESTIGATE-gravitee-fix.md § Recommended Target Shape § Helm values](../backlog/INVESTIGATE-gravitee-fix.md#recommended-target-shape). Specifically:
+  - Disable bundled subcharts (`mongodb-replicaset.enabled: false`, `elasticsearch.enabled: false`, `es.enabled: false`).
+  - `management.type: jdbc`, with JDBC URL/username/password.
+  - `ratelimit.type: none`, `analytics.enabled: false`.
+  - Disable chart-managed ingress on `api`, `gateway`, `ui`, `portal`.
+  - Per-component `resources.requests` and `resources.limits` per the laptop-tuned table in the investigation.
+  - **Critical** (Decision #16): set `ui.env.MANAGEMENT_URL` and `portal.env.PORTAL_API_URL` (or the actual chart key per Open Check #3) to the external Management API hostname `http://gravitee-api.localhost`.
+  - **Critical** (Decision #17): set `api.cors.allowOrigin: "*"` (or actual chart key per Open Check #4).
+
+- [ ] 2.5 Resolve Open Check #2 — try `secret://kubernetes/urbalurba-secrets:KEY` for `management.jdbc.url/username/password`. If pod logs in Phase 4 show `unable to resolve secret reference`, switch to the `extraEnvs` fallback shown in the investigation (apply on **both** `api` and `gateway` blocks).
+
+### Validation
+
+```bash
+kubectl apply --dry-run=client -f manifests/091-gravitee-ingress.yaml
+# Expect: 4 IngressRoutes, no schema errors.
+
+# Helm values render check (still no deploy)
+helm template gravitee-apim graviteeio/apim --version 4.11.3 \
+    --namespace gravitee \
+    -f manifests/090-gravitee-config.yaml \
+    | head -40
+# Expect: no chart-managed Ingress objects in output, JDBC env vars present on api+gateway.
+```
+
+User confirms the rendered values match the intent before moving to Phase 3.
+
+---
+
+## Phase 3: Setup and remove playbooks
+
+### Tasks
+
+- [ ] 3.1 Rewrite `ansible/playbooks/090-setup-gravitee.yml` from scratch around the standard UIS playbook pattern. Steps (per investigation):
+  1. Display deployment context (namespace, chart version, target Postgres host).
+  2. Ensure namespace `gravitee` exists.
+  3. Verify `gravitee/urbalurba-secrets` carries the required `GRAVITEE_POSTGRES_*` and admin keys. Fail with a clear message if missing.
+  4. **Bootstrap database**: idempotently create `graviteedb` and `gravitee_user` against `postgresql.default.svc.cluster.local` using the Postgres admin password from `default/postgresql` secret. Mirror the existing pattern used by Backstage / OpenWebUI / OpenMetadata for Postgres-backed apps. All secret-handling tasks set `no_log: true`.
+  5. Ensure the `graviteeio` Helm repo is registered and up to date.
+  6. Install/upgrade `graviteeio/apim` at `4.11.3` with values from `manifests/090-gravitee-config.yaml` using `kubernetes.core.helm`.
+  7. Apply `manifests/091-gravitee-ingress.yaml` with `kubernetes.core.k8s`.
+  8. Wait for all four Deployments (`gravitee-apim-api`, `gravitee-apim-gateway`, `gravitee-apim-ui`, `gravitee-apim-portal`) to reach Available — use the chart's actual deployment names from Phase 2.1.
+  9. Health-probe internal endpoints from inside the cluster:
+     - `curl -fsS http://gravitee-apim-api.gravitee.svc.cluster.local:83/management/health`
+     - `curl -fsS http://gravitee-apim-gateway.gravitee.svc.cluster.local:82/_node/health`
+     - (Verify exact paths/ports against Open Check #5 results.)
+  10. Print concise access URLs (`http://gravitee.localhost`, `gravitee-api.localhost`, `gravitee-gw.localhost`, `gravitee-portal.localhost`) and a one-line admin login hint sourcing email/password from the secret.
+
+- [ ] 3.2 Create `ansible/playbooks/090-remove-gravitee.yml`:
+  - Default mode: uninstall the `gravitee-apim` Helm release; remove the four IngressRoute objects from namespace `gravitee`. Keep PVCs, secret, namespace.
+  - **`--purge` mode** (Decision #2: aggressive purge): also drop `graviteedb` + `gravitee_user` on PostgreSQL, delete `gravitee/urbalurba-secrets`, delete all PVCs in the `gravitee` namespace, delete the namespace itself. Trigger via Ansible extra-var `gravitee_purge=true`. The setup playbook should be wired so `./uis undeploy gravitee --purge` passes the flag.
+  - **Confirmation prompt**: when `gravitee_purge=true` and stdin is a TTY, prompt "About to drop the gravitee database, role, secret, namespace, and all PVCs. Type 'yes' to continue:". Skip the prompt when `gravitee_purge_yes=true` is also set (for automation / CI).
+  - All destructive tasks `no_log: true`.
+
+- [ ] 3.3 Verify `./uis undeploy gravitee --purge` plumbs through to `gravitee_purge=true`. If the existing `service-deployment.sh` doesn't already pass `--purge`-style flags, update it minimally — same plumbing PostgREST uses for `--app`/`--url-prefix`.
+
+### Validation
+
+```bash
+# Lint
+ansible-playbook --syntax-check ansible/playbooks/090-setup-gravitee.yml
+ansible-playbook --syntax-check ansible/playbooks/090-remove-gravitee.yml
+
+# Dry-run setup (will fail at the actual helm install — that's fine, we want
+# to see steps 1-3 succeed and the bootstrap SQL render correctly)
+ANSIBLE_VAULT_PASSWORD_FILE=... \
+    ansible-playbook ansible/playbooks/090-setup-gravitee.yml --check
+```
+
+User confirms playbook structure follows UIS conventions before Phase 4.
+
+---
+
+## Phase 4: End-to-end validation — the PR-A merge gate
+
+This is the gate. PR-A does not merge until everything in this phase passes on a freshly-reset cluster.
+
+### Tasks
+
+- [ ] 4.1 Reset the local cluster to a known clean state (Rancher Desktop "Reset Kubernetes" or equivalent). Confirm no `gravitee*` namespace, no `gravitee*` pods, no MongoDB-Gravitee residue.
+
+- [ ] 4.2 Bring up dependencies:
+  ```bash
+  ./uis secrets generate
+  ./uis secrets apply
+  ./uis deploy postgresql
+  ```
+  Confirm `postgresql-0` Ready, `default/urbalurba-secrets` carries the new `gravitee/...` block (rendered, not in default), and `gravitee/urbalurba-secrets` carries `GRAVITEE_POSTGRES_*`.
+
+- [ ] 4.3 Deploy:
+  ```bash
+  ./uis deploy gravitee
+  ```
+  Expected: setup playbook completes; all four Deployments reach Available within a reasonable time (Helm chart timeout: 10 minutes).
+
+- [ ] 4.4 **Resolve Open Checks during the live deploy**:
+  - **#3 (SPA URL config)**: load `http://gravitee.localhost`. If the Console SPA can fetch its constants and reach `http://gravitee-api.localhost/management/...`, the `ui.env.MANAGEMENT_URL` setting is correct. Otherwise, browser DevTools will show a 404 / CORS error pointing at the wrong URL — adjust `ui.env.*` and re-deploy.
+  - **#4 (CORS)**: same load attempt — CORS errors in DevTools mean the API server isn't allowing the Console origin. Adjust `api.cors.*`.
+  - **#5 (health endpoint paths)**: confirm the Step 9 curl in `090-setup-gravitee.yml` actually returns 200, not 404.
+  - **#6 (Liquibase migration ownership)**: inspect both `gravitee-apim-api` and `gravitee-apim-gateway` startup logs side-by-side. Expectation: only one runs Liquibase. If both attempt migrations, document the lock-conflict behavior and decide whether to delay gateway start.
+  - **#7 (rate-limit-with-none-store UX)**: in the Console, try to apply a rate-limit policy to a sample API. Document what happens (UI disables the option / accepts but warns / silent no-op). Add the result to `gravitee.md` Troubleshooting if it's surprising.
+  - **#9 (PVCs)**: list PVCs in the `gravitee` namespace. Decide which `--purge` should remove (recommend: all of them, given Decision #2 chose aggressive purge).
+
+- [ ] 4.5 Verify all four URLs resolve from the host:
+  ```bash
+  curl -fsS http://gravitee.localhost/                            # Console SPA root
+  curl -fsS http://gravitee-api.localhost/management/health       # 200 OK
+  curl -fsS http://gravitee-gw.localhost/_node/health             # 200 OK
+  curl -fsS http://gravitee-portal.localhost/                     # Portal SPA root
+  ```
+
+- [ ] 4.6 Log into the Console at `http://gravitee.localhost` with `${DEFAULT_ADMIN_EMAIL}` / `${DEFAULT_ADMIN_PASSWORD}`. Create a sample API. Deploy it. Hit it via the Gateway. (This verifies the full management → gateway → request-proxy flow against real PostgreSQL state. Manual; not part of the automated smoke test, which stays health-only per Decision #4.)
+
+- [ ] 4.7 Verify PostgreSQL state from outside Gravitee:
+  ```bash
+  PGPW=$(kubectl get secret postgresql -n default -o jsonpath='{.data.postgres-password}' | base64 -d)
+  kubectl exec -n default postgresql-0 -- bash -c \
+      "PGPASSWORD='$PGPW' psql -U postgres -At -c '\l graviteedb'"
+  kubectl exec -n default postgresql-0 -- bash -c \
+      "PGPASSWORD='$PGPW' psql -U postgres -d graviteedb -At -c '\dn api_v1; \dt' | head"
+  ```
+  Expect: `graviteedb` exists, owned by `gravitee_user`. The Liquibase-managed schema has tables (count > 0).
+
+- [ ] 4.8 Idempotency: re-run `./uis deploy gravitee` against the running cluster. Expect: `helm upgrade` no-op (or near no-op), no schema changes, all four Deployments stay Available.
+
+- [ ] 4.9 Lifecycle test:
+  ```bash
+  ./uis undeploy gravitee
+  ```
+  Expect: Helm release removed, four IngressRoutes gone, namespace + PVCs + secret + database all preserved.
+  ```bash
+  ./uis deploy gravitee
+  ```
+  Expect: re-deploy succeeds with no re-bootstrap required (database + roles already exist; secret already exists; chart re-installs cleanly).
+
+- [ ] 4.10 Purge test (manual, last):
+  ```bash
+  echo "yes" | ./uis undeploy gravitee --purge
+  ```
+  Expect: confirmation prompt appears; on `yes`, the database, role, secret, all PVCs, and the namespace are gone. Followed by a clean redeploy:
+  ```bash
+  ./uis deploy gravitee
+  ```
+  Expect: full bootstrap rerun, Liquibase recreates schema, all four pods reach Ready.
+
+- [ ] 4.11 Update Open Check answers in [INVESTIGATE-gravitee-fix.md](../backlog/INVESTIGATE-gravitee-fix.md) — replace each open check with the resolved answer. The investigation file moves from `backlog/` to `completed/` after PR-B merges.
+
+### Validation
+
+The Phase 4 task list IS the validation. PR-A merges only when all 11 boxes are checked and the results captured in the PR description.
+
+---
+
+## PR-A acceptance criteria
+
+- [ ] `./uis list` shows Gravitee in namespace `gravitee` with `SCRIPT_REQUIRES="postgresql"` and a populated `SCRIPT_REMOVE_PLAYBOOK`.
+- [ ] `./uis deploy gravitee` deploys APIM 4.11.3 with all four Deployments reaching Available. Gravitee itself does not deploy or depend on MongoDB / Elasticsearch / Redis — none appear in the `gravitee` namespace, and no Gravitee pod holds connections to those services. (UIS may run those services for other consumers; this criterion is about Gravitee's dependencies.)
+- [ ] PostgreSQL contains a `graviteedb` database owned by `gravitee_user`, with a non-empty Liquibase-managed schema.
+- [ ] No tracked manifest contains a literal Gravitee password, JDBC URL with credentials, or admin password.
+- [ ] All four URLs (`http://gravitee.localhost`, `gravitee-api.localhost`, `gravitee-gw.localhost`, `gravitee-portal.localhost`) return 200.
+- [ ] Admin login + create-API + proxy-request flow works once end-to-end (manual test, captured in PR description).
+- [ ] `./uis undeploy gravitee` removes Helm release and IngressRoutes; PVCs, secret, namespace, database preserved. `./uis deploy gravitee` afterward succeeds without re-bootstrap.
+- [ ] `./uis undeploy gravitee --purge` prompts for confirmation, then drops database + role + secret + PVCs + namespace. `./uis deploy gravitee` afterward succeeds with a full bootstrap from scratch.
+- [ ] Open Checks #1, #3, #4, #5, #6, #7, #9 from the investigation are resolved with concrete answers captured in the PR description.
+
+---
+
+# PR-B — Phase 5: MongoDB-residue cleanup
+
+Separate PR. Gates on PR-A merged + verified on at least one fresh cluster bringup. Mechanical cleanup, no behavior change for Gravitee.
+
+## Phase 5: dead-code removal
+
+### Tasks
+
+- [ ] 5.1 Remove the Gravitee-specific blocks from `manifests/040-mongodb-config.yaml` — the init container that creates the `gravitee_user` and `graviteedb` MongoDB user/database (lines ~63 onward). Verify nothing else in the manifest references those env keys.
+- [ ] 5.2 Remove the Gravitee-specific blocks from `ansible/playbooks/040-setup-mongodb.yml` — the validation loop assertion (line ~52) and the verification task (lines ~165–167). The remaining MongoDB setup must still work for any OTHER consumer; a green `./uis deploy mongodb` after this change is the validation.
+- [ ] 5.3 Remove the three transition-stub keys from `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` (`GRAVITEE_MONGODB_DATABASE_NAME/USER/PASSWORD`) and the multi-line deprecation comment block above them.
+- [ ] 5.4 Update `troubleshooting/debug-mongodb.sh` — remove the three `GRAVITEE_MONGODB_DATABASE_*` lookups (lines ~59–61). Replace with a one-line comment noting Gravitee no longer uses MongoDB.
+- [ ] 5.5 Grep the entire repo for `GRAVITEE_MONGODB` — target zero matches. If any remain, decide case-by-case (delete or update).
+- [ ] 5.6 Add `ansible/playbooks/090-test-gravitee.yml` covering: pods Ready, four IngressRoutes resolve, Management API health 200, Gateway `/_node/health` 200, Console root 200, Portal root 200. Health-only per Decision #4.
+- [ ] 5.7 Register Gravitee in the `./uis test-all` flow.
+- [ ] 5.8 Update the integration-testing docs to remove the "Gravitee always skipped" callout.
+- [ ] 5.9 Move `INVESTIGATE-gravitee-fix.md` from `plans/backlog/` to `plans/completed/`. Mark this plan completed and move it from `plans/active/` to `plans/completed/`.
+
+### Validation
+
+```bash
+# MongoDB still works for non-Gravitee consumers
+./uis undeploy mongodb
+./uis deploy mongodb
+# Expect: green; no Gravitee-related validation errors.
+
+# Zero Gravitee-MongoDB references in tracked files
+grep -r "GRAVITEE_MONGODB" \
+    provision-host ansible manifests troubleshooting \
+    website/docs/services website/src/data 2>/dev/null
+# Expect: no output.
+
+# Test playbook works
+./uis verify gravitee
+./uis test-all
+# Expect: gravitee included, all checks pass.
+```
+
+---
+
+## PR-B acceptance criteria
+
+- [ ] `grep -r GRAVITEE_MONGODB` across tracked files returns zero matches.
+- [ ] `./uis deploy mongodb` succeeds on a fresh cluster (no Gravitee bootstrap, since Gravitee no longer uses MongoDB).
+- [ ] `./uis verify gravitee` passes against a running deployment from PR-A.
+- [ ] `./uis test-all` includes Gravitee and reports green.
+- [ ] Investigation document moved to `completed/`. Plan document moved to `completed/`.
+
+---
+
+## Validation Commands (post-merge, both PRs)
+
+```bash
+# Full bringup chain on a fresh cluster
+./uis secrets generate
+./uis secrets apply
+./uis deploy postgresql
+./uis deploy gravitee
+
+# Health checks
+curl -fsS http://gravitee.localhost/
+curl -fsS http://gravitee-api.localhost/management/health
+curl -fsS http://gravitee-gw.localhost/_node/health
+curl -fsS http://gravitee-portal.localhost/
+
+# Database side
+PGPW=$(kubectl get secret postgresql -n default -o jsonpath='{.data.postgres-password}' | base64 -d)
+kubectl exec -n default postgresql-0 -- bash -c \
+    "PGPASSWORD='$PGPW' psql -U postgres -At -c '\l graviteedb'"
+
+# Cluster side
+kubectl get pods -n gravitee
+kubectl get ingressroute -n gravitee
+kubectl get secret urbalurba-secrets -n gravitee -o jsonpath='{.data}' | jq 'keys'
+
+# Lifecycle
+./uis undeploy gravitee
+./uis deploy gravitee
+echo "yes" | ./uis undeploy gravitee --purge
+./uis deploy gravitee
+
+# Automated test
+./uis verify gravitee
+./uis test-all
+```
+
+---
+
+## Files Modified
+
+### PR-A (Phases 1–4)
+
+| File | Change |
+|------|--------|
+| `provision-host/uis/services/integration/service-gravitee.sh` | Replaced. New SCRIPT_* values per investigation target shape. |
+| `manifests/090-gravitee-config.yaml` | Replaced. Helm values for APIM 4.11.3, JDBC backend, no ES/Redis, chart ingress disabled, laptop-tuned resources, SPA URL config, CORS. |
+| `manifests/091-gravitee-ingress.yaml` | Replaced. Four `HostRegexp` IngressRoutes in `gravitee` namespace. |
+| `ansible/playbooks/090-setup-gravitee.yml` | Replaced. Standard UIS playbook pattern, ~150–200 lines (down from 465). |
+| `ansible/playbooks/090-remove-gravitee.yml` | Created. Default + `--purge` modes with confirmation prompt. |
+| `provision-host/uis/lib/service-deployment.sh` | Possibly minor change in 3.3 to wire `--purge` through to the remove playbook. |
+| `website/static/img/services/gravitee-logo.svg` | Added. Sourced from Gravitee's brand assets. |
+| `website/src/data/services.json` | Regenerated by `./uis-docs.sh`. |
+
+### PR-B (Phase 5)
+
+| File | Change |
+|------|--------|
+| `manifests/040-mongodb-config.yaml` | Removed Gravitee-specific MongoDB user/database init. |
+| `ansible/playbooks/040-setup-mongodb.yml` | Removed Gravitee secret-key validation and verification task. |
+| `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` | Removed three `GRAVITEE_MONGODB_DATABASE_*` transition-stub keys + deprecation comment. |
+| `troubleshooting/debug-mongodb.sh` | Removed Gravitee MongoDB lookups. |
+| `ansible/playbooks/090-test-gravitee.yml` | Created. Health-only smoke checks. |
+| `website/docs/ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md` | Moved to `completed/`. |
+| `website/docs/ai-developer/plans/active/PLAN-gravitee-postgresql-deployment.md` | Moved to `completed/`. |
+| Integration testing docs (TBD path) | Removed "Gravitee always skipped" callout. |
+
+---
+
+## Out of Scope (explicitly)
+
+- **No Authentik forward-auth.** Gravitee runs with its own admin login for v1. SSO is a future plan.
+- **No Elasticsearch.** Analytics tab in Console stays empty by design. Switch on later if needed.
+- **No Redis.** Rate-limit and response-cache policies don't enforce. Switch on later if needed.
+- **No collision detection for old MongoDB-Gravitee state.** This plan assumes a fresh local cluster. Contributors with old state on their cluster manually clean it up before deploying.
+- **No production hardening for `GRAVITEE_ENCRYPTION_KEY`.** Default value derived from `${DEFAULT_ADMIN_PASSWORD}`; replace with a securely-generated random key when deploying outside dev.
+- **No functional smoke test (create-API + proxy)** in `090-test-gravitee.yml`. Health-only per Decision #4. A functional test is its own future plan once a fixture API definition is designed.
+- **No image-registry mirror.** Pulls direct from Docker Hub. CI rate-limit concerns are deferred.
+
+---
+
+## Open follow-ups (track but don't block)
+
+| Item | Owner | When |
+|------|-------|------|
+| Functional smoke test (create + proxy) | TBD | Once a fixture API definition exists |
+| Authentik forward-auth integration | TBD | After Gravitee's own login flow is verified working |
+| Switch on Elasticsearch for analytics | TBD | When analytics dashboards become a real ask |
+| Switch on Redis for rate-limit policies | TBD | When rate-limiting becomes a real ask |
+| Production-grade `GRAVITEE_ENCRYPTION_KEY` rotation strategy | TBD | First non-dev deploy target |
+| Chart 4.12 bump | TBD | After 4.12 stable lands (~June 2026) |

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md
@@ -1,4 +1,4 @@
-# Investigate: Fix Gravitee Deployment
+# Investigate: Deploy Gravitee APIM 4.11 on PostgreSQL with a minimal footprint
 
 > **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
@@ -6,137 +6,210 @@
 
 ## Status: Backlog
 
-**Goal**: Get Gravitee working and aligned with UIS patterns — it was broken before the service migration and has never been verified
+**Goal**: Deploy Gravitee API Management on the UIS local cluster as a working API gateway with admin UI, using **PostgreSQL** as the management store and **no Elasticsearch / no Redis / no MongoDB**, on the smallest sustainable resource footprint.
 
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-04-30
 
 **Related**:
-- [STATUS-service-migration.md](../completed/STATUS-service-migration.md) — Gravitee is the only unverified service (Phase 4)
-- [INVESTIGATE-elasticsearch-upgrade.md](../completed/INVESTIGATE-elasticsearch-upgrade.md) — Gravitee supports ES 9.x (9.2.x+)
+- [STATUS-service-migration.md](../completed/STATUS-service-migration.md) - Gravitee was the only unverified service at end of migration; this investigation supersedes that history.
+- [Adding a Service](../../../contributors/guides/adding-a-service.md) - Service definition, playbook, ingress, secrets, and test conventions.
+
+**Depends on**: PostgreSQL (manifest `042`), Traefik IngressRoute CRDs, UIS secrets generation. **Does NOT depend on** MongoDB, Elasticsearch, or Redis.
 
 ---
 
-## Current State
+## Why this is a fresh investigation
 
-Gravitee has a deploy playbook and manifests but was **never verified working**. The service migration status file notes: "Was not working before migration. Needs new setup — deploy playbook may need rewrite."
+The previous Gravitee setup in the repo (`090-setup-gravitee.yml` + `090-gravitee-config.yaml` + `091-gravitee-ingress.yaml` + `service-gravitee.sh`) was last touched over a year ago, never reliably worked, was pinned to APIM **4.8.4** (now ~9 months stale), and assumed **MongoDB** as the metadata store. Both the Helm chart layout and the supported backend matrix have moved enough that patching the existing files line-by-line is more work than starting from a current baseline.
 
-### What exists
-
-| File | Status |
-|------|--------|
-| `provision-host/uis/services/integration/service-gravitee.sh` | Exists — has metadata but `SCRIPT_REMOVE_PLAYBOOK` and `SCRIPT_REQUIRES` are empty |
-| `ansible/playbooks/090-setup-gravitee.yml` | Exists — verbose (465 lines), hardcoded values, may not work |
-| `manifests/090-gravitee-config.yaml` | Exists — hardcoded credentials, version pinned at 4.8.4 |
-| `manifests/091-gravitee-ingress.yaml` | Exists — uses `Host()` instead of `HostRegexp()` |
-| `ansible/playbooks/090-remove-gravitee.yml` | **Missing** |
+This investigation supersedes any prior Gravitee plan in the repo. The implementation will replace the existing service files rather than amend them.
 
 ---
 
-## Issues Found
+## Investigation Result
 
-### 1. Hardcoded credentials in config
+Gravitee APIM 4.11 supports **PostgreSQL via the JDBC repository plugin** as a first-class drop-in for MongoDB for the management/config store. The PostgreSQL JDBC driver is bundled in the official APIM distribution; configuration is documented alongside MongoDB with no "experimental" caveats. A working install on a single-node cluster is achievable with:
 
-`090-gravitee-config.yaml` has MongoDB credentials inline:
+- **4 APIM pods** (Management API, Management UI / Console, Developer Portal, API Gateway)
+- **PostgreSQL** for the management store, reusing the cluster's existing shared `postgresql` service
+- **No Elasticsearch** (analytics dashboards disabled — accepted trade-off)
+- **No Redis** (rate-limit policies disabled — accepted trade-off)
+- **No MongoDB**
 
-```yaml
-mongo:
-  uri: mongodb://gravitee_user:SecretPassword1@mongodb.default.svc.cluster.local:27017/graviteedb?authSource=admin
+Baseline footprint at default sizing is roughly **2 CPU / 4 GiB** across the four pods, tunable down on a laptop. The official `graviteeio/apim` Helm chart (currently at version 4.11.x, lives in `gravitee-io/gravitee-api-management/helm/`) defaults all bundled subcharts (`mongodb-replicaset`, `elasticsearch`) to `enabled: false` and exposes external-DB configuration via standard values.
+
+**Recommendation**: Replace all four current Gravitee files with a minimal PostgreSQL-backed deployment. Treat existing `GRAVITEE_MONGODB_*` keys in the secrets template as obsolete and emit `GRAVITEE_POSTGRES_*` instead. Keep the chart at the latest stable 4.11.x.
+
+---
+
+## Current State (what's in the repo today)
+
+| File | Status | Action in implementation |
+|------|--------|--------------------------|
+| `provision-host/uis/services/integration/service-gravitee.sh` | Exists. `SCRIPT_NAMESPACE=default`, `SCRIPT_REQUIRES=""`, `SCRIPT_REMOVE_PLAYBOOK=""`, `SCRIPT_CHECK_COMMAND` references namespace `gravitee`. Internally inconsistent. | **Rewrite** — namespace `gravitee`, requires `postgresql`, set remove playbook, fix health selector. |
+| `ansible/playbooks/090-setup-gravitee.yml` | Exists, 465 lines, deploys APIM 4.8.4 into `default`, uses raw `kubectl`/`helm`, includes a hardcoded personal Tailscale hostname, mixed health checks and deploy logic. | **Rewrite** from scratch around the standard UIS playbook pattern. |
+| `ansible/playbooks/090-remove-gravitee.yml` | Missing. | **Create.** |
+| `manifests/090-gravitee-config.yaml` | Exists. Helm values pinned at 4.8.4. Disables bundled MongoDB and ES. Embeds a literal MongoDB URI with credentials in two places. Enables chart-managed Kubernetes ingress. | **Rewrite** — JDBC/PostgreSQL backend via secret resolver, chart ingress disabled, no literal credentials. |
+| `manifests/091-gravitee-ingress.yaml` | Exists. Traefik `IngressRoute` in `default` namespace. Uses `Host()` (localhost-only). Generic hostnames `api.localhost`, `portal.localhost`. | **Rewrite** — `gravitee` namespace, `HostRegexp(...)` patterns, `gravitee*` prefixed hostnames. |
+| `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` | Has `GRAVITEE_MONGODB_DATABASE_*` keys in the `default` namespace secret (currently unused after this rewrite). Also has `GRAVITEE_ADMIN_*`, `GRAVITEE_ENCRYPTION_KEY`, `GRAVITEE_TEST_*`. | **Replace** the `GRAVITEE_MONGODB_*` keys with `GRAVITEE_POSTGRES_*`. Move the runtime-secret block into a new `gravitee/urbalurba-secrets`. Keep admin/encryption keys. |
+| `provision-host/uis/templates/secrets-templates/00-common-values.env.template` | No first-class Gravitee variables — values are derived inside `00-master-secrets.yml.template` from `MONGODB_ROOT_PASSWORD`. | **Add** `GRAVITEE_POSTGRES_USER`, `GRAVITEE_POSTGRES_PASSWORD`, `GRAVITEE_POSTGRES_DATABASE` as first-class variables (mirrors the OpenWebUI pattern). |
+| `manifests/040-mongodb-config.yaml` and `ansible/playbooks/040-setup-mongodb.yml` | Both contain Gravitee-specific MongoDB user/database bootstrap. | **Remove** the Gravitee-specific blocks once Gravitee no longer uses MongoDB. Tracked as a follow-up cleanup; not blocking. |
+
+---
+
+## Architecture for the Fix
+
+### Components and their role
+
+The "Resource ask" column shows the **laptop-tuned override** UIS sets in `manifests/090-gravitee-config.yaml` — not the chart defaults. Default chart values ship higher (≈500m / 1Gi requested per pod across all four). Override numbers below are starting points; tune during Phase 4.
+
+| Component | Required? | What it does | Resource ask (laptop-tuned override) |
+|-----------|-----------|--------------|--------------------------------------|
+| **Management API** | Yes | REST backend powering the Console and Portal; owns Liquibase migrations | requests 200m / 768Mi, limits 1000m / 1.5Gi |
+| **Management UI (Console)** | Yes | Admin SPA for API designers | requests 50m / 128Mi, limits 200m / 256Mi |
+| **Developer Portal UI** | Yes | Public catalog SPA for API consumers | requests 50m / 128Mi, limits 200m / 256Mi |
+| **API Gateway** | Yes | The actual proxy enforcing API definitions; reads API definitions from JDBC | requests 200m / 512Mi, limits 1000m / 1Gi |
+| **PostgreSQL** | Shared, cluster-wide | Management/config store via JDBC plugin | (already running) |
+| Elasticsearch | **Skipped (v1)** | Analytics, log search, dashboards. Not running ES means the analytics tab in Console is empty. Gateway works. Console works. APIs are managed normally. | n/a |
+| Redis | **Skipped (v1)** | Rate-limit policy store, response cache. Not running Redis means rate-limit policies cannot be applied (`ratelimit.type: none`). Everything else works. | n/a |
+| MongoDB | **Removed** | Replaced by PostgreSQL. | n/a |
+
+Sustainable baseline at these overrides: **~500m CPU / 1.5 GiB requested** combined across the four pods, with a per-cluster cap of ~2.4 CPU / 3 GiB if all four pods burst to limits simultaneously. Default chart values would land closer to ~2 CPU / 4 GiB requested.
+
+### Data flow
+
+```
+                         ┌─────────────────────────────┐
+                         │        Traefik              │
+                         │  HostRegexp(`gravitee*\..+`)│
+                         └──┬───────┬──────┬──────┬────┘
+                            │       │      │      │
+              gravitee\..+  │       │      │      │  gravitee-portal\..+
+                            ▼       ▼      ▼      ▼
+                          ┌─────┐ ┌─────┐ ┌──────┐ ┌──────┐
+                          │ UI  │ │ API │ │  GW  │ │PORTAL│
+                          │ SPA │ │ REST│ │proxy │ │ SPA  │
+                          └──┬──┘ └──┬──┘ └──┬───┘ └───┬──┘
+                             │       │      │         │
+                             │       └──┬───┘         │
+                             │          │             │
+                             │   ┌──────▼──────┐      │
+                             │   │  postgresql │      │
+                             │   │  (default)  │      │
+                             │   │ graviteedb  │      │
+                             │   └─────────────┘      │
+                             │                        │
+                             └────────[ talks to mgmt-api ]
 ```
 
-And again in the rate limit section:
+The Console UI and Developer Portal UI both call the Management API over HTTP using the cluster-internal service name. The Gateway syncs API definitions from the management database directly. Nothing else is in the picture.
 
-```yaml
-ratelimit:
-  mongodb:
-    uri: mongodb://gravitee_user:SecretPassword1@mongodb.default.svc.cluster.local:27017/graviteedb?authSource=admin
-```
+### What we lose by skipping ES and Redis
 
-This must use the UIS secrets system (`urbalurba-secrets` in the Gravitee namespace).
+This is the explicit trade-off list, so a future contributor knows what to switch on if they need it:
 
-### 2. Deploys in `default` namespace
+- **Empty analytics view in Console** — no per-API request counts, latency graphs, or status-code distributions. APIs still serve traffic; Gravitee just doesn't aggregate it.
+- **No rate-limiting / quota policies** — applying any rate-limit policy in the Console will succeed at design time but silently fail at runtime (or error out, depending on the chart's behavior with `ratelimit.type: none`). Document this in the contributor docs.
+- **No response caching policy** — same shape as rate-limiting, depends on Redis.
+- **No log search in Console** — gateway request logs go to stdout. `kubectl logs` is the only way to search them.
 
-The Helm config sets `gravitee_namespace: "default"`. All other non-core services deploy in their own namespace. Gravitee should use a `gravitee` namespace.
+All four are first-class production features; none are required to validate that "Gravitee is deployed and the gateway proxies traffic."
 
-### 3. Ingress uses `Host()` instead of `HostRegexp()`
+### Hostname strategy
 
-`091-gravitee-ingress.yaml` uses `Host(`gravitee.localhost`)` instead of the UIS standard `HostRegexp(`gravitee\..+`)`. This means it only works on localhost, not on Tailscale or Cloudflare domains.
+| Component | HostRegexp pattern | Purpose |
+|-----------|--------------------|---------|
+| Management Console | ``HostRegexp(`gravitee\..+`)`` | Admin UI |
+| Management API | ``HostRegexp(`gravitee-api\..+`)`` | Backend API for Console + Portal |
+| API Gateway | ``HostRegexp(`gravitee-gw\..+`)`` | Runtime API proxy endpoint |
+| Developer Portal | ``HostRegexp(`gravitee-portal\..+`)`` | Public/internal API catalog |
 
-### 4. Generic hostname conflicts
+All four work across `*.localhost`, `*.<tailnet>.ts.net`, and Cloudflare-tunneled domains without per-domain manifest edits. Public (no Authentik forward auth) for the first fix.
 
-Gravitee uses 4 hostnames:
+---
 
-| Hostname | Component |
-|----------|-----------|
-| `api.localhost` | API Gateway |
-| `portal.localhost` | Developer Portal |
-| `gravitee.localhost` | Management Console |
-| `gravitee-api.localhost` | Management API |
+## Decisions
 
-`api.localhost` and `portal.localhost` are too generic — they could conflict with other services. These should be prefixed: `gravitee-gw.localhost` and `gravitee-portal.localhost` (or similar).
+| # | Topic | Decision |
+|---|-------|----------|
+| 1 | Service model | Single shared Gravitee instance per UIS cluster, not multi-instance. |
+| 2 | Namespace | Run all APIM components in namespace `gravitee`. Leave shared PostgreSQL in `default`. |
+| 3 | Deployment mechanism | Use the official `graviteeio/apim` Helm chart at the **latest 4.11.x** patch (currently 4.11.3). Pin the chart version explicitly; bumps are separate plans. |
+| 4 | Management store | **PostgreSQL via JDBC repository plugin.** No MongoDB. |
+| 5 | Elasticsearch | **Skipped.** Analytics disabled. Re-evaluate when there is a real need. |
+| 6 | Redis | **Skipped.** Rate-limit and response-cache policies disabled. Re-evaluate when policies are actually configured. |
+| 7 | Routing | Disable chart-managed Kubernetes ingress. Use UIS-owned Traefik `IngressRoute` resources in `091-gravitee-ingress.yaml`. |
+| 8 | Hostnames | `gravitee`, `gravitee-api`, `gravitee-gw`, `gravitee-portal` via `HostRegexp`. |
+| 9 | Auth | No Authentik forward-auth in v1. Gravitee has its own admin login. SSO is a follow-up plan. |
+| 10 | Dependencies | `SCRIPT_REQUIRES="postgresql"`. |
+| 11 | Secrets | No credentials in tracked manifests. JDBC connection assembled from `gravitee/urbalurba-secrets` at runtime via the chart's `secret://` resolver if it works for `management.jdbc.*`, otherwise via `extraEnvs` references. (Open check #2.) |
+| 12 | Database bootstrap | The Gravitee setup playbook creates `graviteedb` + `gravitee_user` on PostgreSQL using the platform's `postgresql` admin connection. This is the same pattern UIS uses for OpenWebUI, OpenMetadata, and Backstage on Postgres. No coupling lives inside the PostgreSQL manifest. |
+| 13 | Resource overrides | Set explicit `resources.requests` and `resources.limits` per pod in `090-gravitee-config.yaml` (laptop-tuned). Don't rely on chart defaults. |
+| 14 | Verification | First prove deploy/undeploy works manually via `./uis deploy gravitee` and `./uis undeploy gravitee`. Add `090-test-gravitee.yml` after deploy is stable. |
+| 15 | Existing MongoDB-side bootstrap | Out of scope for this plan. The Gravitee-specific blocks in `040-mongodb-config.yaml` and `040-setup-mongodb.yml` become dead code; remove in a follow-up cleanup PR after the new flow is verified. |
+| 16 | SPA → Management API URL | The Console UI and Developer Portal SPA both run in the user's browser and need the **external** URL of the Management API (e.g. `http://gravitee-api.localhost`), not the cluster-internal service. With chart-managed ingress disabled, UIS owns this configuration. The Helm values must set `ui.env.MANAGEMENT_URL` (or equivalent — exact key per Open Check #3) and the equivalent on `portal`. **This is the #1 deploy-killer for the chart-ingress-disabled approach** — the Console SPA cannot authenticate without it. |
+| 17 | CORS | Default chart values handle CORS automatically when chart ingress is enabled. With chart ingress **disabled** (Decision #7), the Management API must explicitly allow the Console and Portal external origins via the chart's CORS configuration (or a Traefik middleware on the IngressRoute). Verify this works for `*.localhost` patterns. |
 
-### 5. Missing remove playbook
+---
 
-No `090-remove-gravitee.yml` exists. `SCRIPT_REMOVE_PLAYBOOK` is empty in the service script.
+## Recommended Target Shape
 
-### 6. Missing `SCRIPT_REQUIRES`
-
-`SCRIPT_REQUIRES=""` — but Gravitee depends on MongoDB and Elasticsearch. Should be:
+### Service metadata — `service-gravitee.sh`
 
 ```bash
-SCRIPT_REQUIRES="mongodb elasticsearch"
+#!/bin/bash
+# service-gravitee.sh - Gravitee API Management
+
+# === Service Metadata (Required) ===
+SCRIPT_ID="gravitee"
+SCRIPT_NAME="Gravitee APIM"
+SCRIPT_DESCRIPTION="API gateway and management platform"
+SCRIPT_CATEGORY="INTEGRATION"
+
+# === UIS-Specific (Optional) ===
+SCRIPT_PLAYBOOK="090-setup-gravitee.yml"
+SCRIPT_MANIFEST="090-gravitee-config.yaml,091-gravitee-ingress.yaml"
+SCRIPT_CHECK_COMMAND="kubectl get pods -n gravitee -l app.kubernetes.io/instance=gravitee-apim --no-headers 2>/dev/null | grep -qE '\\s(Running|Completed)\\s'"
+SCRIPT_REMOVE_PLAYBOOK="090-remove-gravitee.yml"
+SCRIPT_REQUIRES="postgresql"
+SCRIPT_PRIORITY="50"
+
+# === Deployment Details (Optional) ===
+# Pinned at the latest stable 4.11.x as of 2026-04-30. The graviteeio/apim
+# chart follows APIM versioning. Bump deliberately; verify Phase 4 again.
+SCRIPT_IMAGE="graviteeio/apim:4.11.3"  # informational; chart pulls per-component images
+SCRIPT_NAMESPACE="gravitee"
+
+# === Extended Metadata (Optional) ===
+SCRIPT_KIND="Component"
+SCRIPT_TYPE="service"
+SCRIPT_OWNER="platform-team"
+
+# === Website Metadata (Optional) ===
+SCRIPT_ABSTRACT="A platform service that runs Gravitee API Management with PostgreSQL as the metadata store and no Elasticsearch/Redis dependencies."
+SCRIPT_SUMMARY="Gravitee APIM is an open-source API gateway and management platform with admin Console, Developer Portal, and runtime API gateway. UIS deploys APIM 4.11 with PostgreSQL as the management store via the JDBC repository plugin (no MongoDB). Elasticsearch and Redis are not deployed; analytics dashboards and rate-limit policies are disabled. Suitable for laptop-scale development clusters."
+SCRIPT_LOGO="gravitee-logo.svg"
+SCRIPT_WEBSITE="https://www.gravitee.io"
+SCRIPT_TAGS="api-gateway,api-management,gravitee,postgresql"
+SCRIPT_DOCS="/docs/services/integration/gravitee"
 ```
 
-### 7. Hardcoded Tailscale hostname in playbook
+The exact label selector for `SCRIPT_CHECK_COMMAND` should be verified after the first successful deploy (Open Check #1). The chart's actual instance label may differ from `gravitee-apim`.
 
-The setup playbook final output contains:
+### First-class secret variables — `00-common-values.env.template`
 
-```
-"These are accessible via your Tailscale funnel hostname: rancher-traefik.dog-pence.ts.net"
-```
-
-This is a developer-specific hostname that should not be in the playbook.
-
-### 8. Playbook is overly verbose
-
-At 465 lines, the setup playbook is much longer than comparable services. It has extensive debugging output, manual connectivity checks, and hardcoded values. Other service playbooks (e.g. Unity Catalog at ~100 lines) are much simpler.
-
----
-
-## Dependencies
-
-Gravitee requires:
-
-| Dependency | UIS service | How Gravitee uses it |
-|------------|------------|---------------------|
-| **MongoDB** | manifest 040, `default` namespace | Metadata store — API definitions, policies, analytics config |
-| **Elasticsearch** | manifest 060, `default` namespace | Analytics — request logs, metrics, dashboards |
-
-Both are already deployed in UIS.
-
-### MongoDB setup
-
-Gravitee needs a database and user on the existing MongoDB. The setup playbook should create these (same pattern as OpenMetadata creating a database on PostgreSQL).
-
-### Elasticsearch compatibility
-
-Gravitee supports ES 7.17.x, 8.16.x, and 9.2.x. Works with both current ES 8.5.1 and the planned upgrade to 9.3.0.
-
----
-
-## Secrets Integration
-
-Following the UIS secrets pattern:
-
-**1. Variables in `00-common-values.env.template`:**
+Add (mirrors the existing OpenWebUI pattern):
 
 ```bash
-# Gravitee
-GRAVITEE_MONGODB_USER=gravitee_user
-GRAVITEE_MONGODB_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
-GRAVITEE_MONGODB_DATABASE=graviteedb
+# Gravitee APIM (PostgreSQL backend)
+GRAVITEE_POSTGRES_USER=gravitee_user
+GRAVITEE_POSTGRES_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
+GRAVITEE_POSTGRES_DATABASE=graviteedb
 ```
 
-**2. Secret block in `00-master-secrets.yml.template`:**
+### Namespace secret — `00-master-secrets.yml.template`
+
+Replace the existing `GRAVITEE_MONGODB_DATABASE_*` block in the `default` namespace secret with a new `gravitee` namespace secret:
 
 ```yaml
 ---
@@ -152,77 +225,388 @@ metadata:
   namespace: gravitee
 type: Opaque
 stringData:
-  GRAVITEE_MONGODB_USER: "${GRAVITEE_MONGODB_USER}"
-  GRAVITEE_MONGODB_PASSWORD: "${GRAVITEE_MONGODB_PASSWORD}"
-  GRAVITEE_MONGODB_DATABASE: "${GRAVITEE_MONGODB_DATABASE}"
-  GRAVITEE_MONGODB_URI: "mongodb://${GRAVITEE_MONGODB_USER}:${GRAVITEE_MONGODB_PASSWORD}@mongodb.default.svc.cluster.local:27017/${GRAVITEE_MONGODB_DATABASE}?authSource=admin"
+  # PostgreSQL backend (replaces MongoDB completely)
+  GRAVITEE_POSTGRES_HOST: "postgresql.default.svc.cluster.local"
+  GRAVITEE_POSTGRES_PORT: "5432"
+  GRAVITEE_POSTGRES_USER: "${GRAVITEE_POSTGRES_USER}"
+  GRAVITEE_POSTGRES_PASSWORD: "${GRAVITEE_POSTGRES_PASSWORD}"
+  GRAVITEE_POSTGRES_DATABASE: "${GRAVITEE_POSTGRES_DATABASE}"
+  GRAVITEE_POSTGRES_JDBC_URL: "jdbc:postgresql://postgresql.default.svc.cluster.local:5432/${GRAVITEE_POSTGRES_DATABASE}"
+  # Admin / encryption (preserved from existing template)
+  GRAVITEE_ADMIN_EMAIL: "${DEFAULT_ADMIN_EMAIL}"
+  GRAVITEE_ADMIN_PASSWORD: "${DEFAULT_ADMIN_PASSWORD}"
+  GRAVITEE_ENCRYPTION_KEY: "${GRAVITEE_ENCRYPTION_KEY}"
 ```
 
-The Helm values would reference these via environment variables or `secretKeyRef`.
+The `default` namespace's `urbalurba-secrets` block keeps `GRAVITEE_ADMIN_*` and `GRAVITEE_ENCRYPTION_KEY` *only if* they are needed by the bootstrap flow — otherwise drop them to avoid duplicate sources of truth. The `GRAVITEE_MONGODB_*` keys are removed entirely.
 
-### Password restrictions
+### Helm values — `manifests/090-gravitee-config.yaml`
 
-Do NOT use `!`, `$`, `` ` ``, `\`, or `"` in passwords.
+Top-level shape (only the parts that change vs the chart defaults; verify exact keys against the 4.11.x `values.yaml` during implementation):
+
+```yaml
+# Pinned chart version handled in the Ansible Helm task, not here.
+# This file is the values overrides only.
+
+# Disable bundled subcharts — both default to false in 4.11, but we
+# set them explicitly so the intent is auditable.
+mongodb-replicaset:
+  enabled: false
+elasticsearch:
+  enabled: false
+es:
+  enabled: false
+
+# Management store: PostgreSQL via JDBC plugin
+management:
+  type: jdbc
+  jdbc:
+    # Resolver shape preferred. Confirm during implementation that
+    # secret:// works for the JDBC fields specifically. If not, fall
+    # back to api/portal/gateway extraEnvs referencing the secret.
+    url: "secret://kubernetes/urbalurba-secrets:GRAVITEE_POSTGRES_JDBC_URL"
+    username: "secret://kubernetes/urbalurba-secrets:GRAVITEE_POSTGRES_USER"
+    password: "secret://kubernetes/urbalurba-secrets:GRAVITEE_POSTGRES_PASSWORD"
+    # Liquibase auto-runs schema migrations on first start.
+    liquibase: true
+
+# Rate-limit: disabled — no Redis, no MongoDB
+ratelimit:
+  type: none
+
+# Analytics: disabled — no Elasticsearch
+analytics:
+  enabled: false
+
+# Disable chart-managed ingress for all four components.
+# UIS routes are defined in 091-gravitee-ingress.yaml.
+api:
+  ingress:
+    management:
+      enabled: false
+    portal:
+      enabled: false
+  # Resource overrides — laptop-tuned. Adjust during Phase 4 testing.
+  resources:
+    requests: { cpu: "200m", memory: "768Mi" }
+    limits:   { cpu: "1000m", memory: "1.5Gi" }
+
+gateway:
+  ingress:
+    enabled: false
+  resources:
+    requests: { cpu: "200m", memory: "512Mi" }
+    limits:   { cpu: "1000m", memory: "1Gi" }
+
+ui:
+  ingress:
+    enabled: false
+  baseURL: "/"
+  # CRITICAL (Decision #16): Console UI is an SPA; it calls the Management
+  # API from the user's browser using the EXTERNAL hostname, not the
+  # cluster-internal service. Without this, login fails immediately.
+  # Exact key in 4.11 is one of: ui.env.MANAGEMENT_URL, ui.constants,
+  # or a configmap mount — verify against the chart's values.yaml
+  # (Open Check #3). The value should be the IngressRoute hostname
+  # for the Management API:
+  env:
+    MANAGEMENT_URL: "http://gravitee-api.localhost"
+  resources:
+    requests: { cpu: "50m",  memory: "128Mi" }
+    limits:   { cpu: "200m", memory: "256Mi" }
+
+portal:
+  ingress:
+    enabled: false
+  # Same concern as ui: the Portal SPA calls the Management API from
+  # the user's browser. Verify the exact 4.11 key (likely portal.env
+  # or portal.constants).
+  env:
+    PORTAL_API_URL: "http://gravitee-api.localhost"
+  resources:
+    requests: { cpu: "50m",  memory: "128Mi" }
+    limits:   { cpu: "200m", memory: "256Mi" }
+
+# CORS (Decision #17): with chart-managed ingress disabled, the Management
+# API must explicitly allow the Console and Portal external origins.
+# Most likely set on api.http.api.management.cors / api.http.api.portal.cors
+# in 4.11 — verify exact path. For laptop dev, allow * pattern:
+api:
+  cors:
+    allowOrigin: "*"
+    allowMethods: "OPTIONS, GET, POST, PUT, DELETE"
+    allowHeaders: "*"
+```
+
+If `secret://kubernetes/urbalurba-secrets:KEY` resolution doesn't work for the JDBC fields specifically, the fallback is to use `extraEnvs` on the components that need DB access. Both the Management API **and the Gateway** read API definitions from the management database in 4.x, so both need the secret values:
+
+```yaml
+api:
+  extraEnvs:
+    - name: GRAVITEE_MANAGEMENT_JDBC_URL
+      valueFrom: { secretKeyRef: { name: urbalurba-secrets, key: GRAVITEE_POSTGRES_JDBC_URL } }
+    - name: GRAVITEE_MANAGEMENT_JDBC_USERNAME
+      valueFrom: { secretKeyRef: { name: urbalurba-secrets, key: GRAVITEE_POSTGRES_USER } }
+    - name: GRAVITEE_MANAGEMENT_JDBC_PASSWORD
+      valueFrom: { secretKeyRef: { name: urbalurba-secrets, key: GRAVITEE_POSTGRES_PASSWORD } }
+
+gateway:
+  extraEnvs:
+    - name: GRAVITEE_MANAGEMENT_JDBC_URL
+      valueFrom: { secretKeyRef: { name: urbalurba-secrets, key: GRAVITEE_POSTGRES_JDBC_URL } }
+    - name: GRAVITEE_MANAGEMENT_JDBC_USERNAME
+      valueFrom: { secretKeyRef: { name: urbalurba-secrets, key: GRAVITEE_POSTGRES_USER } }
+    - name: GRAVITEE_MANAGEMENT_JDBC_PASSWORD
+      valueFrom: { secretKeyRef: { name: urbalurba-secrets, key: GRAVITEE_POSTGRES_PASSWORD } }
+```
+
+UI and Portal are static SPAs; they do not connect to PostgreSQL and do not need these env vars.
+
+### IngressRoute — `manifests/091-gravitee-ingress.yaml`
+
+```yaml
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: gravitee-console
+  namespace: gravitee
+spec:
+  entryPoints: [web]
+  routes:
+    - match: HostRegexp(`gravitee\..+`)
+      kind: Rule
+      services:
+        - name: gravitee-apim-ui
+          port: 8002
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: gravitee-management-api
+  namespace: gravitee
+spec:
+  entryPoints: [web]
+  routes:
+    - match: HostRegexp(`gravitee-api\..+`)
+      kind: Rule
+      services:
+        - name: gravitee-apim-api
+          port: 83
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: gravitee-gateway
+  namespace: gravitee
+spec:
+  entryPoints: [web]
+  routes:
+    - match: HostRegexp(`gravitee-gw\..+`)
+      kind: Rule
+      services:
+        - name: gravitee-apim-gateway
+          port: 82
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: gravitee-portal
+  namespace: gravitee
+spec:
+  entryPoints: [web]
+  routes:
+    - match: HostRegexp(`gravitee-portal\..+`)
+      kind: Rule
+      services:
+        - name: gravitee-apim-portal
+          port: 8003
+```
+
+Service names and ports must be verified against the actual chart output (Open Check #1). The values above match the 4.11.x chart's documented defaults but may not be byte-exact.
+
+### Setup playbook — `ansible/playbooks/090-setup-gravitee.yml`
+
+Should follow the same shape used by other UIS service playbooks (Authentik, OpenWebUI, OpenMetadata):
+
+1. **Display deployment context** — namespace, chart version, target Postgres host.
+2. **Ensure namespace** `gravitee`.
+3. **Verify dependency**: PostgreSQL is reachable; the `urbalurba-secrets` Secret exists in the `gravitee` namespace and carries the required JDBC keys.
+4. **Bootstrap database**: create `graviteedb` and `gravitee_user` on the platform's `postgresql` service (idempotent, using `CREATE ROLE ... IF NOT EXISTS` and `CREATE DATABASE ... IF NOT EXISTS`-equivalent SQL via psql against postgresql-0). Use `no_log: true` for password handling.
+5. **Ensure Helm repo** `graviteeio` exists and is up to date.
+6. **Install/upgrade** `graviteeio/apim` at the pinned version using `kubernetes.core.helm`, with values from `manifests/090-gravitee-config.yaml`.
+7. **Apply** `091-gravitee-ingress.yaml` via `kubernetes.core.k8s`.
+8. **Wait** for Management API, Gateway, UI, Portal Deployments to reach Available.
+9. **Health probe** internal endpoints from inside the cluster (Management API `/management/health`, Gateway `/_node/health`).
+10. **Print** concise access URLs (`http://gravitee.localhost`, etc.) and admin credentials hint.
+
+### Remove playbook — `ansible/playbooks/090-remove-gravitee.yml`
+
+1. **Uninstall** the `gravitee-apim` Helm release.
+2. **Remove** the four IngressRoute objects.
+3. **Leave** PVCs and the `gravitee/urbalurba-secrets` Secret intact by default (re-deploy works without re-bootstrap).
+4. **Optional `--purge` extra-var** drops the database, role, secret, namespace. Off by default.
 
 ---
 
-## Proposed Hostname Strategy
+## Proposed Implementation Plan
 
-| Component | Hostname pattern | Access |
-|-----------|-----------------|--------|
-| Management Console | `gravitee.localhost` | Admin UI |
-| Management API | `gravitee-api.localhost` | Admin API |
-| API Gateway | `gravitee-gw.localhost` | Developer gateway |
-| Developer Portal | `gravitee-portal.localhost` | Developer portal |
+Single plan file: `PLAN-gravitee-postgresql-deployment.md`. Suggested phases:
 
-All using `HostRegexp()` for multi-domain support.
+### Phase 1: Replace service metadata and secrets
+
+**Status: partially complete** (secret template work landed during the investigation cycle on 2026-04-30; documented here so the implementer doesn't re-do it).
+
+Already in the working tree:
+
+- [x] `GRAVITEE_POSTGRES_USER`, `GRAVITEE_POSTGRES_PASSWORD`, `GRAVITEE_POSTGRES_DATABASE` added as first-class variables to `00-common-values.env.template`.
+- [x] New `gravitee/urbalurba-secrets` block in `00-master-secrets.yml.template` containing `GRAVITEE_POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE/JDBC_URL`, `GRAVITEE_ADMIN_EMAIL/PASSWORD`, `GRAVITEE_ENCRYPTION_KEY`.
+- [x] Old `GRAVITEE.IO API MANAGEMENT SYSTEM` block removed from the `default` namespace section (admin email/password, encryption key, the stale `GRAVITEE_TEST_*` Cloudflare-tunnel subdomain stubs).
+- [x] **Transition stub** (option-b decision): the three `GRAVITEE_MONGODB_DATABASE_*` keys remain in the MongoDB section of the `default` namespace secret with a deprecation comment, because `040-setup-mongodb.yml` still validates their presence on `./uis deploy mongodb`. They are removed in Phase 5 alongside the MongoDB-side bootstrap.
+
+Still to do:
+
+- [ ] Rewrite `provision-host/uis/services/integration/service-gravitee.sh` per the target shape.
+- [ ] Run `./uis secrets generate` and dry-run-apply the resulting secrets to confirm the new gravitee namespace block renders cleanly.
+
+### Phase 2: Replace Helm values and ingress
+
+- [ ] Rewrite `manifests/090-gravitee-config.yaml` per the target shape (chart 4.11.x, JDBC backend, ratelimit none, analytics off, chart ingress disabled, laptop-tuned resources).
+- [ ] Rewrite `manifests/091-gravitee-ingress.yaml` (`gravitee` namespace, four `HostRegexp` IngressRoutes).
+- [ ] Verify the chart's actual service names and ports against the values file (Open Check #1).
+
+### Phase 3: Rewrite deploy and remove playbooks
+
+- [ ] Rewrite `090-setup-gravitee.yml` from scratch using the standard UIS playbook pattern.
+- [ ] Create `090-remove-gravitee.yml`.
+- [ ] Use `kubernetes.core.helm` and `kubernetes.core.k8s` modules instead of raw `helm`/`kubectl` shell calls.
+- [ ] All secret-handling tasks set `no_log: true`.
+- [ ] No personal hostnames, no debug-only output blocks.
+
+### Phase 4: End-to-end deploy validation
+
+- [ ] On a fresh cluster, `./uis deploy postgresql` then `./uis deploy gravitee`.
+- [ ] Verify all four pods reach Ready in namespace `gravitee`.
+- [ ] Verify the four IngressRoutes resolve and serve content.
+- [ ] Log into the admin Console at `http://gravitee.localhost`. Create a sample API. Hit it via the Gateway.
+- [ ] `./uis undeploy gravitee`. Re-run `./uis deploy gravitee`. Confirm idempotency.
+- [ ] Remove the cluster, redeploy from scratch end-to-end. This must work without manual intervention.
+
+### Phase 5: Cleanup and add automated verification
+
+- [ ] Remove the Gravitee-specific blocks from `040-mongodb-config.yaml` and `040-setup-mongodb.yml` (they are now dead code — they no longer serve any consumer).
+- [ ] Remove the three transition-stub keys (`GRAVITEE_MONGODB_DATABASE_NAME/USER/PASSWORD`) from the MongoDB section of `00-master-secrets.yml.template` and the deprecation comment block above them. These were kept in option-b to preserve `./uis deploy mongodb` validation; once the MongoDB-side bootstrap is gone, the validation reference goes too.
+- [ ] Update `troubleshooting/debug-mongodb.sh` to drop the three `GRAVITEE_MONGODB_DATABASE_*` lookups (lines ~59–61). Replace with a comment indicating Gravitee no longer uses MongoDB.
+- [ ] Grep the repo for any remaining `GRAVITEE_MONGODB` reference and remove (target: zero matches).
+- [ ] Add `090-test-gravitee.yml` covering: pods Ready, IngressRoutes resolve, Management API health endpoint returns 200, Gateway `/_node/health` returns 200, Console root returns 200, Portal root returns 200.
+- [ ] Register Gravitee in the `./uis test-all` flow.
+- [ ] Update integration testing docs to remove the "Gravitee always skipped" note.
 
 ---
 
-## What Needs to Happen
+## Validation Commands
 
-1. Move Gravitee to its own `gravitee` namespace
-2. Replace hardcoded credentials with UIS secrets system
-3. Add secrets variables to templates
-4. Switch ingress from `Host()` to `HostRegexp()` pattern
-5. Rename generic hostnames (`api`, `portal`) to Gravitee-prefixed names
-6. Create `090-remove-gravitee.yml`
-7. Update `service-gravitee.sh` — set `SCRIPT_REMOVE_PLAYBOOK` and `SCRIPT_REQUIRES`
-8. Simplify the setup playbook (remove debugging output, hardcoded Tailscale hostname)
-9. Test deploy and undeploy cycle
+```bash
+# Secrets path
+./uis secrets generate
+kubectl apply --dry-run=client -f .uis.secrets/generated/kubernetes/kubernetes-secrets.yml
+
+# Cluster baseline
+./uis deploy postgresql
+
+# Deploy
+./uis deploy gravitee
+
+# Verify Kubernetes objects
+kubectl get pods -n gravitee
+kubectl get svc -n gravitee
+kubectl get ingressroute -n gravitee
+kubectl get secret urbalurba-secrets -n gravitee -o jsonpath='{.data}' | jq 'keys'
+
+# Verify the database side
+PGPW=$(kubectl get secret postgresql -n default -o jsonpath='{.data.postgres-password}' | base64 -d)
+kubectl exec -n default postgresql-0 -- bash -c \
+  "PGPASSWORD='$PGPW' psql -U postgres -c '\l graviteedb'"
+kubectl exec -n default postgresql-0 -- bash -c \
+  "PGPASSWORD='$PGPW' psql -U postgres -c '\du gravitee_user'"
+
+# Smoke
+curl -fsS http://gravitee.localhost/         # admin Console SPA
+curl -fsS http://gravitee-api.localhost/management/health
+curl -fsS http://gravitee-gw.localhost/_node/health
+curl -fsS http://gravitee-portal.localhost/  # developer portal SPA
+
+# Lifecycle
+./uis undeploy gravitee
+```
+
+Once `090-test-gravitee.yml` exists:
+
+```bash
+./uis verify gravitee
+./uis test-all
+```
 
 ---
 
-## Resource Requirements
+## Acceptance Criteria
 
-Gravitee deploys 4 components (API server, Gateway, Management UI, Portal UI). Estimated:
-
-| Component | CPU request | Memory request |
-|-----------|------------|---------------|
-| Management API | 250m | 512Mi |
-| Gateway | 250m | 512Mi |
-| Management UI | 100m | 128Mi |
-| Portal UI | 100m | 128Mi |
-| **Total** | **~700m** | **~1.3Gi** |
-
-MongoDB and Elasticsearch are shared (already running).
+- [ ] `./uis list` shows Gravitee in namespace `gravitee` with `SCRIPT_REQUIRES="postgresql"` and a populated `SCRIPT_REMOVE_PLAYBOOK`.
+- [ ] `./uis deploy gravitee` deploys APIM 4.11.x with all four Deployments reaching Available. Gravitee itself does not deploy or depend on MongoDB / Elasticsearch / Redis — none appear in the `gravitee` namespace, and no Gravitee component holds connections to them. (UIS may run those services for *other* consumers; this criterion is about Gravitee's dependencies, not the cluster as a whole.)
+- [ ] PostgreSQL contains a `graviteedb` database owned by `gravitee_user`. Liquibase migrations have run cleanly on first start (visible in Management API pod logs).
+- [ ] No tracked manifest contains a literal Gravitee password, JDBC URL with credentials, or admin password.
+- [ ] All four URLs (`http://gravitee.localhost`, `gravitee-api.localhost`, `gravitee-gw.localhost`, `gravitee-portal.localhost`) resolve and return the expected SPA / health response.
+- [ ] An admin can log in to the Console with `${DEFAULT_ADMIN_EMAIL}` / `${DEFAULT_ADMIN_PASSWORD}`, create a sample API, deploy it, and proxy a request through the Gateway successfully.
+- [ ] `./uis undeploy gravitee` removes the Helm release and IngressRoutes; PVCs and the secret remain. `./uis deploy gravitee` afterward succeeds without re-bootstrap.
+- [ ] A full `./uis undeploy gravitee && ./uis deploy gravitee` cycle passes on a cluster that already has Gravitee state (idempotent re-deploy).
+- [ ] On a fresh cluster, the entire `./uis deploy postgresql && ./uis deploy gravitee` chain works end-to-end without manual intervention.
 
 ---
 
-## Proposed Files
+## Files to Modify in the Implementation Plan
 
-| Piece | Change |
-|-------|--------|
-| `provision-host/uis/services/integration/service-gravitee.sh` | Update `SCRIPT_REMOVE_PLAYBOOK`, `SCRIPT_REQUIRES`, `SCRIPT_NAMESPACE` |
-| `ansible/playbooks/090-setup-gravitee.yml` | Rewrite — simpler, secrets-based, `gravitee` namespace |
-| `ansible/playbooks/090-remove-gravitee.yml` | **Create** — tear down Gravitee deployment |
-| `manifests/090-gravitee-config.yaml` | Replace hardcoded credentials, move to `gravitee` namespace |
-| `manifests/091-gravitee-ingress.yaml` | Switch to `HostRegexp()`, rename generic hostnames |
-| Secrets templates | Add Gravitee variables and namespace block |
+| File | Change |
+|------|--------|
+| `provision-host/uis/services/integration/service-gravitee.sh` | Rewrite per target shape. |
+| `ansible/playbooks/090-setup-gravitee.yml` | Replace contents with standard UIS playbook pattern. |
+| `ansible/playbooks/090-remove-gravitee.yml` | Create. |
+| `manifests/090-gravitee-config.yaml` | Replace contents — JDBC backend, no ES/Redis, chart ingress disabled, laptop-tuned resources. |
+| `manifests/091-gravitee-ingress.yaml` | Replace contents — `gravitee` namespace, four `HostRegexp` IngressRoutes. |
+| `provision-host/uis/templates/secrets-templates/00-common-values.env.template` | Add `GRAVITEE_POSTGRES_*` variables. |
+| `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template` | Replace `GRAVITEE_MONGODB_*` block with `gravitee/urbalurba-secrets` block. |
+| `ansible/playbooks/090-test-gravitee.yml` | Create after Phase 4 succeeds. |
+| `manifests/040-mongodb-config.yaml` | **Phase 5**: remove Gravitee-specific init logic (dead code after switch). |
+| `ansible/playbooks/040-setup-mongodb.yml` | **Phase 5**: remove Gravitee-specific verification (dead code after switch). |
+| Integration testing docs | **Phase 5**: remove the "Gravitee always skipped" note. |
+| `website/static/img/services/gravitee-logo.svg` | Add if not already present (referenced by `SCRIPT_LOGO`). |
+
+---
+
+## Open Checks Before Implementation
+
+1. **Verify chart service names, ports, and instance label.** Run `helm template graviteeio/apim --version 4.11.3` (or current) on a clean working tree to print exact resource names. Update `091-gravitee-ingress.yaml` and `service-gravitee.sh` `SCRIPT_CHECK_COMMAND` accordingly.
+2. **Verify `secret://kubernetes/urbalurba-secrets:KEY` resolution** for `management.jdbc.url`, `management.jdbc.username`, `management.jdbc.password`. **Verification method:** do a 5-minute throwaway deploy with one JDBC field set via `secret://`; if the Management API pod logs show `unable to resolve secret reference` or similar, fall back to `extraEnvs` on `api` and `gateway` (per the Helm values fallback section). The Gravitee secret resolver is documented for some fields but not universally; confirm against 4.11 docs *and* actual pod logs.
+3. **Confirm Console UI and Developer Portal external-URL configuration shape in 4.11.x** (Decision #16 is load-bearing). The Console SPA and Portal SPA both run in the user's browser and need to know the *external* URL of the Management API. Historically this was `ui.env.MANAGEMENT_URL` / `ui.constants` / a configmap mount; the exact 4.11 key needs to be looked up against the chart's `values.yaml`. **Same check for `portal.env.PORTAL_API_URL` (or equivalent).** Without this, the Console fails to authenticate immediately on first load.
+4. **Confirm CORS configuration shape on the Management API for 4.11.x** (Decision #17). With chart ingress disabled, UIS owns CORS. Verify whether the chart key is `api.cors.*`, `api.http.api.management.cors.*`, or somewhere else, and whether `*` allow-origin works for `*.localhost` patterns or requires explicit listing.
+5. **Confirm health endpoint paths on APIM 4.11.x components.** Probably:
+   - Gateway: `/_node/health`
+   - Management API: `/management/health` or `/management/_health`
+   - UI/Portal: standard SPA root.
+
+   Verify against the deployed chart in Phase 4 and update the playbook health probes accordingly.
+6. **Liquibase migration ownership and ordering** (more pointed than "does it auto-run"). When the chart deploys mgmt-api + gateway simultaneously and both have JDBC connections to the same database, who owns running Liquibase? If both attempt migrations on first start, you risk a Liquibase lock conflict or schema corruption. Verify the chart enforces "only the management API runs migrations" (typical APIM pattern) or document the wait/retry behavior. Inspect Management API and Gateway pod startup logs side-by-side in Phase 4.
+7. **Verify behavior when applying a rate-limit policy with `ratelimit.type: none`.** Confirm whether Console disables the policy UI, accepts but warns, or silently saves a non-functional policy. Document the result for contributors.
+8. **Choose a chart pin policy.** APIM moves quarterly; the chart at 4.11.x is current today, 4.12 lands ~June 2026. Decide whether to track latest chart automatically or pin and bump deliberately. Recommended: pin and bump as separate plans, same convention as PostgreSQL/MongoDB/Elasticsearch.
+9. **Persistence (PVCs).** The chart likely creates PVCs for plugin storage, license cache, etc. Inventory these during Phase 4 and decide what `./uis undeploy gravitee --purge` should remove vs preserve.
+10. **Image pull source / rate limits.** APIM images come from `graviteeio/*` on Docker Hub (not GHCR). Anonymous pulls have IP-level rate limits — fine on a single dev laptop, worth noting for CI/multi-cluster scenarios.
+11. **Chart upgrade-in-place behavior.** When 4.12 lands and `SCRIPT_IMAGE` is bumped, `./uis deploy gravitee` does a `helm upgrade`. Will Liquibase auto-migrate the existing schema? Will any existing encrypted data require the same `GRAVITEE_ENCRYPTION_KEY` to remain readable? Document the upgrade/rollback story before the first 4.12 bump.
+12. **TLS / external HTTPS callback URLs.** When Gravitee is reached via Cloudflare tunnel (HTTPS externally, HTTP into Traefik), do any Gravitee features (OAuth callbacks, portal links) rely on the request scheme? Verify Gravitee respects `X-Forwarded-Proto` or hard-code the scheme in the SPA URL config above.
 
 ---
 
 ## Next Steps
 
-- [ ] Verify Gravitee actually deploys (test current playbook on a running cluster)
-- [ ] Create PLAN-gravitee-fix.md with implementation phases
+- [ ] Promote this investigation to `PLAN-gravitee-postgresql-deployment.md` in `plans/active/`.
+- [ ] Resolve Open Check #1 (chart resource names) before writing `091-gravitee-ingress.yaml` to avoid a broken first deploy.
+- [ ] Phase 1–4 in order. Phase 5 cleanup gates on a clean Phase 4 sign-off, not before.
+- [ ] Validate on a freshly reset cluster — old MongoDB-backed PVCs and secrets must not be in the picture.

--- a/website/docs/services/integration/gravitee.md
+++ b/website/docs/services/integration/gravitee.md
@@ -25,14 +25,17 @@ Gravitee API Management is an open-source API gateway and management platform. U
 
 Single shared instance per UIS cluster. Routing via Traefik `IngressRoute` resources with `HostRegexp` patterns so the same routes work across `*.localhost`, `*.<tailnet>.ts.net`, and Cloudflare-tunneled domains:
 
-| Component | Hostname pattern | Purpose |
+| URL pattern | Routes to | Purpose |
 |---|---|---|
-| Management Console | ``HostRegexp(`gravitee\..+`)`` | Admin UI for API designers |
-| Management API | ``HostRegexp(`gravitee-api\..+`)`` | Backend REST API for Console + Portal |
-| API Gateway | ``HostRegexp(`gravitee-gw\..+`)`` | Runtime API proxy endpoint |
-| Developer Portal | ``HostRegexp(`gravitee-portal\..+`)`` | Public/internal API catalog |
+| ``gravitee.<domain>/`` | `gravitee-apim-ui:8002` | Management Console SPA |
+| ``gravitee.<domain>/management/`` | `gravitee-apim-api:83` | Management REST API (Console XHR target) |
+| ``gravitee.<domain>/portal/`` | `gravitee-apim-api:83` | Portal-facing REST API (Portal SPA XHR target) |
+| ``gravitee-portal.<domain>`` | `gravitee-apim-portal:8003` | Developer Portal SPA |
+| ``gravitee-gw.<domain>`` | `gravitee-apim-gateway:82` | Public API Gateway runtime |
 
-The Management API connects to the cluster's shared `postgresql` service against database `graviteedb` as role `gravitee_user`. The setup playbook creates both during `./uis deploy gravitee`. The Console UI and Developer Portal SPA both call the Management API over HTTP using the cluster-internal service name; no inter-component coupling reaches outside the `gravitee` namespace except for the PostgreSQL connection.
+**Why Console + management API share a hostname.** Gravitee uses an HttpOnly session cookie for Console authentication. Cross-origin XHR (Console at one subdomain calling API at another) needs `SameSite=None; Secure` cookies, which require HTTPS. Plain HTTP for laptop dev forces same-origin: route the API under a `/management/*` path on the Console hostname so cookies travel trivially. This matches the Gravitee chart's default deployment shape.
+
+The Management API connects to the cluster's shared `postgresql` service against database `graviteedb` as role `gravitee_user`. The setup playbook creates both during `./uis deploy gravitee`. No inter-component coupling reaches outside the `gravitee` namespace except for the PostgreSQL connection.
 
 ## Limitations and gotchas
 
@@ -77,8 +80,8 @@ kubectl get ingressroute -n gravitee
 # Smoke checks (run from host)
 curl -fsS http://gravitee.localhost/                            # Console SPA  -> 200
 curl -fsS http://gravitee-portal.localhost/                     # Portal SPA   -> 200
-curl -fsS -u admin:admin \
-    http://gravitee-api.localhost/management/organizations/DEFAULT  # Mgmt API -> 200
+curl -fsS -u admin:LocalDev@123 \
+    http://gravitee.localhost/management/organizations/DEFAULT  # Mgmt API     -> 200
 curl -sS -o /dev/null -w "%{http_code}\n" http://gravitee-gw.localhost/
                                                                 # Gateway      -> 404 by design
                                                                 # (no APIs deployed yet; 404 with body
@@ -132,7 +135,7 @@ After editing the source common-values, run `./uis secrets generate` and `./uis 
 
 ### SPA URL configuration
 
-The Console and Developer Portal SPAs read their management API URL from `/constants.json` (Console) and `/assets/config.json` (Portal). UIS overrides `ui.baseURL`, `portal.baseURL`, and `ui.portal.entrypoint` in `manifests/090-gravitee-config.yaml` so the SPAs talk to `http://gravitee-api.localhost/...` rather than the chart's `apim.example.com` placeholder. CORS on the management API echoes the `Origin` header, so the cross-host XHR pattern (Console at `gravitee.localhost`, API at `gravitee-api.localhost`) works without additional configuration.
+The Console and Developer Portal SPAs read their management API URL from `/constants.json` (Console) and `/assets/config.json` (Portal). UIS overrides `ui.baseURL`, `portal.baseURL`, and `ui.portal.entrypoint` in `manifests/090-gravitee-config.yaml`. Both SPAs point at the same hostname they're served from (Console at `gravitee.<domain>`, with the API at `gravitee.<domain>/management/`) for same-origin auth — see the [Architecture](#architecture) section for why.
 
 ## Undeploy
 
@@ -204,7 +207,7 @@ The Console at `http://gravitee.localhost/` fetches `/constants.json` to learn t
 curl -fsS http://gravitee.localhost/constants.json | head
 ```
 
-Expected `baseURL: "http://gravitee-api.localhost/management"`. If you see `apim.example.com`, `manifests/090-gravitee-config.yaml` is missing the `ui.baseURL` and `portal.baseURL` overrides; re-deploy after restoring them.
+Expected `baseURL: "http://gravitee.localhost/management"`. If you see `apim.example.com`, `manifests/090-gravitee-config.yaml` is missing the `ui.baseURL` and `portal.baseURL` overrides; re-deploy after restoring them.
 
 ## Learn More
 

--- a/website/docs/services/integration/gravitee.md
+++ b/website/docs/services/integration/gravitee.md
@@ -5,52 +5,122 @@ sidebar_label: Gravitee
 
 # Gravitee
 
-API management and gateway platform.
+API management and gateway platform — Gravitee APIM 4.11 on PostgreSQL.
 
 | | |
 |---|---|
 | **Category** | Integration |
 | **Deploy** | `./uis deploy gravitee` |
 | **Undeploy** | `./uis undeploy gravitee` |
-| **Depends on** | None |
+| **Depends on** | postgresql |
 | **Required by** | None |
-| **Helm chart** | `graviteeio/apim3` (unpinned) |
-| **Default namespace** | `default` |
+| **Helm chart** | `graviteeio/apim:4.11.x` |
+| **Default namespace** | `gravitee` |
+
+:::warning Implementation in Progress
+This page describes the **target architecture** per [INVESTIGATE-gravitee-fix.md](../../ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md). The deployment is being rewritten end-to-end — `./uis deploy gravitee` may not yet match this shape. The previous Gravitee setup (MongoDB-backed, namespace `default`) is being replaced. Treat this page as authoritative for the *new* deployment once the implementation plan lands.
+:::
 
 ## What It Does
 
-Gravitee provides API management capabilities including an API gateway, developer portal, and management console. It is used for creating, publishing, and managing APIs with policies for rate limiting, authentication, and transformation.
+Gravitee API Management is an open-source API gateway and management platform. UIS deploys APIM 4.11 with **PostgreSQL** as the management/config store via the JDBC repository plugin — no MongoDB, no Elasticsearch, no Redis. Four pods run in the `gravitee` namespace: Management API, Management UI (Console), Developer Portal, and the API Gateway. The platform's shared `postgresql` service holds Gravitee's metadata (API definitions, policies, users, audit log); Liquibase auto-applies the schema on first start.
 
-:::warning Skipped in Testing
-Gravitee is not included in automated test runs due to its complexity and resource requirements. It may require additional configuration to work correctly.
-:::
+## Architecture
+
+Single shared instance per UIS cluster. Routing via Traefik `IngressRoute` resources with `HostRegexp` patterns so the same routes work across `*.localhost`, `*.<tailnet>.ts.net`, and Cloudflare-tunneled domains:
+
+| Component | Hostname pattern | Purpose |
+|---|---|---|
+| Management Console | ``HostRegexp(`gravitee\..+`)`` | Admin UI for API designers |
+| Management API | ``HostRegexp(`gravitee-api\..+`)`` | Backend REST API for Console + Portal |
+| API Gateway | ``HostRegexp(`gravitee-gw\..+`)`` | Runtime API proxy endpoint |
+| Developer Portal | ``HostRegexp(`gravitee-portal\..+`)`` | Public/internal API catalog |
+
+The Management API connects to the cluster's shared `postgresql` service against database `graviteedb` as role `gravitee_user`. The setup playbook creates both during `./uis deploy gravitee`. The Console UI and Developer Portal SPA both call the Management API over HTTP using the cluster-internal service name; no inter-component coupling reaches outside the `gravitee` namespace except for the PostgreSQL connection.
+
+## Limitations and gotchas
+
+### What we lose by skipping Elasticsearch and Redis
+
+UIS deploys Gravitee without Elasticsearch and Redis to keep the laptop-scale resource footprint down. Each is independently optional in APIM 4.x; the trade-offs are listed here so a future contributor knows exactly what to switch on if any of these gaps become real requirements.
+
+- **Empty analytics view in the Console.** Without Elasticsearch, the Console's analytics tab has no per-API request counts, latency graphs, or status-code distributions. APIs still serve traffic — Gravitee just doesn't aggregate it. Gateway request logs are visible via `kubectl logs deployment/gravitee-apim-gateway -n gravitee` for ad-hoc debugging.
+- **No rate-limiting or quota policies.** The chart is configured with `ratelimit.type: none`. Applying a rate-limit policy in the Console may succeed at design time but will not enforce limits at runtime. Gravitee's recommended rate-limit store is Redis; the JDBC/PostgreSQL alternative has [known concurrency bugs](https://github.com/gravitee-io/issues/issues/6563) (closed wontfix) and is discouraged.
+- **No response caching policy.** Same shape as rate-limiting — depends on Redis.
+- **No log search in the Console.** The Console's log-search feature depends on Elasticsearch. Gateway request logs are stdout-only.
+
+All four are first-class production features; none are required to validate "Gravitee is deployed and the gateway proxies traffic." For a single-developer or local-dev cluster, the omissions are usually acceptable. Add Elasticsearch and/or Redis later if a real need surfaces; both are independent toggles in `manifests/090-gravitee-config.yaml`.
+
+### PostgreSQL is the management store, not the rate-limit store
+
+The two roles are separate. Using PostgreSQL for management/config is solid (JDBC repository plugin is first-class in APIM 4.x, Liquibase migrations are auto-applied). Using PostgreSQL as the rate-limit backend is the [bug](https://github.com/gravitee-io/issues/issues/6563) referenced above. If rate-limiting is enabled in the future, plan for Redis — don't route rate-limit policies through PostgreSQL.
+
+### Resource footprint
+
+Default chart values are sized for production. UIS overrides per-component `resources.requests` and `resources.limits` in `manifests/090-gravitee-config.yaml` to a laptop-tuned baseline (~1.2 CPU / 2.5 GiB combined across the four pods). Adjust there if the local cluster has more or less headroom.
 
 ## Deploy
 
 ```bash
+# Required dependency:
+./uis deploy postgresql
+
+# Then:
 ./uis deploy gravitee
 ```
 
-No dependencies (uses its own embedded Elasticsearch and MongoDB, or can use the shared instances).
+The setup playbook creates the `gravitee` namespace, ensures the `gravitee/urbalurba-secrets` Secret has the required keys, bootstraps `graviteedb` + `gravitee_user` against the platform's `postgresql` service, installs the `graviteeio/apim` Helm chart, applies the IngressRoute resources, and waits for all four Deployments to reach Available.
 
 ## Verify
 
 ```bash
-# Quick check
-./uis verify gravitee
+# Pods
+kubectl get pods -n gravitee
+kubectl get ingressroute -n gravitee
 
-# Manual check
-kubectl get pods -n default -l app.kubernetes.io/name=gravitee
+# Smoke checks (run from host)
+curl -fsS http://gravitee.localhost/                          # Console SPA
+curl -fsS http://gravitee-api.localhost/management/health     # Management API health
+curl -fsS http://gravitee-gw.localhost/_node/health           # Gateway health
+curl -fsS http://gravitee-portal.localhost/                   # Portal SPA
 ```
+
+The Console default admin login is `${GRAVITEE_ADMIN_EMAIL}` / `${GRAVITEE_ADMIN_PASSWORD}` (sourced from the namespace secret).
 
 ## Configuration
 
-### Key Files
+### Key files
 
 | File | Purpose |
 |------|---------|
+| `provision-host/uis/services/integration/service-gravitee.sh` | Service metadata (UIS conventions) |
 | `ansible/playbooks/090-setup-gravitee.yml` | Deployment playbook |
 | `ansible/playbooks/090-remove-gravitee.yml` | Removal playbook |
+| `manifests/090-gravitee-config.yaml` | Helm values overrides (chart pin, JDBC backend, ingress disabled, resource limits) |
+| `manifests/091-gravitee-ingress.yaml` | Traefik IngressRoutes |
+| `provision-host/uis/templates/secrets-templates/00-common-values.env.template` | First-class `GRAVITEE_POSTGRES_*` variables |
+
+### Secrets
+
+Gravitee reads its PostgreSQL connection and admin credentials from `gravitee/urbalurba-secrets`. Relevant keys:
+
+| Key | Source | Purpose |
+|---|---|---|
+| `GRAVITEE_POSTGRES_USER` | first-class env var | Postgres role for the management connection |
+| `GRAVITEE_POSTGRES_PASSWORD` | first-class env var | Postgres role password |
+| `GRAVITEE_POSTGRES_DATABASE` | first-class env var | Database name (default `graviteedb`) |
+| `GRAVITEE_POSTGRES_HOST` | derived | Cluster-internal Postgres service hostname |
+| `GRAVITEE_POSTGRES_PORT` | derived | `5432` |
+| `GRAVITEE_POSTGRES_JDBC_URL` | derived | Pre-assembled JDBC URL passed to `management.jdbc.url` |
+| `GRAVITEE_ADMIN_EMAIL` | derived from `DEFAULT_ADMIN_EMAIL` | Console default admin login |
+| `GRAVITEE_ADMIN_PASSWORD` | derived from `DEFAULT_ADMIN_PASSWORD` | Console default admin password |
+| `GRAVITEE_ENCRYPTION_KEY` | derived | Encrypts sensitive data at rest in the management DB |
+
+After editing `00-common-values.env.template`, run `./uis secrets generate` and `./uis secrets apply`.
+
+### Helm chart pin
+
+`SCRIPT_IMAGE` in `service-gravitee.sh` and the chart version in `090-setup-gravitee.yml` reference the same APIM patch (currently 4.11.x). Bumps are deliberate — see the [investigation](../../ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md) for the chart pin policy.
 
 ## Undeploy
 
@@ -58,6 +128,36 @@ kubectl get pods -n default -l app.kubernetes.io/name=gravitee
 ./uis undeploy gravitee
 ```
 
+Removes the Helm release and the four IngressRoute objects. PostgreSQL state (`graviteedb`, `gravitee_user`) and the namespace secret are preserved by default; re-deploy works without re-bootstrap.
+
+For a full teardown that drops the database, role, secret, and namespace, the remove playbook accepts an explicit `--purge` extra var.
+
+## Troubleshooting
+
+### Pods stuck in `Init` or `CrashLoopBackOff` after deploy
+
+Check the Management API logs first — most issues surface there:
+
+```bash
+kubectl logs -n gravitee deployment/gravitee-apim-api --tail=200
+```
+
+Common causes:
+
+- **PostgreSQL not reachable** — Management API logs will show JDBC connection refused. Verify `./uis deploy postgresql` is running and the JDBC URL in the secret resolves.
+- **Liquibase migrations failing** — visible in Management API startup logs. Usually a stale `graviteedb` from a prior schema. Drop and redeploy: `./uis undeploy gravitee --purge && ./uis deploy gravitee`.
+- **Encryption key changed after first deploy** — anything previously encrypted in the management DB becomes unreadable. The Management API may start but the Console will fail to load existing API definitions. Either restore the original `GRAVITEE_ENCRYPTION_KEY` or purge and redeploy.
+
+### Applied a rate-limit policy and it doesn't enforce
+
+This is expected — see [What we lose by skipping Elasticsearch and Redis](#what-we-lose-by-skipping-elasticsearch-and-redis). Rate-limit policies require a configured rate-limit store; UIS sets `ratelimit.type: none` to avoid the Redis dependency. Add Redis and switch `ratelimit.type` if rate-limiting is needed.
+
+### Analytics tab in Console is empty
+
+Same root cause — no Elasticsearch deployed. Gateway request logs are accessible via `kubectl logs`.
+
 ## Learn More
 
 - [Official Gravitee documentation](https://documentation.gravitee.io/)
+- [Gravitee JDBC repository (PostgreSQL configuration)](https://documentation.gravitee.io/apim/installation-and-upgrades/repositories/jdbc)
+- [INVESTIGATE-gravitee-fix.md](../../ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md) — current architecture and implementation plan

--- a/website/docs/services/integration/gravitee.md
+++ b/website/docs/services/integration/gravitee.md
@@ -14,12 +14,8 @@ API management and gateway platform — Gravitee APIM 4.11 on PostgreSQL.
 | **Undeploy** | `./uis undeploy gravitee` |
 | **Depends on** | postgresql |
 | **Required by** | None |
-| **Helm chart** | `graviteeio/apim:4.11.x` |
+| **Helm chart** | `graviteeio/apim` (4.11.3) |
 | **Default namespace** | `gravitee` |
-
-:::warning Implementation in Progress
-This page describes the **target architecture** per [INVESTIGATE-gravitee-fix.md](../../ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md). The deployment is being rewritten end-to-end — `./uis deploy gravitee` may not yet match this shape. The previous Gravitee setup (MongoDB-backed, namespace `default`) is being replaced. Treat this page as authoritative for the *new* deployment once the implementation plan lands.
-:::
 
 ## What It Does
 
@@ -74,18 +70,29 @@ The setup playbook creates the `gravitee` namespace, ensures the `gravitee/urbal
 ## Verify
 
 ```bash
-# Pods
+# Pods (expect 6: api, gateway, portal, ui×3)
 kubectl get pods -n gravitee
 kubectl get ingressroute -n gravitee
 
 # Smoke checks (run from host)
-curl -fsS http://gravitee.localhost/                          # Console SPA
-curl -fsS http://gravitee-api.localhost/management/health     # Management API health
-curl -fsS http://gravitee-gw.localhost/_node/health           # Gateway health
-curl -fsS http://gravitee-portal.localhost/                   # Portal SPA
+curl -fsS http://gravitee.localhost/                            # Console SPA  -> 200
+curl -fsS http://gravitee-portal.localhost/                     # Portal SPA   -> 200
+curl -fsS -u admin:admin \
+    http://gravitee-api.localhost/management/organizations/DEFAULT  # Mgmt API -> 200
+curl -sS -o /dev/null -w "%{http_code}\n" http://gravitee-gw.localhost/
+                                                                # Gateway      -> 404 by design
+                                                                # (no APIs deployed yet; 404 with body
+                                                                # "No context-path matches the request URI"
+                                                                # is the gateway responding correctly)
 ```
 
-The Console default admin login is `${GRAVITEE_ADMIN_EMAIL}` / `${GRAVITEE_ADMIN_PASSWORD}` (sourced from the namespace secret).
+Open `http://gravitee.localhost` in a browser, log in to the Console with the credentials in `gravitee/urbalurba-secrets`, create an API pointing at any HTTP echo backend, and curl the resulting `/your-context-path` to verify end-to-end gateway routing.
+
+```bash
+EMAIL=$(kubectl get secret urbalurba-secrets -n gravitee -o jsonpath='{.data.GRAVITEE_ADMIN_EMAIL}' | base64 -d)
+PASSWORD=$(kubectl get secret urbalurba-secrets -n gravitee -o jsonpath='{.data.GRAVITEE_ADMIN_PASSWORD}' | base64 -d)
+echo "Console: http://gravitee.localhost/   login: admin (or $EMAIL) / $PASSWORD"
+```
 
 ## Configuration
 
@@ -104,33 +111,43 @@ The Console default admin login is `${GRAVITEE_ADMIN_EMAIL}` / `${GRAVITEE_ADMIN
 
 Gravitee reads its PostgreSQL connection and admin credentials from `gravitee/urbalurba-secrets`. Relevant keys:
 
-| Key | Source | Purpose |
-|---|---|---|
-| `GRAVITEE_POSTGRES_USER` | first-class env var | Postgres role for the management connection |
-| `GRAVITEE_POSTGRES_PASSWORD` | first-class env var | Postgres role password |
-| `GRAVITEE_POSTGRES_DATABASE` | first-class env var | Database name (default `graviteedb`) |
-| `GRAVITEE_POSTGRES_HOST` | derived | Cluster-internal Postgres service hostname |
-| `GRAVITEE_POSTGRES_PORT` | derived | `5432` |
-| `GRAVITEE_POSTGRES_JDBC_URL` | derived | Pre-assembled JDBC URL passed to `management.jdbc.url` |
-| `GRAVITEE_ADMIN_EMAIL` | derived from `DEFAULT_ADMIN_EMAIL` | Console default admin login |
-| `GRAVITEE_ADMIN_PASSWORD` | derived from `DEFAULT_ADMIN_PASSWORD` | Console default admin password |
-| `GRAVITEE_ENCRYPTION_KEY` | derived | Encrypts sensitive data at rest in the management DB |
+| Key | Source | Purpose | Wired? |
+|---|---|---|---|
+| `GRAVITEE_POSTGRES_USER` | first-class env var | Postgres role for the management connection | ✅ |
+| `GRAVITEE_POSTGRES_PASSWORD` | first-class env var | Postgres role password (env-injected on api + gateway as `GRAVITEE_MANAGEMENT_JDBC_PASSWORD`) | ✅ |
+| `GRAVITEE_POSTGRES_DATABASE` | first-class env var | Database name (default `graviteedb`) | ✅ |
+| `GRAVITEE_POSTGRES_HOST` | derived | Cluster-internal Postgres service hostname | ✅ |
+| `GRAVITEE_POSTGRES_PORT` | derived | `5432` | ✅ |
+| `GRAVITEE_POSTGRES_JDBC_URL` | derived | Pre-assembled JDBC URL passed to `management.jdbc.url` | ✅ |
+| `GRAVITEE_ADMIN_EMAIL` | derived from `DEFAULT_ADMIN_EMAIL` | Console admin email (passed to chart as `adminEmail`) | ✅ |
+| `GRAVITEE_ADMIN_PASSWORD` | derived from `DEFAULT_ADMIN_PASSWORD` | Console admin password (bcrypted at deploy time, passed to chart as `adminPasswordBcrypt`) | ✅ |
+| `GRAVITEE_ADMIN_PASSWORD_BCRYPT` | computed by setup playbook | Cached bcrypt hash; reused on subsequent deploys to keep `helm upgrade` idempotent. Not user-editable — wiped by `./uis secrets apply`, recomputed on next deploy. | (auto) |
+| `GRAVITEE_ENCRYPTION_KEY` | derived | Encrypts sensitive data at rest (env-injected on api + gateway as `GRAVITEE_API_PROPERTIES_ENCRYPTION_SECRET`) | ✅ |
 
-After editing `00-common-values.env.template`, run `./uis secrets generate` and `./uis secrets apply`.
+After editing the source common-values, run `./uis secrets generate` and `./uis secrets apply`. New variables added to the source template are **not** propagated to existing `.uis.secrets/` directories — append them manually or `rm -rf .uis.secrets` to re-init.
 
 ### Helm chart pin
 
-`SCRIPT_IMAGE` in `service-gravitee.sh` and the chart version in `090-setup-gravitee.yml` reference the same APIM patch (currently 4.11.x). Bumps are deliberate — see the [investigation](../../ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md) for the chart pin policy.
+`SCRIPT_IMAGE` in `service-gravitee.sh` and the chart version reference in `090-setup-gravitee.yml` are pinned to the same APIM patch (currently `4.11.3`). Bumps are deliberate — chart breakages are usually visible as Liquibase migration errors on first start of the Management API pod.
+
+### SPA URL configuration
+
+The Console and Developer Portal SPAs read their management API URL from `/constants.json` (Console) and `/assets/config.json` (Portal). UIS overrides `ui.baseURL`, `portal.baseURL`, and `ui.portal.entrypoint` in `manifests/090-gravitee-config.yaml` so the SPAs talk to `http://gravitee-api.localhost/...` rather than the chart's `apim.example.com` placeholder. CORS on the management API echoes the `Origin` header, so the cross-host XHR pattern (Console at `gravitee.localhost`, API at `gravitee-api.localhost`) works without additional configuration.
 
 ## Undeploy
 
 ```bash
+# Default: leaves persistent state intact
 ./uis undeploy gravitee
+
+# Full teardown
+./uis undeploy gravitee --purge          # prompts for confirmation
+./uis undeploy gravitee --purge --yes    # automation override
 ```
 
-Removes the Helm release and the four IngressRoute objects. PostgreSQL state (`graviteedb`, `gravitee_user`) and the namespace secret are preserved by default; re-deploy works without re-bootstrap.
+Default mode removes the Helm release and the four IngressRoute objects. PostgreSQL state (`graviteedb`, `gravitee_user`) and the namespace secret are preserved; re-deploy works without re-bootstrap.
 
-For a full teardown that drops the database, role, secret, and namespace, the remove playbook accepts an explicit `--purge` extra var.
+`--purge` additionally drops the database, role, secret, all PVCs in the namespace, and the namespace itself. The next `./uis deploy gravitee` after a purge re-bootstraps from scratch — Liquibase recreates the schema. The confirmation prompt requires an interactive TTY; in scripted contexts pass `--yes` to skip it (or the command bails before destroying anything).
 
 ## Troubleshooting
 
@@ -150,14 +167,46 @@ Common causes:
 
 ### Applied a rate-limit policy and it doesn't enforce
 
-This is expected — see [What we lose by skipping Elasticsearch and Redis](#what-we-lose-by-skipping-elasticsearch-and-redis). Rate-limit policies require a configured rate-limit store; UIS sets `ratelimit.type: none` to avoid the Redis dependency. Add Redis and switch `ratelimit.type` if rate-limiting is needed.
+Expected — see [What we lose by skipping Elasticsearch and Redis](#what-we-lose-by-skipping-elasticsearch-and-redis). With `ratelimit.type: none`, the gateway loads `Repository [RATE_LIMIT] loaded by none` at startup; the management API and Console UI accept rate-limit policies without complaint, but the gateway does not enforce them at runtime. **There is no UI warning** that the policy is inert — operators have to know. Add Redis and switch `ratelimit.type: redis` if rate-limiting is required.
 
 ### Analytics tab in Console is empty
 
-Same root cause — no Elasticsearch deployed. Gateway request logs are accessible via `kubectl logs`.
+Same root cause — no Elasticsearch. Gateway request logs are accessible via `kubectl logs deployment/gravitee-apim-gateway -n gravitee`.
+
+### Admin login fails with the secret-stored credentials
+
+The setup playbook bcrypts `GRAVITEE_ADMIN_PASSWORD` and passes it to the chart as `adminPasswordBcrypt`, with `adminEmail` from the secret. If login fails, verify the rendered chart values:
+
+```bash
+helm get values gravitee-apim -n gravitee | grep -E 'admin(Email|Password)'
+```
+
+Expected: `adminEmail` and `adminPasswordBcrypt: $2a$10$...`. The Console accepts either `admin` or the email address as the username field — both authenticate to the same in-memory account.
+
+If `adminPasswordBcrypt` is missing or still the chart-default `$2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq`, the playbook's bcrypt step (`090-setup-gravitee.yml` task 20d) didn't run or didn't populate the helm flag. Re-deploy with `./uis deploy gravitee`.
+
+### Pods log "You still use the default secret" for the encryption key
+
+If you see this warning, the api/gateway pod isn't picking up `GRAVITEE_API_PROPERTIES_ENCRYPTION_SECRET`. Verify with:
+
+```bash
+kubectl get pod -n gravitee -l app.kubernetes.io/component=api \
+    -o jsonpath='{.items[0].spec.containers[0].env[*].name}{"\n"}'
+```
+
+The list should include `GRAVITEE_API_PROPERTIES_ENCRYPTION_SECRET` and `GRAVITEE_MANAGEMENT_JDBC_PASSWORD`. If missing, the `env:` block under `api:` and `gateway:` in `manifests/090-gravitee-config.yaml` got renamed back to the chart-ignored `extraEnvs:` — the chart honors `env:` (or `deployment.extraEnvs:`) but silently drops bare `extraEnvs:`.
+
+### Console SPA loads but no data appears (page stays empty / 404 on XHR)
+
+The Console at `http://gravitee.localhost/` fetches `/constants.json` to learn the management API URL. If `constants.json` baseURL points at `apim.example.com` (the chart's placeholder), every XHR fails. Verify with:
+
+```bash
+curl -fsS http://gravitee.localhost/constants.json | head
+```
+
+Expected `baseURL: "http://gravitee-api.localhost/management"`. If you see `apim.example.com`, `manifests/090-gravitee-config.yaml` is missing the `ui.baseURL` and `portal.baseURL` overrides; re-deploy after restoring them.
 
 ## Learn More
 
 - [Official Gravitee documentation](https://documentation.gravitee.io/)
 - [Gravitee JDBC repository (PostgreSQL configuration)](https://documentation.gravitee.io/apim/installation-and-upgrades/repositories/jdbc)
-- [INVESTIGATE-gravitee-fix.md](../../ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md) — current architecture and implementation plan

--- a/website/docs/services/integration/gravitee.md
+++ b/website/docs/services/integration/gravitee.md
@@ -58,6 +58,15 @@ The two roles are separate. Using PostgreSQL for management/config is solid (JDB
 
 Default chart values are sized for production. UIS overrides per-component `resources.requests` and `resources.limits` in `manifests/090-gravitee-config.yaml` to a laptop-tuned baseline (~1.2 CPU / 2.5 GiB combined across the four pods). Adjust there if the local cluster has more or less headroom.
 
+### Enterprise-only Console features
+
+The Helm chart we deploy is the OSS Gravitee APIM image. The Console SPA still ships UI for several Enterprise-licensed modules, which appear with a lock icon and are non-functional without an EE license:
+
+- **API Products**, **Kafka Clusters**, **Audit**, **Alerts** in the left navigation.
+- A `503` on `GET /management/v2/organizations/DEFAULT/ui/customization` (Console branding/customization) — served by an EE component the OSS chart does not deploy. Login, navigation, and API management work normally; only the customization UI is unavailable.
+
+These are expected on an OSS install and are not regressions to investigate.
+
 ## Deploy
 
 ```bash

--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -305,17 +305,20 @@
     "name": "Gravitee",
     "description": "API management and gateway platform",
     "category": "INTEGRATION",
-    "tags": ["api-gateway", "api-management", "rest", "graphql", "security"],
-    "abstract": "Open-source API management platform for designing, deploying, and managing APIs",
+    "tags": ["api-gateway", "api-management", "gravitee", "postgresql"],
+    "abstract": "A platform service that runs Gravitee API Management with PostgreSQL as the metadata store and no Elasticsearch/Redis dependencies.",
     "logo": "gravitee-logo.svg",
     "website": "https://www.gravitee.io"
-    ,"summary": "Gravitee is an open-source API management platform that helps you design, deploy, and manage APIs. It provides a gateway, management console, and developer portal for comprehensive API lifecycle management."
+    ,"summary": "Gravitee APIM is an open-source API gateway and management platform with admin Console, Developer Portal, and runtime API gateway. UIS deploys APIM 4.11 with PostgreSQL as the management store via the JDBC repository plugin (no MongoDB). Elasticsearch and Redis are not deployed; analytics dashboards and rate-limit policies are disabled. Suitable for laptop-scale development clusters."
     ,"docs": "/docs/services/integration/gravitee"
     ,"playbook": "090-setup-gravitee.yml"
-    ,"priority": 81
-    ,"checkCommand": "kubectl get pods -n gravitee -l app.kubernetes.io/name=gravitee --no-headers 2>/dev/null | grep -q Running"
+    ,"priority": 50
+    ,"checkCommand": "kubectl get pods -n gravitee -l app.kubernetes.io/instance=gravitee-apim --no-headers 2>/dev/null | grep -qE \\\\s(Running|Completed)\\\\s"
+    ,"removePlaybook": "090-remove-gravitee.yml"
+    ,"requires": ["postgresql"]
     ,"helmChart": "graviteeio/apim"
-    ,"namespace": "default"
+    ,"namespace": "gravitee"
+    ,"image": "graviteeio/apim:4.11.3"
   }
 ,
   {


### PR DESCRIPTION
## Summary

Re-architect Gravitee APIM deployment for laptop-scale UIS clusters:
- Use PostgreSQL via JDBC repository plugin instead of MongoDB
- Disable Elasticsearch (analytics off) and Redis (rate-limit `none`)
- Pin chart `graviteeio/apim` at `4.11.3`; disable chart-managed Ingress; UIS owns 4 Traefik IngressRoutes (Console, API, Gateway, Portal)
- Per-pod resource overrides (~1.2 CPU / 2.5 GiB combined)
- New `--purge` flag plumbed through `./uis undeploy` → playbook `_purge=true` extra-var (TTY confirmation, `--yes` automation override). Generic infrastructure, reusable across services
- Idempotent Postgres role+db bootstrap with password rotation; per-pod JDBC password via `secretKeyRef` on both `api` and `gateway`
- Secrets: deprecate `GRAVITEE_MONGODB_*` (kept as transition stubs), introduce first-class `GRAVITEE_POSTGRES_*`

This is **PR-A (Phases 1-4)**. PR-B will remove the MongoDB stubs after this lands and verifies in production.

See `website/docs/ai-developer/plans/active/PLAN-gravitee-postgresql-deployment.md` for the full plan and `website/docs/ai-developer/plans/backlog/INVESTIGATE-gravitee-fix.md` for the investigation that drove the decisions.

## Test plan

- [ ] Phase 4 (merge gate) — fresh-reset cluster end-to-end:
  - [ ] `./uis deploy postgresql` succeeds; `graviteedb` and `gravitee_user` are bootstrapped idempotently
  - [ ] `./uis deploy gravitee` succeeds; all four pods (`gravitee-apim-api`, `-gateway`, `-ui`, `-portal`) reach Ready
  - [ ] Liquibase migrations complete cleanly on first start of management API
  - [ ] Console (`http://gravitee.localhost`) loads, admin login works (admin email/password from secret)
  - [ ] Management API (`http://gravitee-api.localhost/management/v2/console/health`) returns 200
  - [ ] Gateway (`http://gravitee-gw.localhost/`) responds
  - [ ] Portal (`http://gravitee-portal.localhost/`) loads
  - [ ] No MongoDB/Elasticsearch/Redis pods scheduled in `gravitee` namespace
  - [ ] `./uis undeploy gravitee` (default mode) leaves PVCs, secret, namespace, and database intact; redeploy succeeds without re-bootstrap
  - [ ] `./uis undeploy gravitee --purge` drops database, role, PVCs, secret, and namespace; subsequent deploy fully bootstraps from scratch
  - [ ] `./uis undeploy gravitee --purge --yes` skips interactive confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)