### PR TITLE
fix(gravitee): count IngressRoutes dynamically in undeploy summary

### DIFF
--- a/ansible/playbooks/090-remove-gravitee.yml
+++ b/ansible/playbooks/090-remove-gravitee.yml
@@ -5,7 +5,7 @@
 #
 #   Default mode (no extra-var):
 #     - Uninstall the Helm release
-#     - Remove the four Traefik IngressRoutes
+#     - Remove the Traefik IngressRoutes (count varies; 091-gravitee-ingress.yaml is the source of truth)
 #     - Wait for pods to terminate
 #     KEEPS: PVCs, gravitee/urbalurba-secrets, namespace, PostgreSQL graviteedb
 #     A subsequent ./uis deploy gravitee re-installs without re-bootstrap.
@@ -44,6 +44,19 @@
           Mode:         {{ 'PURGE — drops database, role, secret, PVCs, namespace' if purge_mode else 'default — keeps PVCs, secret, database, namespace' }}
 
     # ============= ALWAYS: KUBERNETES OBJECTS =============
+
+    - name: 1b. Count IngressRoutes before delete (for accurate status message)
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ merged_kubeconf_file }}"
+        api_version: traefik.io/v1alpha1
+        kind: IngressRoute
+        namespace: "{{ gravitee_namespace }}"
+      register: ingressroutes_before
+      ignore_errors: true
+
+    - name: 1c. Set IngressRoute count fact
+      ansible.builtin.set_fact:
+        ingressroute_count: "{{ ingressroutes_before.resources | default([]) | length }}"
 
     - name: 2. Delete Traefik IngressRoutes
       kubernetes.core.k8s:
@@ -189,7 +202,7 @@
           {% if purge_mode %}
           Removed:
             - Helm release ({{ gravitee_release_name }})
-            - 4 IngressRoutes
+            - {{ ingressroute_count }} IngressRoute{{ '' if ingressroute_count == '1' else 's' }}
             - PostgreSQL database ({{ gravitee_db_name | default('graviteedb') }}) and role ({{ gravitee_db_user | default('gravitee_user') }})
             - All PVCs in namespace
             - gravitee/urbalurba-secrets
@@ -199,7 +212,7 @@
           {% else %}
           Removed:
             - Helm release ({{ gravitee_release_name }})
-            - 4 IngressRoutes
+            - {{ ingressroute_count }} IngressRoute{{ '' if ingressroute_count == '1' else 's' }}
 
           KEPT (use --purge to remove):
             - PostgreSQL database ({{ gravitee_db_name | default('graviteedb') }}) and role


### PR DESCRIPTION
## Why

Tester's Round 10 follow-up surfaced two CLI/playbook nits after the gravitee install was verified. Both were unrelated to PR #137's correctness; one is now fixed here, the other turned out to be a non-issue on current main.

### Finding 1 (the fix in this PR) — undeploy summary claims wrong route count

Before this PR, `./uis undeploy gravitee` printed:

```
Removed:
  - Helm release (gravitee-apim)
  - 4 IngressRoutes      ← wrong; only 3 exist after Round 10
```

The literal `4` was a stale hardcode from before `a5cc0c8` consolidated Console + management API to a single hostname. After consolidation there are 3 IngressRoutes, not 4, and the summary kept lying about it.

**Fix:** new task `1b` reads the actual IngressRoute count from the namespace via `kubernetes.core.k8s_info` *before* the delete runs, registers it as `ingressroute_count`, and the status template substitutes the live count with proper pluralization.

Future shape changes (drop to 2, add a 5th) won't need a status-message edit.

### Finding 2 (no fix needed) — `./uis remove gravitee` silent-success

The tester reported:

```
$ ./uis remove gravitee > /tmp/log 2>&1; echo "EXIT=$?"
EXIT=0
```

Couldn't reproduce on current main. `./uis remove gravitee` now exits 1 with `Unknown command: remove`. The unknown-verb path in `uis-cli.sh main()` (around line 1908) calls `exit "$EXIT_GENERAL_ERROR"`, which `utilities.sh:37` defines as `1`. The tester's EXIT=0 was likely from an older image where this dispatcher path behaved differently; addressed implicitly. Documented in the commit message so the diagnosis is searchable later.

## Test plan

- [x] `ansible-playbook --syntax-check ansible/playbooks/090-remove-gravitee.yml` → OK
- [x] Verified `./uis remove gravitee` returns exit 1 with "Unknown command: remove" (Finding 2 non-issue confirmed)
- [ ] Reviewer: redeploy gravitee → undeploy → confirm summary shows the actual route count (3 today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)