### PR TITLE
fix(build): make uis-provision-host container build resilient to launchpad outages

### DIFF
--- a/provision-host/provision-host-02-kubetools.sh
+++ b/provision-host/provision-host-02-kubetools.sh
@@ -59,13 +59,16 @@ install_ansible_kubernetes() {
         add_status "Ansible" "Status" "Already installed (${ANSIBLE_VERSION})"
     else
         echo "Installing Ansible and Kubernetes Python module"
+        # ansible-core is installed from PyPI rather than the ppa:ansible/ansible PPA.
+        # Launchpad's HTTPS layer flakes regularly (504s, SSL handshake EOF), and the
+        # add-apt-repository call goes through api.launchpad.net which is the
+        # single point of failure. PyPI is more reliable. On Python 3.10 (Ubuntu 22.04),
+        # pip auto-resolves to ansible-core 2.17.x, which matches what the PPA shipped.
+        # python3-kubernetes still comes from apt (universe), unchanged.
         sudo apt-get update -qq || return 1
-        sudo apt-get install -qq -y software-properties-common || return 1
-        sudo add-apt-repository --yes --update ppa:ansible/ansible || return 1
-
-        # Install ansible-core (slim) instead of full ansible package (~350MB savings)
-        # Then install only the collections we actually use
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ansible-core python3-kubernetes || return 1
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends \
+            python3-pip python3-kubernetes || return 1
+        sudo pip3 install --quiet ansible-core || return 1
         check_command_success "Ansible" "Installation" || return 1
 
         # Install only required Ansible collections (used in our playbooks)
@@ -177,12 +180,21 @@ install_kubectl() {
     # Check if we're in a container or if snap is available
     if [ "$RUNNING_IN_CONTAINER" = "true" ] || ! command -v snap &> /dev/null; then
         echo "Installing kubectl directly (not using snap)"
-        KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-        curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl"
-        chmod +x kubectl
-        sudo mv kubectl /usr/local/bin/
+        KUBECTL_VERSION=$(curl -fL -s https://dl.k8s.io/release/stable.txt) || { add_error "kubectl" "Failed to fetch stable version"; return 1; }
+        if [ -z "$KUBECTL_VERSION" ]; then
+            add_error "kubectl" "Empty version from dl.k8s.io/release/stable.txt"
+            return 1
+        fi
+        curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl" || { add_error "kubectl" "Failed to download kubectl binary"; return 1; }
+        chmod +x kubectl || { add_error "kubectl" "Failed to chmod kubectl"; return 1; }
+        sudo mv kubectl /usr/local/bin/ || { add_error "kubectl" "Failed to move kubectl to /usr/local/bin/"; return 1; }
+        if ! command -v kubectl &> /dev/null; then
+            add_error "kubectl" "kubectl not on PATH after install"
+            return 1
+        fi
         KUBECTL_VERSION=$(kubectl version --client --output=yaml | grep gitVersion | cut -d' ' -f4)
         add_status "kubectl" "Status" "Installed (${KUBECTL_VERSION})"
+        return 0
     else
         echo "Installing kubectl using snap"
         if sudo snap install kubectl --classic; then
@@ -324,10 +336,14 @@ main() {
         sudo apt-get install -qq -y curl snapd || return 1
     fi
 
-    install_ansible_kubernetes || return 1
+    # Install kubectl, helm, k9s first — direct downloads from k8s.io / GitHub,
+    # most resilient. Ansible install (via PyPI) also avoids launchpad now,
+    # but we keep it last so a transient PyPI hiccup can't strand the cluster
+    # tooling that other scripts depend on.
     install_kubectl || return 1
-    install_k9s || return 1
     install_helm || return 1
+    install_k9s || return 1
+    install_ansible_kubernetes || return 1
 
     print_summary
 

--- a/provision-host/provision-host-provision.sh
+++ b/provision-host/provision-host-provision.sh
@@ -171,12 +171,6 @@ main() {
 
     print_summary
 
-    # In container builds, continue even if some scripts fail (e.g., snap not available)
-    if is_container && [ "$overall_exit_code" -ne 0 ]; then
-        echo "Some scripts failed but continuing (container build mode)"
-        exit 0
-    fi
-
     exit $overall_exit_code
 }
 

--- a/uis
+++ b/uis
@@ -282,6 +282,26 @@ case "${1:-help}" in
         # Clean up old temp directories
         docker exec "$CONTAINER_NAME" rm -rf /mnt/urbalurbadisk/.temp /mnt/urbalurbadisk/generate 2>/dev/null || true
 
+        # Test 0: deploy-flow binaries are present
+        # Catches silent regressions in the provision-host-02-kubetools.sh layer
+        # (e.g. a curl from dl.k8s.io failing without aborting the build, leaving
+        # an empty /usr/local/bin/kubectl). Without this, missing binaries only
+        # surface when an actual ./uis deploy runs against a cluster.
+        log_info "Test 0: deploy-flow binary presence"
+        docker exec "$CONTAINER_NAME" bash -c '
+          set -e
+          for bin in kubectl helm ansible-playbook python3; do
+            if ! command -v "$bin" >/dev/null 2>&1; then
+              echo "MISSING: $bin not found on PATH" >&2
+              exit 1
+            fi
+            echo "  $bin: $(command -v "$bin")"
+          done
+          # bcrypt is needed by 090-setup-gravitee.yml for admin-password wiring
+          python3 -c "import bcrypt" || { echo "MISSING: python3 bcrypt module" >&2; exit 1; }
+          echo "  python3 bcrypt: ok"
+        '
+
         # Test 1: uis-cli version
         log_info "Test 1: uis-cli version"
         docker exec "$CONTAINER_NAME" /mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh version


### PR DESCRIPTION
## Why

The `./uis build` command silently produced broken images (no `kubectl`, no `helm`, no `ansible`) whenever launchpad.net had a hiccup — and it's hiccupped twice in this session alone. The build reported success; the missing binaries only surfaced later when `./uis deploy` failed inside the cluster. This PR makes the build robust against the most common launchpad failure modes and removes the dependency entirely for ansible.

Discovered while debugging Gravitee deploys: the running container had no `kubectl`, even though that file had not changed in the repo. Git history showed three commits stacked the failure mode:
- `7325f1a` (Jan 21) — switched to `ansible-core` via the PPA, slimmed snapd
- `11711df` (Jan 27) — added "exit 0 in container build mode" to swallow failures
- (today) — launchpad returned `SSL: UNEXPECTED_EOF_WHILE_READING` from `add-apt-repository`, which fails the ansible install, which short-circuited the rest of `kubetools.sh`, which the build silently accepted

## What

Three concrete fixes in `provision-host/provision-host-02-kubetools.sh` and one in `provision-host-provision.sh`:

1. **Reorder installs** — `kubectl` → `helm` → `k9s` first (direct downloads from `dl.k8s.io` / GitHub, no launchpad), then `ansible` last. A failure in ansible install no longer leaves the cluster tooling missing.

2. **Stop swallowing failures** — removed the `if is_container && exit_code != 0; then exit 0; fi` block in `provision-host-provision.sh`. Build now fails loudly when a provisioning script fails.

3. **Switch ansible-core source from PPA to PyPI** — `pip3 install ansible-core` instead of `add-apt-repository ppa:ansible/ansible && apt install ansible-core`. On Python 3.10 (Ubuntu 22.04), pip auto-resolves to ansible-core 2.17.14 — identical to what the PPA shipped, identical to what the working GHCR image runs. Removes `software-properties-common` + `python3-launchpadlib` + the entire launchpad SPOF.

4. **Hardened `install_kubectl` direct-download branch** — added `|| return 1` on each step. Previously the function returned 0 even if `curl`/`mv` failed, because `add_status` was the last command.

5. **Added Test 0 to `./uis test`** — checks `kubectl`, `helm`, `ansible-playbook`, `python3`, and `python3-bcrypt` are present on PATH. Catches a broken image before deploy.

## Verification

End-to-end, **while launchpad was still returning SSL handshake errors**:
- ✅ Clean `--no-cache` rebuild succeeds
- ✅ All five tools present and working (`kubectl`, `helm`, `k9s`, `ansible 2.17.14`, `ansible-playbook`)
- ✅ Same collection versions as the working GHCR image (kubernetes.core 6.4.0, community.postgresql 4.2.0, community.general 12.6.0)
- ✅ `python3-kubernetes` (apt) importable from pip-installed ansible
- ✅ `./uis test` — all 7 tests pass (Test 0 through Test 6)
- ✅ Live syntax-check of real playbooks (`090-setup-gravitee.yml`, `05-install-helm-repos.yml`, `070-setup-authentik.yml`) — all OK

## Why split from gravitee PR

Build-system change. Affects every future container build, not just gravitee. Easier to review, easier to revert, lets the gravitee PR rebase on a stable foundation.

## Test plan

- [x] `./uis build` on this branch → image built clean, no errors
- [x] `./uis test` → all tests pass (Test 0 confirms binaries present)
- [x] Verified ansible-core version matches GHCR image (2.17.14)
- [x] Verified collection versions match GHCR image
- [x] Verified all real playbooks syntax-check OK
- [ ] Reviewer sanity-check on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)