### PR TITLE
feat(postgrest): --schemas flag with State Matrix dispatch

### DIFF
--- a/ansible/playbooks/088-setup-postgrest.yml
+++ b/ansible/playbooks/088-setup-postgrest.yml
@@ -18,11 +18,14 @@
 # Required extra-vars (passed by uis-cli.sh from `--app <name>`):
 #   _app_name    — per-app instance name (k8s-safe), e.g. "atlas"
 #   _url_prefix  — first label of the public hostname, e.g. "api-atlas"
-#   _schema      — Postgres schema PostgREST exposes, e.g. "api_v1"
+#
+# The schema list (PGRST_DB_SCHEMAS) is read from the per-app secret, not
+# passed as an extra-var — configure-postgrest.sh writes it on every
+# successful run; the Deployment template reads it via valueFrom.secretKeyRef.
 #
 # Usage:
 # ansible-playbook playbooks/088-setup-postgrest.yml \
-#   -e "_app_name=atlas _url_prefix=api-atlas _schema=api_v1"
+#   -e "_app_name=atlas _url_prefix=api-atlas"
 
 - name: Set up PostgREST instance for one application
   hosts: localhost
@@ -39,20 +42,20 @@
         that:
           - _app_name is defined and _app_name | length > 0
           - _url_prefix is defined and _url_prefix | length > 0
-          - _schema is defined and _schema | length > 0
         fail_msg: |
           Missing required extra-vars. Multi-instance services need per-app
           context. Run via: ./uis deploy postgrest --app <name>
-          Or directly: ansible-playbook ... -e "_app_name=X _url_prefix=Y _schema=Z"
+          Or directly: ansible-playbook ... -e "_app_name=X _url_prefix=Y"
+          (The schema list is read from the per-app secret, not passed here.)
 
     - name: 2. Print playbook context
       ansible.builtin.debug:
         msg: |
           Setting up PostgREST instance
           App:       {{ _app_name }}
-          Schema:    {{ _schema }}
           URL host:  {{ _url_prefix }}.<any-domain-traefik-knows>
           Namespace: {{ postgrest_namespace }} (shared)
+          Schemas:   read from secret '{{ _app_name }}-postgrest' key PGRST_DB_SCHEMAS
 
     # ============= PHASE 1: PREREQUISITE CHECK =============
 
@@ -77,7 +80,7 @@
         msg: |
           Secret '{{ _app_name }}-postgrest' not found in namespace '{{ postgrest_namespace }}'.
           The configure step must run before deploy. Run:
-            ./uis configure postgrest --app {{ _app_name }} --schema {{ _schema }} --url-prefix {{ _url_prefix }}
+            ./uis configure postgrest --app {{ _app_name }} --schemas <list> --url-prefix {{ _url_prefix }}
           Then retry this deploy.
       when: pgrst_secret_check.resources | length == 0
 

--- a/ansible/playbooks/templates/088-postgrest-config.yml.j2
+++ b/ansible/playbooks/templates/088-postgrest-config.yml.j2
@@ -1,12 +1,14 @@
 # Per-app PostgREST Deployment + Service.
 # Rendered by 088-setup-postgrest.yml with extra-vars:
 #   _app_name    — per-app instance name (k8s-safe), e.g. "atlas"
-#   _schema      — Postgres schema PostgREST exposes, e.g. "api_v1"
 #   _url_prefix  — first label of the public hostname (used by the IngressRoute, not here)
 #
-# The Deployment mounts the per-app secret <app>-postgrest (key PGRST_DB_URI),
-# created by configure-postgrest.sh. If that secret does not exist, the pod
-# will CrashLoopBackOff with a clear "secret not found" event.
+# The schema list (PGRST_DB_SCHEMAS) is no longer a Jinja substitution — it
+# lives as a key on the per-app secret <app>-postgrest, written by
+# configure-postgrest.sh. The Deployment mounts both PGRST_DB_URI and
+# PGRST_DB_SCHEMAS via valueFrom.secretKeyRef. If either key is missing, the
+# pod CrashLoopBackOffs with a clear "couldn't find key" event — that's the
+# operator's signal to run `./uis configure postgrest --app <name> --schemas <list>`.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,7 +47,10 @@ spec:
                   name: "{{ _app_name }}-postgrest"
                   key: PGRST_DB_URI
             - name: PGRST_DB_SCHEMAS
-              value: "{{ _schema }}"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ _app_name }}-postgrest"
+                  key: PGRST_DB_SCHEMAS
             - name: PGRST_DB_ANON_ROLE
               value: "{{ _app_name | replace('-', '_') }}_web_anon"
             - name: PGRST_DB_POOL

--- a/provision-host/uis/lib/configure-postgrest.sh
+++ b/provision-host/uis/lib/configure-postgrest.sh
@@ -21,6 +21,81 @@ PG_CLUSTER_HOST="postgresql.default.svc.cluster.local"
 # PostgREST namespace (where the per-app Deployment + Secret live)
 PGRST_NAMESPACE="postgrest"
 
+# Normalize a --schemas value into a comma-separated list of valid Postgres
+# identifiers. Implements R4 string-level checks from the investigation:
+#   1. Trim whitespace per component
+#   2. Reject empty value or empty components after trim
+#   3. Reject components not matching ^[a-zA-Z_][a-zA-Z0-9_]*$ (SQL-injection guard)
+#   4. De-dupe with a stderr warning (preserves first occurrence)
+# Prints the normalized value to stdout on success; prints an error to stderr
+# and returns non-zero on rejection. The R4 step-4 existence check (does the
+# schema actually exist in pg_namespace) is wired separately at call time —
+# this helper is pure (no DB I/O) and safe to test in isolation.
+_pgrst_normalize_schemas() {
+    local raw="$1"
+    local -a parts=()
+    local seen=""
+    local part trimmed
+    local IFS=','
+
+    if [[ -z "$raw" ]]; then
+        echo "Schema list is empty. Pass --schemas <list> with at least one schema name." >&2
+        return 1
+    fi
+
+    # Catch leading/trailing comma before bash IFS field-splitting drops
+    # the empty trailing field. (Leading commas show up as the first split
+    # being empty and are caught by the per-component empty check below.)
+    if [[ "$raw" == *, ]]; then
+        echo "Schema list contains an empty component (trailing comma)." >&2
+        return 1
+    fi
+
+    for part in $raw; do
+        # Trim leading/trailing whitespace
+        trimmed="${part#"${part%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+
+        if [[ -z "$trimmed" ]]; then
+            echo "Schema list contains an empty component (consecutive commas or trailing comma)." >&2
+            return 1
+        fi
+
+        if ! [[ "$trimmed" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+            echo "Schema name '$trimmed' is not a valid Postgres identifier (must match ^[a-zA-Z_][a-zA-Z0-9_]*\$)." >&2
+            return 1
+        fi
+
+        # De-dupe (case-sensitive; for the platform's intended use, exact
+        # match is sufficient — Postgres folds unquoted identifiers to
+        # lowercase but operators are expected to pass already-lowercase
+        # names since the regex above forbids mixed-case ambiguity in
+        # practice).
+        if [[ ",$seen," == *",$trimmed,"* ]]; then
+            # log_warn writes to stdout by project convention; force it to
+            # stderr here so it doesn't corrupt the normalizer's stdout
+            # output (which is the normalized schema list).
+            log_warn "Duplicate schema '$trimmed' in --schemas list; ignoring the duplicate." >&2
+            continue
+        fi
+
+        parts+=("$trimmed")
+        seen="${seen:+$seen,}$trimmed"
+    done
+
+    if [[ ${#parts[@]} -eq 0 ]]; then
+        echo "Schema list is empty after de-duplication." >&2
+        return 1
+    fi
+
+    # Join with commas, no spaces
+    local out=""
+    for part in "${parts[@]}"; do
+        out="${out:+$out,}$part"
+    done
+    printf '%s' "$out"
+}
+
 # Get the postgresql admin password from urbalurba-secrets
 _pgrst_get_admin_password() {
     local kubeconf="${KUBECONF:-/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all}"
@@ -116,18 +191,111 @@ _pgrst_ensure_namespace() {
         | kubectl apply --kubeconfig="$kubeconf" -f - >/dev/null 2>&1
 }
 
-# Create or update the per-app PGRST_DB_URI secret (idempotent)
+# Create or update the per-app secret with both PGRST_DB_URI and PGRST_DB_SCHEMAS
+# keys (idempotent). PGRST_DB_SCHEMAS holds the comma-separated, normalized
+# schema list that PostgREST exposes; the deploy template reads it via
+# valueFrom.secretKeyRef.
 _pgrst_create_secret() {
     local secret_name="$1"
     local db_uri="$2"
+    local schemas="$3"
     local kubeconf="${KUBECONF:-/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all}"
 
     kubectl create secret generic "$secret_name" \
         --namespace="$PGRST_NAMESPACE" \
         --from-literal=PGRST_DB_URI="$db_uri" \
+        --from-literal=PGRST_DB_SCHEMAS="$schemas" \
         --kubeconfig="$kubeconf" \
         --dry-run=client -o yaml 2>/dev/null \
         | kubectl apply --kubeconfig="$kubeconf" -f - >/dev/null 2>&1
+}
+
+# Read the PGRST_DB_SCHEMAS key from an existing secret (empty string if
+# secret or key is missing). Used for State Matrix dispatch.
+_pgrst_get_secret_schemas() {
+    local secret_name="$1"
+    local kubeconf="${KUBECONF:-/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all}"
+    local val
+    val=$(kubectl get secret "$secret_name" -n "$PGRST_NAMESPACE" \
+        --kubeconfig="$kubeconf" \
+        -o jsonpath='{.data.PGRST_DB_SCHEMAS}' 2>/dev/null)
+    if [[ -n "$val" ]]; then
+        printf '%s' "$val" | base64 -d
+    fi
+}
+
+# Read the PGRST_DB_URI key from an existing secret (empty string if missing).
+# Used by Reconfigure-preserve-URI path to round-trip the URI verbatim.
+_pgrst_get_secret_uri() {
+    local secret_name="$1"
+    local kubeconf="${KUBECONF:-/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all}"
+    local val
+    val=$(kubectl get secret "$secret_name" -n "$PGRST_NAMESPACE" \
+        --kubeconfig="$kubeconf" \
+        -o jsonpath='{.data.PGRST_DB_URI}' 2>/dev/null)
+    if [[ -n "$val" ]]; then
+        printf '%s' "$val" | base64 -d
+    fi
+}
+
+# R4 step 4: verify every schema in the normalized list exists in the target
+# database. Prints the offending schema name to stderr and returns 1 on the
+# first miss; returns 0 if all exist. Schemas have already passed string-level
+# validation (R4 steps 1–3) before this is called, so SQL injection is not a
+# concern here.
+_pgrst_check_schemas_exist() {
+    local schemas="$1"
+    local admin_pass="$2"
+    local database="$3"
+    local IFS=','
+    local s result rc=0
+    for s in $schemas; do
+        result=$(_pgrst_exec_db "SELECT 1 FROM pg_namespace WHERE nspname='$s'" "$admin_pass" "$database") || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            echo "Failed to query pg_namespace in database '$database' (psql exit $rc): $result" >&2
+            return 1
+        fi
+        # _pgrst_exec_db uses psql's default (verbose) output:
+        #     ?column?
+        #    ----------
+        #            1
+        #    (1 row)
+        # The row value has leading whitespace, so anchored grep on "^1$"
+        # doesn't match. Detect "no rows" via the row-count footer instead:
+        # absence of "(0 rows)" + presence of a "(N rows)" footer means at
+        # least one row came back, which is what we want.
+        if printf '%s\n' "$result" | grep -q '(0 rows)'; then
+            echo "Schema '$s' does not exist in database '$database'. Create it first (typically via the consuming app's migration), then retry: ./uis configure postgrest --app <name> --database $database --schemas <list>" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
+# Build the per-schema GRANT block (USAGE on schema + SELECT on existing
+# tables + DEFAULT PRIVILEGES for future tables) for one role across a
+# comma-separated schema list. Caller wraps the result in a transaction.
+_pgrst_build_grant_sql() {
+    local schemas="$1"
+    local role="$2"
+    local IFS=','
+    local s out=""
+    for s in $schemas; do
+        out+="GRANT USAGE ON SCHEMA $s TO $role;
+GRANT SELECT ON ALL TABLES IN SCHEMA $s TO $role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA $s GRANT SELECT ON TABLES TO $role;
+"
+    done
+    printf '%s' "$out"
+}
+
+# Issue NOTIFY pgrst, 'reload schema' against the per-app database so the
+# live PostgREST refreshes its schema cache. PostgREST's db-channel defaults
+# to 'pgrst' on the connected database; no further config needed.
+_pgrst_notify_reload() {
+    local admin_pass="$1"
+    local database="$2"
+    _pgrst_exec_db "NOTIFY pgrst, 'reload schema';" "$admin_pass" "$database" >/dev/null 2>&1 || true
 }
 
 # Delete the per-app secret
@@ -142,7 +310,7 @@ _pgrst_delete_secret() {
 #
 # Argument layout matches the run_configure dispatch in configure.sh:
 #   $1=service_id $2=app_name $3=database_name $4=init_file $5=json_output
-#   $6=namespace $7=secret_name_prefix $8=schema $9=url_prefix $10=rotate $11=purge
+#   $6=namespace $7=secret_name_prefix $8=schemas $9=url_prefix $10=rotate $11=purge
 #
 # Multi-instance handler convention: namespace/secret_name_prefix come from the
 # generic --namespace / --secret-name-prefix flags but PostgREST rejects those
@@ -156,14 +324,14 @@ configure_service() {
     local json_output="$5"
     local namespace="${6:-}"
     local secret_name_prefix="${7:-}"
-    local schema="${8:-}"
+    local schemas="${8:-}"
     local url_prefix="${9:-}"
     local rotate="${10:-false}"
     local purge="${11:-false}"
 
     # Reject flags that don't apply to postgrest (Decision #6)
     if [[ -n "$namespace" || -n "$secret_name_prefix" ]]; then
-        local msg="--namespace and --secret-name-prefix are not supported for postgrest. PostgREST manages its own namespace ($PGRST_NAMESPACE) and secret name (<app>-postgrest). Run: ./uis configure postgrest --app <name> --database <name> --schema api_v1 --url-prefix <prefix>"
+        local msg="--namespace and --secret-name-prefix are not supported for postgrest. PostgREST manages its own namespace ($PGRST_NAMESPACE) and secret name (<app>-postgrest). Run: ./uis configure postgrest --app <name> --database <name> --schemas api_v1,marts,raw --url-prefix <prefix>"
         if [[ "$json_output" == true ]]; then
             _configure_error "usage" "$service_id" "$msg"
         fi
@@ -175,8 +343,8 @@ configure_service() {
     if [[ -z "$database_name" ]]; then
         database_name=$(echo "${app_name}" | tr '-' '_')
     fi
-    if [[ -z "$schema" ]]; then
-        schema="api_v1"
+    if [[ -z "$schemas" ]]; then
+        schemas="api_v1"
     fi
     if [[ -z "$url_prefix" ]]; then
         url_prefix="api-${app_name}"
@@ -288,9 +456,26 @@ EOF
     fi
 
     # ---- ROTATE PATH (Decision #17) ----
+    # Rotate generates a new password and rewrites the secret. PGRST_DB_SCHEMAS
+    # must be preserved across rotate; if the key is missing (PLAN-002-era
+    # secret), refuse and direct the operator to run configure first.
     if [[ "$rotate" == "true" ]]; then
         if ! _pgrst_role_exists "$authenticator_role" "$admin_pass"; then
             local msg="Cannot rotate password for $app_name: role '$authenticator_role' does not exist. Run configure without --rotate first to create it."
+            if [[ "$json_output" == true ]]; then
+                _configure_error "rotate" "$service_id" "$msg"
+            fi
+            log_error "$msg"
+            return 1
+        fi
+
+        # Read PGRST_DB_SCHEMAS from existing secret; fail if absent. Rotate
+        # is not the upgrade path — operator must run configure with --schemas
+        # first to establish the key.
+        local existing_schemas
+        existing_schemas=$(_pgrst_get_secret_schemas "$secret_name")
+        if [[ -z "$existing_schemas" ]]; then
+            local msg="PGRST_DB_SCHEMAS not present in secret. Run './uis configure postgrest --app $app_name --schemas <list>' first to establish the schema list, then retry rotate."
             if [[ "$json_output" == true ]]; then
                 _configure_error "rotate" "$service_id" "$msg"
             fi
@@ -316,38 +501,148 @@ EOF
             return 1
         fi
 
-        # Update the secret with the new password
+        # Update the secret with the new password; preserve schemas verbatim.
         local db_uri="postgresql://${authenticator_role}:${new_password}@${PG_CLUSTER_HOST}:${PG_INTERNAL_PORT}/${database_name}"
         _pgrst_ensure_namespace "$PGRST_NAMESPACE"
-        _pgrst_create_secret "$secret_name" "$db_uri"
+        _pgrst_create_secret "$secret_name" "$db_uri" "$existing_schemas"
 
         if [[ "$json_output" == true ]]; then
             cat <<EOF
-{"status":"rotated","service":"postgrest","app":"$app_name","namespace":"$PGRST_NAMESPACE","secret":"$secret_name","next_step":"kubectl rollout restart deployment/$deployment_name -n $PGRST_NAMESPACE"}
+{"status":"rotated","service":"postgrest","app":"$app_name","namespace":"$PGRST_NAMESPACE","secret":"$secret_name","schemas":"$existing_schemas","next_step":"kubectl rollout restart deployment/$deployment_name -n $PGRST_NAMESPACE"}
 EOF
         else
             echo ""
             echo "Rotated password for '$app_name':"
             echo "  Role: $authenticator_role"
-            echo "  Secret: $PGRST_NAMESPACE/$secret_name (key PGRST_DB_URI)"
+            echo "  Secret: $PGRST_NAMESPACE/$secret_name (keys PGRST_DB_URI + PGRST_DB_SCHEMAS)"
+            echo "  Schemas: $existing_schemas (preserved)"
             echo "  Next step: kubectl rollout restart deployment/$deployment_name -n $PGRST_NAMESPACE"
         fi
         return 0
     fi
 
-    # ---- IDEMPOTENT NO-OP CHECK (Decision #17) ----
-    # If both roles AND the secret already exist, treat configure as a no-op.
-    if _pgrst_role_exists "$web_anon_role" "$admin_pass" \
-        && _pgrst_role_exists "$authenticator_role" "$admin_pass" \
-        && _pgrst_secret_exists "$secret_name"; then
-        echo "PostgREST already configured for '$app_name' — nothing to do." >&2
+    # ---- DEFAULT PATH (configure with --schemas) ----
+    # Implements the State Matrix dispatch from
+    # INVESTIGATE-postgrest-multi-schema-reconciliation.md §State Matrix.
+    # Five paths: First-time, Reconfigure-preserve-URI,
+    # Reconfigure-fresh-password, No-op, Inconsistent.
+
+    echo "Configuring PostgREST for app '$app_name'..." >&2
+    echo "  Database: $database_name" >&2
+    echo "  Schemas:  $schemas" >&2
+    echo "  URL prefix: $url_prefix" >&2
+
+    # ---- PHASE 1: pre-flight validation (R4) ----
+
+    # R4 string-level: normalize, regex, dedup, empty-check.
+    local normalized_schemas
+    normalized_schemas=$(_pgrst_normalize_schemas "$schemas") || {
+        # error already printed to stderr by the helper
+        if [[ "$json_output" == true ]]; then
+            _configure_error "usage" "$service_id" "Invalid --schemas value '$schemas' (see stderr for details)."
+        fi
+        return 1
+    }
+    schemas="$normalized_schemas"
+
+    # Database existence precheck (otherwise psql exits 2 with a confusing
+    # "could not connect" inside _pgrst_exec_db). Belt-and-suspenders before
+    # the per-schema existence check, which assumes the database exists.
+    local db_check_rc=0
+    local db_check
+    db_check=$(_pgrst_exec "SELECT 1 FROM pg_database WHERE datname='$database_name'" "$admin_pass") || db_check_rc=$?
+    if [[ $db_check_rc -ne 0 || "$db_check" != "1" ]]; then
+        local msg="Database '$database_name' does not exist in the cluster's PostgreSQL. Create it first (typically via the consuming app's migration / bootstrap script), then retry: ./uis configure postgrest --app $app_name --database $database_name --schemas $schemas"
+        if [[ "$json_output" == true ]]; then
+            _configure_error "create_resources" "$service_id" "$msg"
+        fi
+        log_error "$msg"
+        return 1
+    fi
+
+    # R4 step 4: per-schema existence check. Fail-loud naming the offender.
+    if ! _pgrst_check_schemas_exist "$schemas" "$admin_pass" "$database_name"; then
+        # error printed by helper
+        if [[ "$json_output" == true ]]; then
+            _configure_error "usage" "$service_id" "One or more schemas in '$schemas' do not exist in database '$database_name'."
+        fi
+        return 1
+    fi
+
+    # ---- PHASE 2: state inspection (place ourselves on the State Matrix) ----
+
+    local web_anon_exists=false
+    local auth_exists=false
+    local secret_exists=false
+    local existing_schemas=""
+    local existing_uri=""
+
+    _pgrst_role_exists "$web_anon_role" "$admin_pass" && web_anon_exists=true
+    _pgrst_role_exists "$authenticator_role" "$admin_pass" && auth_exists=true
+    _pgrst_secret_exists "$secret_name" && secret_exists=true
+
+    if [[ "$secret_exists" == true ]]; then
+        existing_schemas=$(_pgrst_get_secret_schemas "$secret_name")
+        existing_uri=$(_pgrst_get_secret_uri "$secret_name")
+    fi
+
+    # ---- PHASE 3: reject inconsistent states (Partial roles, Orphan secret) ----
+
+    if [[ "$web_anon_exists" != "$auth_exists" ]]; then
+        local existing_role missing_role
+        if [[ "$web_anon_exists" == true ]]; then
+            existing_role="$web_anon_role"; missing_role="$authenticator_role"
+        else
+            existing_role="$authenticator_role"; missing_role="$web_anon_role"
+        fi
+        local msg="Inconsistent role state for app '$app_name': role '$existing_role' exists but '$missing_role' does not. Run './uis configure postgrest --app $app_name --purge' to clear and retry."
+        if [[ "$json_output" == true ]]; then
+            _configure_error "inconsistent_state" "$service_id" "$msg"
+        fi
+        log_error "$msg"
+        return 1
+    fi
+
+    # At this point web_anon_exists == auth_exists. If neither exists but the
+    # secret does, we have an orphan secret (roles dropped externally).
+    if [[ "$secret_exists" == true && "$web_anon_exists" == false ]]; then
+        local msg="Orphan secret: '$secret_name' exists but neither role exists. Run './uis configure postgrest --app $app_name --purge' to clear and retry."
+        if [[ "$json_output" == true ]]; then
+            _configure_error "inconsistent_state" "$service_id" "$msg"
+        fi
+        log_error "$msg"
+        return 1
+    fi
+
+    # ---- PHASE 4: dispatch to a State Matrix path ----
+
+    local path
+    if [[ "$web_anon_exists" == true ]]; then
+        # Both roles exist.
+        if [[ "$secret_exists" == true ]]; then
+            if [[ -n "$existing_schemas" && "$existing_schemas" == "$schemas" ]]; then
+                path="no-op"
+            else
+                path="reconfigure-preserve-uri"
+            fi
+        else
+            path="reconfigure-fresh-password"
+        fi
+    else
+        # Neither role exists, no secret (orphan-secret case rejected above).
+        path="first-time"
+    fi
+
+    # ---- PHASE 5: no-op short-circuit ----
+    if [[ "$path" == "no-op" ]]; then
+        echo "PostgREST already configured for '$app_name' with schemas '$schemas' — nothing to do." >&2
         if [[ "$json_output" == true ]]; then
             cat <<EOF
-{"status":"already_configured","service":"postgrest","app":"$app_name","namespace":"$PGRST_NAMESPACE","secret":"$secret_name","public_url_prefix":"$url_prefix","next_step":"./uis deploy postgrest --app $app_name"}
+{"status":"already_configured","service":"postgrest","app":"$app_name","namespace":"$PGRST_NAMESPACE","secret":"$secret_name","schemas":"$schemas","public_url_prefix":"$url_prefix","next_step":"./uis deploy postgrest --app $app_name"}
 EOF
         else
             echo ""
-            echo "PostgREST already configured for '$app_name'. To proceed:"
+            echo "PostgREST already configured for '$app_name' (schemas: $schemas). To proceed:"
             echo "  ./uis deploy postgrest --app $app_name"
             echo ""
             echo "To rotate the password: ./uis configure postgrest --app $app_name --rotate"
@@ -356,34 +651,23 @@ EOF
         return 0
     fi
 
-    # ---- CREATE PATH ----
-    echo "Configuring PostgREST for app '$app_name'..." >&2
-    echo "  Database: $database_name" >&2
-    echo "  Schema:   $schema" >&2
-    echo "  URL prefix: $url_prefix" >&2
+    # ---- PHASE 6: build SQL for the chosen path ----
 
-    # Precheck: the per-app database must exist (otherwise psql exits 2 with
-    # "could not connect" inside _pgrst_exec_db, which is a confusing failure).
-    # `|| true` to keep the check itself errexit-safe.
-    local db_check_rc=0
-    local db_check
-    db_check=$(_pgrst_exec "SELECT 1 FROM pg_database WHERE datname='$database_name'" "$admin_pass") || db_check_rc=$?
-    if [[ $db_check_rc -ne 0 || "$db_check" != "1" ]]; then
-        local msg="Database '$database_name' does not exist in the cluster's PostgreSQL. Create it first (typically via the consuming app's migration / bootstrap script), then retry: ./uis configure postgrest --app $app_name --database $database_name"
-        if [[ "$json_output" == true ]]; then
-            _configure_error "create_resources" "$service_id" "$msg"
-        fi
-        log_error "$msg"
-        return 1
-    fi
+    # Per-schema GRANT block (USAGE + SELECT on existing tables + DEFAULT
+    # PRIVILEGES for future tables) — used by all three SQL paths.
+    local grant_sql
+    grant_sql=$(_pgrst_build_grant_sql "$schemas" "$web_anon_role")
 
-    # Generate password (UIS does not store this; only the secret holds it)
-    local app_password
-    app_password=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
-
-    # Build the role-creation SQL block (Atlas addendum's ALTER DEFAULT PRIVILEGES included)
-    local sql_block
-    sql_block=$(cat <<EOF
+    # Decide password handling per path. For Reconfigure-preserve-URI the
+    # password is unchanged; we don't touch the role's stored password and we
+    # round-trip the existing PGRST_DB_URI verbatim into the secret.
+    local app_password=""
+    local sql_block=""
+    case "$path" in
+        first-time)
+            app_password=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+            sql_block=$(cat <<EOF
+BEGIN;
 DO \$\$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='$web_anon_role') THEN
@@ -391,66 +675,109 @@ BEGIN
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='$authenticator_role') THEN
         CREATE ROLE $authenticator_role LOGIN PASSWORD '$app_password' NOINHERIT;
-    ELSE
-        ALTER USER $authenticator_role WITH PASSWORD '$app_password';
     END IF;
 END
 \$\$;
 GRANT $web_anon_role TO $authenticator_role;
-GRANT USAGE ON SCHEMA $schema TO $web_anon_role;
-GRANT SELECT ON ALL TABLES IN SCHEMA $schema TO $web_anon_role;
-ALTER DEFAULT PRIVILEGES IN SCHEMA $schema GRANT SELECT ON TABLES TO $web_anon_role;
+$grant_sql
+COMMIT;
 EOF
 )
+            ;;
+        reconfigure-preserve-uri)
+            sql_block=$(cat <<EOF
+BEGIN;
+DROP OWNED BY $web_anon_role;
+$grant_sql
+COMMIT;
+EOF
+)
+            ;;
+        reconfigure-fresh-password)
+            app_password=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+            sql_block=$(cat <<EOF
+BEGIN;
+ALTER USER $authenticator_role WITH PASSWORD '$app_password';
+DROP OWNED BY $web_anon_role;
+$grant_sql
+COMMIT;
+EOF
+)
+            ;;
+    esac
 
-    echo "Creating Postgres roles and grants for app '$app_name' in database '$database_name'..." >&2
-    # Capture exit code WITHOUT tripping the calling script's `set -e`. A bare
-    # `var=$(failing_cmd); rc=$?` would terminate uis-cli.sh before we reach
-    # the if-check. The `|| rc=$?` form makes the assignment a compound
-    # command that errexit treats as handled. Same fix in rotate + purge below.
+    echo "Applying SQL for path '$path' (database: $database_name)..." >&2
     local sql_result rc=0
     sql_result=$(_pgrst_exec_db "$sql_block" "$admin_pass" "$database_name") || rc=$?
     if [[ $rc -ne 0 ]]; then
         local hint="psql exit $rc: $sql_result"
         if [[ $rc -eq 2 ]]; then
-            hint+=$'\n'"Hint: psql exit 2 means it could not connect to database '$database_name'. Verify the database exists: kubectl exec -n default postgresql-0 -- psql -U postgres -lqt | grep '$database_name'"
-        else
-            hint+=$'\n'"Hint: schema '$schema' must exist in database '$database_name' before configure runs (the application's migration creates it)."
+            hint+=$'\n'"Hint: psql exit 2 means it could not connect to database '$database_name'."
         fi
         if [[ "$json_output" == true ]]; then
-            _configure_error "create_resources" "$service_id" "Role creation failed for '$app_name' in '$database_name'. $hint"
+            _configure_error "create_resources" "$service_id" "SQL transaction failed for path '$path' in '$database_name'. $hint"
         fi
-        log_error "Role creation failed for '$app_name' in '$database_name' (psql exit $rc):"
+        log_error "SQL transaction failed for path '$path' in '$database_name' (psql exit $rc):"
         log_error "$sql_result"
-        if [[ $rc -eq 2 ]]; then
-            log_error "Hint: psql exit 2 = connection error. Verify '$database_name' exists in the cluster's postgresql instance."
-        else
-            log_error "Hint: schema '$schema' must exist in database '$database_name' before configure runs (the application's migration creates it)."
-        fi
         return 1
     fi
 
-    # Ensure the postgrest namespace exists, then write the secret
-    echo "Ensuring namespace '$PGRST_NAMESPACE' exists..." >&2
+    # ---- PHASE 7: write the secret ----
+
     _pgrst_ensure_namespace "$PGRST_NAMESPACE"
 
-    local db_uri="postgresql://${authenticator_role}:${app_password}@${PG_CLUSTER_HOST}:${PG_INTERNAL_PORT}/${database_name}"
-    echo "Writing secret '$secret_name' in namespace $PGRST_NAMESPACE..." >&2
-    _pgrst_create_secret "$secret_name" "$db_uri"
+    local db_uri
+    if [[ "$path" == "reconfigure-preserve-uri" ]]; then
+        # Preserve the existing PGRST_DB_URI verbatim (password unchanged).
+        # If the secret has no PGRST_DB_URI key (shouldn't happen — secret
+        # exists per state inspection — but defensive): rebuild from a fresh
+        # password as a last resort.
+        if [[ -n "$existing_uri" ]]; then
+            db_uri="$existing_uri"
+        else
+            log_warn "Existing secret '$secret_name' has no PGRST_DB_URI key; generating a fresh password (recovery path)."
+            app_password=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+            db_uri="postgresql://${authenticator_role}:${app_password}@${PG_CLUSTER_HOST}:${PG_INTERNAL_PORT}/${database_name}"
+            # Apply the new password to the role since we're now diverging
+            # from the on-disk URI.
+            _pgrst_exec "ALTER USER $authenticator_role WITH PASSWORD '$app_password'" "$admin_pass" >/dev/null 2>&1 || true
+        fi
+    else
+        # First-time and Reconfigure-fresh-password both have a fresh password.
+        db_uri="postgresql://${authenticator_role}:${app_password}@${PG_CLUSTER_HOST}:${PG_INTERNAL_PORT}/${database_name}"
+    fi
 
-    # Output (Decision #20: JSON without credentials; plain output with next-step hint)
+    echo "Writing secret '$secret_name' in namespace $PGRST_NAMESPACE..." >&2
+    _pgrst_create_secret "$secret_name" "$db_uri" "$schemas"
+
+    # ---- PHASE 8: NOTIFY pgrst, 'reload schema' ----
+
+    _pgrst_notify_reload "$admin_pass" "$database_name"
+
+    # ---- PHASE 9: output ----
+
     if [[ "$json_output" == true ]]; then
         cat <<EOF
-{"status":"ok","service":"postgrest","app":"$app_name","namespace":"$PGRST_NAMESPACE","secret":"$secret_name","in_cluster_url":"http://$deployment_name.$PGRST_NAMESPACE.svc.cluster.local:3000","public_url_prefix":"$url_prefix","next_step":"./uis deploy postgrest --app $app_name"}
+{"status":"ok","service":"postgrest","app":"$app_name","namespace":"$PGRST_NAMESPACE","secret":"$secret_name","schemas":"$schemas","path":"$path","in_cluster_url":"http://$deployment_name.$PGRST_NAMESPACE.svc.cluster.local:3000","public_url_prefix":"$url_prefix","next_step":"./uis deploy postgrest --app $app_name"}
 EOF
     else
         echo ""
-        echo "PostgREST configured for '$app_name':"
+        echo "PostgREST configured for '$app_name' (path: $path):"
         echo "  Database:        $database_name"
-        echo "  Schema:          $schema"
+        echo "  Schemas:         $schemas"
         echo "  URL prefix:      $url_prefix"
-        echo "  Roles created:   $web_anon_role (NOLOGIN), $authenticator_role (LOGIN NOINHERIT)"
-        echo "  Secret:          $PGRST_NAMESPACE/$secret_name (key PGRST_DB_URI)"
+        case "$path" in
+            first-time)
+                echo "  Roles created:   $web_anon_role (NOLOGIN), $authenticator_role (LOGIN NOINHERIT)"
+                ;;
+            reconfigure-preserve-uri)
+                echo "  Roles:           kept (password preserved)"
+                ;;
+            reconfigure-fresh-password)
+                echo "  Roles:           kept; password rotated (secret was missing)"
+                ;;
+        esac
+        echo "  Secret:          $PGRST_NAMESPACE/$secret_name (keys PGRST_DB_URI + PGRST_DB_SCHEMAS)"
         echo ""
         echo "Next step:"
         echo "  ./uis deploy postgrest --app $app_name"

--- a/provision-host/uis/lib/configure.sh
+++ b/provision-host/uis/lib/configure.sh
@@ -95,7 +95,7 @@ run_configure() {
     local json_output=false
     local namespace=""
     local secret_name_prefix=""
-    local schema=""
+    local schemas=""
     local url_prefix=""
     local rotate=false
     local purge=false
@@ -123,8 +123,8 @@ run_configure() {
                 secret_name_prefix="$2"
                 shift 2
                 ;;
-            --schema)
-                schema="$2"
+            --schemas)
+                schemas="$2"
                 shift 2
                 ;;
             --url-prefix)
@@ -253,8 +253,8 @@ run_configure() {
     fi
 
     # Source and run handler. Multi-instance handlers receive the extended argument set
-    # (schema, url_prefix, rotate, purge); single-instance handlers ignore the trailing args
+    # (schemas, url_prefix, rotate, purge); single-instance handlers ignore the trailing args
     # via positional parameter rules.
     source "$handler"
-    configure_service "$service_id" "$app_name" "$database_name" "$init_file" "$json_output" "$namespace" "$secret_name_prefix" "$schema" "$url_prefix" "$rotate" "$purge"
+    configure_service "$service_id" "$app_name" "$database_name" "$init_file" "$json_output" "$namespace" "$secret_name_prefix" "$schemas" "$url_prefix" "$rotate" "$purge"
 }

--- a/provision-host/uis/lib/service-deployment.sh
+++ b/provision-host/uis/lib/service-deployment.sh
@@ -83,15 +83,15 @@ _is_service_multi_instance() {
     [[ "$val" == "true" ]]
 }
 
-# Usage: deploy_single_service <service_id> [<app_name> [<url_prefix> [<schema>]]]
+# Usage: deploy_single_service <service_id> [<app_name> [<url_prefix>]]
 # For multi-instance services (multiInstance: true in services.json), app_name is
-# required and gets translated into Ansible extra-vars (_app_name, _url_prefix,
-# _schema) per the convention in ansible/playbooks/templates/README.md.
+# required and gets translated into Ansible extra-vars (_app_name, _url_prefix)
+# per the convention in ansible/playbooks/templates/README.md. Schema lists for
+# postgrest are read from the per-app secret, not from CLI flags.
 deploy_single_service() {
     local service_id="$1"
     local app_name="${2:-}"
     local url_prefix="${3:-}"
-    local schema="${4:-}"
     local script
 
     script=$(find_service_script "$service_id")
@@ -144,7 +144,6 @@ deploy_single_service() {
         if [[ -n "$app_name" ]]; then
             ansible_args+=("-e" "_app_name=$app_name")
             [[ -n "$url_prefix" ]] && ansible_args+=("-e" "_url_prefix=$url_prefix")
-            [[ -n "$schema" ]] && ansible_args+=("-e" "_schema=$schema")
             log_info "Running Ansible playbook: $SCRIPT_PLAYBOOK (target: $target_host, app: $app_name)"
         else
             log_info "Running Ansible playbook: $SCRIPT_PLAYBOOK (target: $target_host)"

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -298,14 +298,15 @@ cmd_deploy() {
     local service_id=""
     local app_name=""
     local url_prefix=""
-    local schema=""
 
     # Parse positional + flag args. First positional is service_id.
+    # Note: deploy does not accept --schema/--schemas. The schema list lives
+    # on the per-app secret (written by configure) and is read by the
+    # Deployment template via valueFrom.secretKeyRef.
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --app)         app_name="$2"; shift 2 ;;
             --url-prefix)  url_prefix="$2"; shift 2 ;;
-            --schema)      schema="$2"; shift 2 ;;
             -*)            log_error "Unknown option: $1"; exit "$EXIT_GENERAL_ERROR" ;;
             *)             [[ -z "$service_id" ]] && service_id="$1"; shift ;;
         esac
@@ -339,18 +340,17 @@ cmd_deploy() {
             fi
             # Apply per-app defaults (Decision #16/#19 in INVESTIGATE-postgrest.md)
             url_prefix="${url_prefix:-api-$app_name}"
-            schema="${schema:-api_v1}"
             log_info "Deploying service: $service_id (app: $app_name)"
         else
-            if [[ -n "$app_name" || -n "$url_prefix" || -n "$schema" ]]; then
-                log_error "Service '$service_id' is single-instance — --app/--url-prefix/--schema not allowed"
+            if [[ -n "$app_name" || -n "$url_prefix" ]]; then
+                log_error "Service '$service_id' is single-instance — --app/--url-prefix not allowed"
                 exit "$EXIT_GENERAL_ERROR"
             fi
             log_info "Deploying service: $service_id"
         fi
 
         # Deploy
-        deploy_single_service "$service_id" "$app_name" "$url_prefix" "$schema"
+        deploy_single_service "$service_id" "$app_name" "$url_prefix"
 
         # Auto-enable if successful and service-auto-enable is available
         # (Skip for multi-instance: enabled-services.conf is for single-instance autostart only)

--- a/provision-host/uis/services/integration/service-postgrest.sh
+++ b/provision-host/uis/services/integration/service-postgrest.sh
@@ -5,10 +5,15 @@
 # deploys one PostgREST instance per consuming application; all
 # instances share a namespace and the platform's PostgreSQL service.
 #
-# Multi-instance lifecycle (PLAN-002):
+# Multi-instance lifecycle:
 #   ./uis configure postgrest --app <name> [--database <db>] \
-#       [--schema api_v1] [--url-prefix api-<name>]
+#       [--schemas api_v1,marts,raw] [--url-prefix api-<name>]
 #   ./uis deploy postgrest --app <name>
+#
+# The schema list lives on the per-app secret (key PGRST_DB_SCHEMAS),
+# written by configure and read by the Deployment template via
+# valueFrom.secretKeyRef. Deploy does not accept --schemas — there's only
+# one source of truth.
 #
 # See INVESTIGATE-postgrest.md and PLAN-002-postgrest-deployment.md.
 

--- a/provision-host/uis/tests/deploy/test-configure-postgrest-schemas-integration.sh
+++ b/provision-host/uis/tests/deploy/test-configure-postgrest-schemas-integration.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# test-configure-postgrest-schemas-integration.sh — Integration tests for the
+# --schemas flag and State Matrix dispatch in configure-postgrest.sh.
+#
+# REQUIRES: Running K8s cluster with PostgreSQL deployed.
+# Run: uis deploy postgresql (before running these tests).
+#
+# These tests create and remove resources in the cluster:
+# - A test database (created via psql; not via uis configure postgresql,
+#   to keep this file self-contained and avoid coupling to that handler).
+# - A pair of per-app roles (<app>_web_anon, <app>_authenticator).
+# - Test schemas (api_v1, marts, raw) populated in the test database.
+# - A per-app secret in the postgrest namespace.
+#
+# All resources use a TEST_TIMESTAMP-suffixed name to avoid collision with
+# real deployments. Teardown runs at end via trap.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/test-framework.sh"
+
+if [[ -d "/mnt/urbalurbadisk/provision-host/uis" ]]; then
+    UIS_CLI="/mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh"
+else
+    UIS_CLI="$(cd "$SCRIPT_DIR/../../manage" && pwd)/uis-cli.sh"
+fi
+
+TEST_TIMESTAMP=$(date +%s)
+TEST_APP="pgrst-test-${TEST_TIMESTAMP}"
+TEST_DB="pgrst_test_${TEST_TIMESTAMP}"
+TEST_WEB_ANON="${TEST_APP//-/_}_web_anon"
+TEST_AUTH="${TEST_APP//-/_}_authenticator"
+TEST_SECRET="${TEST_APP}-postgrest"
+TEST_NS="postgrest"
+
+# --- helpers ---------------------------------------------------------------
+
+_psql_admin() {
+    # Run psql as the admin against the cluster's postgres pod. Returns stdout
+    # of the query; merges stderr so failures are visible in test output.
+    local sql="$1"
+    local db="${2:-postgres}"
+    local pod
+    pod=$(kubectl get pods -n default -l app.kubernetes.io/name=postgresql -o jsonpath='{.items[0].metadata.name}')
+    local pw
+    pw=$(kubectl get secret urbalurba-secrets -n default -o jsonpath='{.data.PGPASSWORD}' | base64 -d)
+    kubectl exec -n default "$pod" -- env PGPASSWORD="$pw" psql -U postgres -d "$db" -tAc "$sql" 2>&1
+}
+
+_assert_has_usage() {
+    local schema="$1"
+    local result
+    result=$(_psql_admin "SELECT has_schema_privilege('$TEST_WEB_ANON', '$schema', 'USAGE')" "$TEST_DB")
+    [[ "$result" == "t" ]]
+}
+
+_count_default_acl_for_role() {
+    # Count pg_default_acl rows in $TEST_DB whose acl mentions the test
+    # web_anon role and target the named schema.
+    local schema="$1"
+    _psql_admin "SELECT count(*) FROM pg_default_acl WHERE defaclnamespace=(SELECT oid FROM pg_namespace WHERE nspname='$schema') AND defaclacl::text LIKE '%${TEST_WEB_ANON}%'" "$TEST_DB"
+}
+
+_secret_key() {
+    local key="$1"
+    kubectl get secret "$TEST_SECRET" -n "$TEST_NS" -o jsonpath="{.data.${key}}" 2>/dev/null | base64 -d 2>/dev/null
+}
+
+_teardown() {
+    echo "" >&2
+    echo "─── teardown ───" >&2
+    "$UIS_CLI" configure postgrest --app "$TEST_APP" --purge --json >/dev/null 2>&1 || true
+    _psql_admin "DROP DATABASE IF EXISTS $TEST_DB" >/dev/null 2>&1 || true
+    _psql_admin "DROP ROLE IF EXISTS $TEST_AUTH" >/dev/null 2>&1 || true
+    _psql_admin "DROP ROLE IF EXISTS $TEST_WEB_ANON" >/dev/null 2>&1 || true
+    kubectl delete secret "$TEST_SECRET" -n "$TEST_NS" >/dev/null 2>&1 || true
+}
+trap _teardown EXIT
+
+# --- pre-flight -----------------------------------------------------------
+
+print_test_section "Integration: pre-flight"
+
+start_test "kubectl is available"
+if command -v kubectl &>/dev/null; then pass_test; else fail_test "kubectl not found"; print_summary; exit 1; fi
+
+start_test "PostgreSQL is deployed"
+if kubectl get pods -n default -l app.kubernetes.io/name=postgresql --no-headers 2>/dev/null | grep -q Running; then
+    pass_test
+else
+    fail_test "PostgreSQL is not running. Run: uis deploy postgresql"
+    print_summary
+    exit 1
+fi
+
+start_test "create test database + schemas"
+_psql_admin "CREATE DATABASE $TEST_DB" >/dev/null
+_psql_admin "CREATE SCHEMA api_v1; CREATE SCHEMA marts; CREATE SCHEMA raw; CREATE TABLE api_v1.t1 (id int); CREATE TABLE marts.t2 (id int); CREATE TABLE raw.t3 (id int);" "$TEST_DB" >/dev/null
+pass_test
+
+# --- 6.3 first-time configure --------------------------------------------
+
+print_test_section "6.3: first-time configure with --schemas api_v1,marts,raw"
+
+start_test "configure exits ok"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,marts,raw --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "ok" ]] && pass_test || fail_test "got: $output"
+
+start_test "JSON includes path=first-time"
+path=$(echo "$output" | jq -r '.path' 2>/dev/null)
+[[ "$path" == "first-time" ]] && pass_test || fail_test "got path=$path"
+
+start_test "JSON includes schemas=api_v1,marts,raw"
+schemas_out=$(echo "$output" | jq -r '.schemas' 2>/dev/null)
+[[ "$schemas_out" == "api_v1,marts,raw" ]] && pass_test || fail_test "got: $schemas_out"
+
+start_test "USAGE granted on api_v1"
+_assert_has_usage api_v1 && pass_test || fail_test "no USAGE"
+
+start_test "USAGE granted on marts"
+_assert_has_usage marts && pass_test || fail_test "no USAGE"
+
+start_test "USAGE granted on raw"
+_assert_has_usage raw && pass_test || fail_test "no USAGE"
+
+start_test "secret has PGRST_DB_URI key"
+[[ -n "$(_secret_key PGRST_DB_URI)" ]] && pass_test || fail_test "URI missing"
+
+start_test "secret PGRST_DB_SCHEMAS == api_v1,marts,raw"
+[[ "$(_secret_key PGRST_DB_SCHEMAS)" == "api_v1,marts,raw" ]] && pass_test || fail_test "got: $(_secret_key PGRST_DB_SCHEMAS)"
+
+# --- 6.4 idempotent re-run ------------------------------------------------
+
+print_test_section "6.4: re-run with same list — no-op"
+
+start_test "re-run returns already_configured"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,marts,raw --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "already_configured" ]] && pass_test || fail_test "got: $output"
+
+# --- 6.5 reconfigure: drop a schema --------------------------------------
+
+print_test_section "6.5: reconfigure --schemas api_v1,marts (drop raw)"
+
+start_test "configure exits ok"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,marts --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "ok" ]] && pass_test || fail_test "got: $output"
+
+start_test "path=reconfigure-preserve-uri"
+path=$(echo "$output" | jq -r '.path' 2>/dev/null)
+[[ "$path" == "reconfigure-preserve-uri" ]] && pass_test || fail_test "got path=$path"
+
+start_test "USAGE on raw revoked"
+result=$(_psql_admin "SELECT has_schema_privilege('$TEST_WEB_ANON', 'raw', 'USAGE')" "$TEST_DB")
+[[ "$result" == "f" ]] && pass_test || fail_test "USAGE still granted (got: $result)"
+
+start_test "pg_default_acl cleared for raw"
+count=$(_count_default_acl_for_role raw)
+[[ "$count" == "0" ]] && pass_test || fail_test "expected 0, got: $count"
+
+start_test "USAGE on api_v1 + marts still granted"
+_assert_has_usage api_v1 && _assert_has_usage marts && pass_test || fail_test "missing grants"
+
+start_test "secret PGRST_DB_SCHEMAS updated to api_v1,marts"
+[[ "$(_secret_key PGRST_DB_SCHEMAS)" == "api_v1,marts" ]] && pass_test || fail_test "got: $(_secret_key PGRST_DB_SCHEMAS)"
+
+# --- 6.6 order-only change -----------------------------------------------
+
+print_test_section "6.6: order-only change marts,api_v1"
+
+start_test "configure exits ok"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas marts,api_v1 --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "ok" ]] && pass_test || fail_test "got: $output"
+
+start_test "secret value reflects new order"
+[[ "$(_secret_key PGRST_DB_SCHEMAS)" == "marts,api_v1" ]] && pass_test || fail_test "got: $(_secret_key PGRST_DB_SCHEMAS)"
+
+start_test "grants unchanged (set-equal end state)"
+_assert_has_usage api_v1 && _assert_has_usage marts && pass_test || fail_test "missing grants"
+
+# --- 6.7 missing schema rejected by pre-validation ------------------------
+
+print_test_section "6.7: missing schema rejected before any state change"
+
+start_test "configure with bogus schema returns error"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,bogus_xyz --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "error" ]] && pass_test || fail_test "got: $output"
+
+start_test "existing grants unchanged after rejection"
+_assert_has_usage marts && _assert_has_usage api_v1 && pass_test || fail_test "grants disturbed"
+
+start_test "secret PGRST_DB_SCHEMAS unchanged after rejection"
+[[ "$(_secret_key PGRST_DB_SCHEMAS)" == "marts,api_v1" ]] && pass_test || fail_test "secret modified"
+
+# --- 6.8 authenticator membership survives DROP OWNED BY ------------------
+
+print_test_section "6.8: <app>_authenticator → <app>_web_anon membership"
+
+start_test "membership exists after the previous reconfigure"
+result=$(_psql_admin "SELECT EXISTS (SELECT 1 FROM pg_auth_members WHERE roleid=(SELECT oid FROM pg_authid WHERE rolname='$TEST_WEB_ANON') AND member=(SELECT oid FROM pg_authid WHERE rolname='$TEST_AUTH'))")
+[[ "$result" == "t" ]] && pass_test || fail_test "membership lost (got: $result)"
+
+# --- 6.9 rotate fails when PGRST_DB_SCHEMAS missing -----------------------
+
+print_test_section "6.9: rotate fails loudly on PLAN-002-era secret"
+
+start_test "remove PGRST_DB_SCHEMAS key from secret"
+kubectl patch secret "$TEST_SECRET" -n "$TEST_NS" --type=json -p='[{"op":"remove","path":"/data/PGRST_DB_SCHEMAS"}]' >/dev/null
+[[ -z "$(_secret_key PGRST_DB_SCHEMAS)" ]] && pass_test || fail_test "key still present"
+
+start_test "rotate fails with the prescribed error"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --rotate --json 2>&1)
+echo "$output" | grep -q "PGRST_DB_SCHEMAS not present" && pass_test || fail_test "got: $output"
+
+# --- 6.11 PLAN-002 upgrade path -------------------------------------------
+
+print_test_section "6.11: PLAN-002 upgrade — secret has only PGRST_DB_URI"
+
+# (Continuing from 6.9: the secret now has only PGRST_DB_URI. Capture it
+# so we can verify the URI is preserved.)
+start_test "capture pre-upgrade PGRST_DB_URI"
+PRE_UPGRADE_URI=$(_secret_key PGRST_DB_URI)
+[[ -n "$PRE_UPGRADE_URI" ]] && pass_test || fail_test "URI missing pre-upgrade"
+
+start_test "configure with --schemas adds the missing key"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,marts --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "ok" ]] && pass_test || fail_test "got: $output"
+
+start_test "path=reconfigure-preserve-uri"
+path=$(echo "$output" | jq -r '.path' 2>/dev/null)
+[[ "$path" == "reconfigure-preserve-uri" ]] && pass_test || fail_test "got path=$path"
+
+start_test "PGRST_DB_URI preserved verbatim"
+[[ "$(_secret_key PGRST_DB_URI)" == "$PRE_UPGRADE_URI" ]] && pass_test || fail_test "URI changed"
+
+start_test "PGRST_DB_SCHEMAS now populated"
+[[ "$(_secret_key PGRST_DB_SCHEMAS)" == "api_v1,marts" ]] && pass_test || fail_test "got: $(_secret_key PGRST_DB_SCHEMAS)"
+
+# --- 6.10 recovery: secret deleted manually -------------------------------
+
+print_test_section "6.10: recovery — delete secret, reconfigure"
+
+start_test "capture pre-deletion URI for comparison"
+PRE_DELETE_URI=$(_secret_key PGRST_DB_URI)
+[[ -n "$PRE_DELETE_URI" ]] && pass_test || fail_test "URI missing"
+
+start_test "delete secret"
+kubectl delete secret "$TEST_SECRET" -n "$TEST_NS" >/dev/null
+[[ -z "$(_secret_key PGRST_DB_URI)" ]] && pass_test || fail_test "secret still exists"
+
+start_test "configure rebuilds secret"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,marts --json 2>&1)
+status=$(echo "$output" | jq -r '.status' 2>/dev/null)
+[[ "$status" == "ok" ]] && pass_test || fail_test "got: $output"
+
+start_test "path=reconfigure-fresh-password"
+path=$(echo "$output" | jq -r '.path' 2>/dev/null)
+[[ "$path" == "reconfigure-fresh-password" ]] && pass_test || fail_test "got path=$path"
+
+start_test "new URI differs from pre-deletion (password rotated)"
+[[ "$(_secret_key PGRST_DB_URI)" != "$PRE_DELETE_URI" ]] && pass_test || fail_test "URI unchanged"
+
+start_test "secret has both keys"
+[[ -n "$(_secret_key PGRST_DB_URI)" && -n "$(_secret_key PGRST_DB_SCHEMAS)" ]] && pass_test || fail_test "key missing"
+
+# --- 6.12 partial role state ----------------------------------------------
+
+print_test_section "6.12: partial role state — error and refuse to act"
+
+start_test "drop authenticator role"
+kubectl delete secret "$TEST_SECRET" -n "$TEST_NS" >/dev/null 2>&1 || true
+_psql_admin "DROP ROLE IF EXISTS $TEST_AUTH" >/dev/null
+result=$(_psql_admin "SELECT count(*) FROM pg_roles WHERE rolname='$TEST_AUTH'")
+[[ "$result" == "0" ]] && pass_test || fail_test "role still exists"
+
+start_test "configure errors with 'Inconsistent role state'"
+output=$("$UIS_CLI" configure postgrest --app "$TEST_APP" --database "$TEST_DB" --schemas api_v1,marts --json 2>&1)
+echo "$output" | grep -q "Inconsistent role state" && pass_test || fail_test "got: $output"
+
+# --- summary --------------------------------------------------------------
+
+print_summary

--- a/provision-host/uis/tests/static/test-postgrest-template-structure.sh
+++ b/provision-host/uis/tests/static/test-postgrest-template-structure.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# test-postgrest-template-structure.sh — Static checks on the postgrest
+# Ansible Jinja2 templates.
+#
+# These guard against regressions where someone reverts the deploy template
+# from `valueFrom.secretKeyRef` back to an inline `value: "{{ _schema }}"`
+# (the PLAN-002 shape). That regression would silently break multi-schema
+# setups: the playbook would still render, but the running pod would only
+# expose whatever the operator passed via --schema/--schemas on deploy
+# (now: nothing, since deploy doesn't take that flag).
+#
+# Cheap, deterministic, no cluster needed. Runs as part of static tests in
+# CI's "Test UIS Scripts" workflow.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/test-framework.sh"
+
+# Locate the Ansible playbook templates dir (works in container + on host).
+if [[ -d "/mnt/urbalurbadisk/ansible/playbooks/templates" ]]; then
+    TEMPLATES_DIR="/mnt/urbalurbadisk/ansible/playbooks/templates"
+else
+    TEMPLATES_DIR="$(cd "$SCRIPT_DIR/../../../../ansible/playbooks/templates" && pwd)"
+fi
+
+CONFIG_TEMPLATE="$TEMPLATES_DIR/088-postgrest-config.yml.j2"
+SETUP_PLAYBOOK="$(dirname "$TEMPLATES_DIR")/088-setup-postgrest.yml"
+
+print_test_section "PostgREST deploy-template structure (static)"
+
+# ============================================================================
+# Template file existence
+# ============================================================================
+
+start_test "088-postgrest-config.yml.j2 exists"
+[[ -f "$CONFIG_TEMPLATE" ]] && pass_test || fail_test "$CONFIG_TEMPLATE missing"
+
+start_test "088-setup-postgrest.yml exists"
+[[ -f "$SETUP_PLAYBOOK" ]] && pass_test || fail_test "$SETUP_PLAYBOOK missing"
+
+# ============================================================================
+# PGRST_DB_URI must use valueFrom.secretKeyRef (existing PLAN-002 shape)
+# ============================================================================
+
+start_test "PGRST_DB_URI uses valueFrom.secretKeyRef"
+# Look for the env entry's secretKeyRef block immediately after PGRST_DB_URI.
+# `awk` extracts the next 4 lines after the `name: PGRST_DB_URI` marker so
+# we can grep that window for `secretKeyRef`.
+window=$(awk '/name: PGRST_DB_URI/{flag=1; c=0} flag{print; c++; if (c==5) exit}' "$CONFIG_TEMPLATE")
+echo "$window" | grep -q 'secretKeyRef' && pass_test || fail_test "got: $window"
+
+start_test "PGRST_DB_URI references key 'PGRST_DB_URI'"
+echo "$window" | grep -q 'key: PGRST_DB_URI' && pass_test || fail_test "got: $window"
+
+# ============================================================================
+# PGRST_DB_SCHEMAS must use valueFrom.secretKeyRef — this is the new shape.
+# Regression guard: if someone reverts to `value: "{{ _schema }}"`, this
+# fails fast before the change reaches the cluster.
+# ============================================================================
+
+start_test "PGRST_DB_SCHEMAS uses valueFrom.secretKeyRef (not inline value)"
+window=$(awk '/name: PGRST_DB_SCHEMAS/{flag=1; c=0} flag{print; c++; if (c==5) exit}' "$CONFIG_TEMPLATE")
+echo "$window" | grep -q 'secretKeyRef' && pass_test || fail_test "got: $window"
+
+start_test "PGRST_DB_SCHEMAS does NOT have an inline 'value:' field"
+echo "$window" | grep -qE '^[[:space:]]+value:' && \
+    fail_test "found inline 'value:' field — should be valueFrom.secretKeyRef. Window: $window" || \
+    pass_test
+
+start_test "PGRST_DB_SCHEMAS references key 'PGRST_DB_SCHEMAS'"
+echo "$window" | grep -q 'key: PGRST_DB_SCHEMAS' && pass_test || fail_test "got: $window"
+
+start_test "PGRST_DB_SCHEMAS references the per-app secret"
+echo "$window" | grep -q 'name: "{{ _app_name }}-postgrest"' && pass_test || fail_test "got: $window"
+
+# ============================================================================
+# The template must NOT reference {{ _schema }} (PLAN-002-era extra-var).
+# ============================================================================
+
+start_test "Template does not reference {{ _schema }} extra-var anywhere"
+if grep -q '{{ _schema }}' "$CONFIG_TEMPLATE"; then
+    fail_test "Found {{ _schema }} in $CONFIG_TEMPLATE — should be sourced from secret"
+else
+    pass_test
+fi
+
+# ============================================================================
+# The setup playbook must NOT require _schema as an extra-var.
+# ============================================================================
+
+start_test "088-setup-postgrest.yml does not require _schema in its assertion"
+# The assertion lists required extra-vars; _schema must not be in that list.
+# Tolerate _schema appearing in a comment (e.g. historical context).
+assert_block=$(awk '/Validate required extra-vars/,/fail_msg:/' "$SETUP_PLAYBOOK")
+if echo "$assert_block" | grep -E '^[[:space:]]+- _schema' >/dev/null; then
+    fail_test "Found _schema in extra-vars assertion. Block: $assert_block"
+else
+    pass_test
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+print_summary

--- a/provision-host/uis/tests/unit/test-configure-postgrest-schemas.sh
+++ b/provision-host/uis/tests/unit/test-configure-postgrest-schemas.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# test-configure-postgrest-schemas.sh — Unit tests for the --schemas flag
+#
+# Covers:
+#   - _pgrst_normalize_schemas() — R4 string-level checks (R4 steps 1–3:
+#     trim/empty/regex/dedup). The DB existence check (R4 step 4) is
+#     integration-level and lives in deploy/test-configure-postgrest-schemas-integration.sh.
+#   - CLI parsing: --schemas accepted on configure path; --schema rejected
+#     as an unknown option (no aliasing — R5 in the investigation).
+#
+# No cluster needed. Sources the helper directly and shells out to uis-cli.sh
+# for the CLI-parsing assertions.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/test-framework.sh"
+
+if [[ -d "/mnt/urbalurbadisk/provision-host/uis" ]]; then
+    UIS_LIB="/mnt/urbalurbadisk/provision-host/uis/lib"
+    UIS_CLI="/mnt/urbalurbadisk/provision-host/uis/manage/uis-cli.sh"
+else
+    UIS_LIB="$(cd "$SCRIPT_DIR/../../lib" && pwd)"
+    UIS_CLI="$(cd "$SCRIPT_DIR/../../manage" && pwd)/uis-cli.sh"
+fi
+
+# Source the handler to get _pgrst_normalize_schemas. logging.sh is needed
+# for log_warn (used on duplicate detection).
+source "$UIS_LIB/logging.sh"
+source "$UIS_LIB/configure-postgrest.sh"
+
+# ============================================================================
+# _pgrst_normalize_schemas — happy paths
+# ============================================================================
+
+print_test_section "Normalizer: happy paths"
+
+start_test "single schema returns unchanged"
+out=$(_pgrst_normalize_schemas "api_v1" 2>/dev/null)
+[[ "$out" == "api_v1" ]] && pass_test || fail_test "got: $out"
+
+start_test "three schemas returns comma-separated"
+out=$(_pgrst_normalize_schemas "api_v1,marts,raw" 2>/dev/null)
+[[ "$out" == "api_v1,marts,raw" ]] && pass_test || fail_test "got: $out"
+
+start_test "leading/trailing whitespace per component is trimmed"
+out=$(_pgrst_normalize_schemas " api_v1 , marts , raw " 2>/dev/null)
+[[ "$out" == "api_v1,marts,raw" ]] && pass_test || fail_test "got: $out"
+
+start_test "underscore + digit identifiers accepted"
+out=$(_pgrst_normalize_schemas "api_v1,_internal,table_2" 2>/dev/null)
+[[ "$out" == "api_v1,_internal,table_2" ]] && pass_test || fail_test "got: $out"
+
+# ============================================================================
+# _pgrst_normalize_schemas — rejection paths (R4 string-level)
+# ============================================================================
+
+print_test_section "Normalizer: rejection paths"
+
+start_test "empty string rejected"
+_pgrst_normalize_schemas "" 2>/dev/null && fail_test "should have rejected empty input" || pass_test
+
+start_test "consecutive commas (empty component) rejected"
+_pgrst_normalize_schemas "api_v1,,marts" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "trailing comma rejected"
+_pgrst_normalize_schemas "api_v1,marts," 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "leading comma rejected"
+_pgrst_normalize_schemas ",api_v1,marts" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "whitespace-only component rejected"
+_pgrst_normalize_schemas "api_v1, ,marts" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "hyphen in identifier rejected (not a valid Postgres unquoted identifier)"
+_pgrst_normalize_schemas "api_v1,bad-name" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "leading digit rejected"
+_pgrst_normalize_schemas "1bad" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "SQL-injection attempt rejected (semicolon + statement)"
+_pgrst_normalize_schemas "api_v1; DROP TABLE users;--" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "single quote rejected"
+_pgrst_normalize_schemas "api_v1,bad'name" 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "double quote rejected"
+_pgrst_normalize_schemas 'api_v1,bad"name' 2>/dev/null && fail_test "should have rejected" || pass_test
+
+start_test "backslash rejected"
+_pgrst_normalize_schemas 'api_v1,bad\name' 2>/dev/null && fail_test "should have rejected" || pass_test
+
+# ============================================================================
+# _pgrst_normalize_schemas — duplicate handling
+# ============================================================================
+
+print_test_section "Normalizer: duplicate handling"
+
+start_test "exact duplicate de-duped, first occurrence preserved"
+out=$(_pgrst_normalize_schemas "api_v1,api_v1,marts" 2>/dev/null)
+[[ "$out" == "api_v1,marts" ]] && pass_test || fail_test "got: $out"
+
+start_test "duplicate prints warning to stderr"
+err=$(_pgrst_normalize_schemas "api_v1,api_v1,marts" 2>&1 >/dev/null)
+echo "$err" | grep -qi "duplicate" && pass_test || fail_test "got stderr: $err"
+
+start_test "duplicate at end de-duped"
+out=$(_pgrst_normalize_schemas "api_v1,marts,api_v1" 2>/dev/null)
+[[ "$out" == "api_v1,marts" ]] && pass_test || fail_test "got: $out"
+
+start_test "all-duplicate input collapses to single value"
+out=$(_pgrst_normalize_schemas "api_v1,api_v1,api_v1" 2>/dev/null)
+[[ "$out" == "api_v1" ]] && pass_test || fail_test "got: $out"
+
+# ============================================================================
+# CLI parsing: --schema is no longer accepted (R5)
+#
+# These shell out to uis-cli.sh, which only runs cleanly inside the
+# uis-provision-host container (its lib dependencies expect container paths).
+# Skip when running on the host so the normalizer unit tests above still
+# give a useful local signal; CI runs inside the container.
+# ============================================================================
+
+print_test_section "CLI parsing: --schema is gone, --schemas is the only flag"
+
+if [[ ! -d "/mnt/urbalurbadisk/provision-host/uis" ]]; then
+    skip_test "Skipping CLI parsing tests: not running inside uis-provision-host container"
+    skip_test "Skipping CLI parsing tests: not running inside uis-provision-host container"
+    skip_test "Skipping CLI parsing tests: not running inside uis-provision-host container"
+else
+    start_test "configure: --schema returns 'Unknown option' error"
+    output=$("$UIS_CLI" configure postgrest --app atlas --database atlas_db --schema api_v1 2>&1 || true)
+    echo "$output" | grep -qi "unknown option" && pass_test || fail_test "expected 'Unknown option' in: $output"
+
+    start_test "deploy: --schema returns 'Unknown option' error"
+    output=$("$UIS_CLI" deploy postgrest --app atlas --schema api_v1 2>&1 || true)
+    echo "$output" | grep -qi "unknown option" && pass_test || fail_test "expected 'Unknown option' in: $output"
+
+    start_test "deploy: --schemas returns 'Unknown option' error (deploy doesn't take schema flags)"
+    output=$("$UIS_CLI" deploy postgrest --app atlas --schemas api_v1,marts 2>&1 || true)
+    echo "$output" | grep -qi "unknown option" && pass_test || fail_test "expected 'Unknown option' in: $output"
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+print_summary

--- a/website/docs/ai-developer/plans/active/PLAN-postgrest-multi-schema-reconciliation.md
+++ b/website/docs/ai-developer/plans/active/PLAN-postgrest-multi-schema-reconciliation.md
@@ -1,0 +1,293 @@
+# Feature: PostgREST `--schemas` flag with wipe-and-rewrite reconciliation
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active
+
+**Goal**: Extend `./uis configure postgrest` to expose multiple PostgreSQL schemas via a single PostgREST instance, with deterministic reconfigure semantics.
+
+**Last Updated**: 2026-05-06 (moved to active/, execution started)
+
+**Investigation**: [INVESTIGATE-postgrest-multi-schema-reconciliation.md](../backlog/INVESTIGATE-postgrest-multi-schema-reconciliation.md)
+
+**Cross-repo coordination**: [atlas talk thread](file:///Users/terje.christensen/learn/helpers/atlas/website/docs/ai-developer/plans/talk/talk.md) Messages 1–3. Atlas confirmed direction in Message 3; awaiting rebuilt `uis-provision-host:latest` SHA from this PR.
+
+---
+
+## Overview
+
+PLAN-002 shipped a single-schema PostgREST handler. Atlas now needs three schemas exposed (`api_v1`, `marts`, `raw`) and the design must support arbitrary schema-list changes across configure runs without leaking grants. The investigation settled on a wipe-and-rewrite approach (`DROP OWNED BY` + per-schema GRANTs in one transaction) with the schema list memorized in the per-app secret. Deploy reads the schema list from the secret, eliminating configure/deploy drift.
+
+The full design is in the investigation's *Final contract* section. This plan executes it.
+
+---
+
+## Phase 1: Input parsing and validation
+
+Pure CLI / handler input handling. No DB or k8s side effects.
+
+### Tasks
+
+- [ ] 1.1 In `provision-host/uis/manage/uis-cli.sh` `cmd_configure`: **replace** the existing `--schema` flag with `--schemas` (line 308). `--schema` falls through to the unknown-option error. Atlas is the only consumer; atlas's setup.md is being updated per atlas Message 3; the only docs / call-sites still using `--schema` are inside this repo and are all rewritten by this plan.
+- [ ] 1.2 In `provision-host/uis/lib/configure.sh` `run_configure`: replace `--schema` with `--schemas` in the argument-parsing case block (line 126). Internal variable is renamed `schema` → `schemas` for clarity. The parsed value flows through to the handler via `configure_service` (line 259) — same dispatch, new name.
+- [ ] 1.3 In `configure-postgrest.sh`: add a `_pgrst_normalize_schemas()` helper that takes the raw schemas value and returns the normalized comma-separated list. Steps: split on `,`, trim each component, reject empty value, reject empty components after trim, reject components not matching `^[a-zA-Z_][a-zA-Z0-9_]*$`, de-dupe while preserving first occurrence (call `log_warn` to stderr for any drop, naming the duplicate), join with `,` (no spaces).
+- [ ] 1.4 In `configure-postgrest.sh` default-path entry: call the normalizer first; surface its rejections via `_configure_error "usage" …` with the offending input named in the message.
+- [ ] 1.5 Update the existing usage error at `configure-postgrest.sh:166` to reference `--schemas api_v1,marts,raw` in the example.
+
+### Validation
+
+```bash
+# Build local image (contributor-side; the tester will run the integration cycle later)
+./uis build
+
+# Sanity checks on read-only command help
+docker run --rm uis-provision-host:local uis configure postgrest --help 2>&1 | grep -E '\-\-schemas?'
+```
+
+Help output mentions only `--schemas` (no `--schema`). User confirms.
+
+---
+
+## Phase 2: Wipe-and-rewrite reconciliation
+
+Implement the State Matrix dispatch from the investigation. This phase is structural; SQL contents and path-by-path behavior are defined in the investigation's *State Matrix* section.
+
+### Tasks
+
+- [ ] 2.1 Add `_pgrst_get_secret_schemas()` helper to `configure-postgrest.sh` — reads the existing secret (if present) and returns the `PGRST_DB_SCHEMAS` value, empty string if key absent or secret missing. (Companion to existing `_pgrst_secret_exists` and `_pgrst_role_exists`.)
+- [ ] 2.2 Add `_pgrst_get_secret_uri()` helper — reads `PGRST_DB_URI` from the existing secret, empty if absent. Needed for the Reconfigure-preserve-URI path.
+- [ ] 2.3 After the normalize call wired in task 1.4 (string-level checks complete), add R4 step 4: per-schema existence check via `SELECT 1 FROM pg_namespace WHERE nspname=$1`. Any miss → reject naming the offender via `_configure_error "usage" …`. Must run before any state inspection (no role/secret reads happen until validation passes).
+- [ ] 2.4 Implement state detection: read the three booleans (`web_anon_exists`, `authenticator_exists`, `secret_schemas_value`) and dispatch to one of the five paths from the investigation's State Matrix. One `case` statement; one helper per path. Inconsistent cells emit the error messages exactly as written in §State Matrix → "Inconsistent" subsection.
+- [ ] 2.5 Implement the four non-trivial paths as separate helper functions, each containing a single SQL transaction:
+  - `_pgrst_path_first_time()`
+  - `_pgrst_path_reconfigure_preserve_uri()`
+  - `_pgrst_path_reconfigure_fresh_password()`
+  - (No-op path: just logs and returns; no helper needed.)
+  
+  SQL contents per the investigation's path definitions. Replace the existing CREATE-ROLE + GRANT block (`configure-postgrest.sh:386–404`).
+- [ ] 2.6 Extend `_pgrst_create_secret` (or add `_pgrst_create_secret_with_schemas`) to write both `PGRST_DB_URI` and `PGRST_DB_SCHEMAS` keys. Existing single-key callers updated; rotate path also calls through this.
+- [ ] 2.7 At the end of every path that committed SQL, issue `NOTIFY pgrst, 'reload schema'` via `_pgrst_exec_db` against the per-app database.
+- [ ] 2.8 Update the JSON success output to include `"schemas": "<normalized list>"`. Update `_configure_error` JSON shape only if a new error code is added (none expected).
+
+### Validation
+
+```bash
+# After tester deploys with the test brief (see Phase 7), sanity from contributor side:
+docker exec uis-provision-host kubectl get secret atlas-postgrest -n postgrest \
+  -o jsonpath='{.data.PGRST_DB_SCHEMAS}' | base64 -d
+# Expected: api_v1,marts,raw
+
+docker exec uis-provision-host kubectl exec -n default postgresql-0 -- \
+  psql -U postgres -d atlas_db -c "\dn+"
+# Expected: atlas_web_anon listed with USAGE on api_v1, marts, raw — and only those.
+```
+
+User confirms wipe-and-rewrite produces exact end state for: first-run, add-schema, remove-schema, replace-schema, order-only-change.
+
+---
+
+## Phase 3: Rotate path preservation + missing-key error
+
+### Tasks
+
+- [ ] 3.1 In `configure-postgrest.sh` rotate path (lines ~290–336): before generating the new password, read the existing secret's `PGRST_DB_SCHEMAS`. If the key is missing, error with: *"`PGRST_DB_SCHEMAS` not present in secret. Run `./uis configure postgrest --app <app> --schemas <list>` first to establish the schema list, then retry rotate."* If the key is present but malformed (e.g. operator hand-edited the secret), trust the value — re-validation isn't rotate's job; configure was the only legitimate writer.
+- [ ] 3.2 On successful rotate, rewrite the secret with both `PGRST_DB_URI` (new password) and the preserved `PGRST_DB_SCHEMAS`.
+
+### Validation
+
+```bash
+# After Phase 2 lands and atlas is configured:
+docker exec uis-provision-host uis configure postgrest --app atlas --rotate
+docker exec uis-provision-host kubectl get secret atlas-postgrest -n postgrest \
+  -o jsonpath='{.data.PGRST_DB_SCHEMAS}' | base64 -d
+# Expected: still api_v1,marts,raw (preserved across rotate).
+```
+
+User confirms rotate preserves schema list and fails loudly on PLAN-002-era secrets.
+
+---
+
+## Phase 4: Deploy template + playbook switch to `secretKeyRef`
+
+### Tasks
+
+- [ ] 4.1 In `ansible/playbooks/templates/088-postgrest-config.yml.j2`: replace the `PGRST_DB_SCHEMAS` env entry's `value: "{{ _schema }}"` with `valueFrom.secretKeyRef` pointing at the per-app secret's `PGRST_DB_SCHEMAS` key.
+- [ ] 4.2 In `ansible/playbooks/088-setup-postgrest.yml`: drop `_schema` from the required-extra-vars assertion (task 1, lines 38–46).
+- [ ] 4.3 In the same playbook: remove the `Schema:    {{ _schema }}` line from the debug output (task 2, lines 51–56).
+- [ ] 4.4 *(Decided: skipped.)* No extra key-presence check in the playbook. Kubernetes' built-in `secretKeyRef` resolution will surface a clear `CreateContainerConfigError` ("couldn't find key PGRST_DB_SCHEMAS in Secret postgrest/<app>-postgrest") on pod start if configure wasn't run first. That error is readable enough; the rotate-path error in Phase 3.1 already forces an upgrade-via-configure before deploy.
+
+### Validation
+
+```bash
+docker exec uis-provision-host ansible-playbook \
+  /mnt/urbalurbadisk/ansible/playbooks/088-setup-postgrest.yml \
+  -e "_app_name=atlas _url_prefix=api-atlas" --check
+```
+
+Dry-run completes without "missing extra-var" errors. User confirms the rendered Deployment references `valueFrom.secretKeyRef` for `PGRST_DB_SCHEMAS`.
+
+---
+
+## Phase 5: CLI cleanup on the deploy path
+
+### Tasks
+
+- [ ] 5.1 In `uis-cli.sh` `cmd_deploy` (lines ~297–371): remove `--schema` flag parsing and the `schema` local variable.
+- [ ] 5.2 Remove the `schema="${schema:-api_v1}"` default and the `schema` argument from the `deploy_single_service` call.
+- [ ] 5.3 In the same file's "Service is single-instance" rejection (line ~346), remove `--schema` from the disallowed-flags message (the message currently lists `--app/--url-prefix/--schema`).
+- [ ] 5.4 In `provision-host/uis/services/integration/service-postgrest.sh`: update the example command at line 10 to show `--schemas` on configure and bare `./uis deploy postgrest --app <name>` on deploy.
+- [ ] 5.5 In `ansible/playbooks/088-setup-postgrest.yml` (line 80): update the fail message that prints the configure-retry hint to use `--schemas <list>` instead of `--schema {{ _schema }}`.
+
+(Note: `configure.sh` is the configure-side dispatcher only; it has no deploy-side dispatch to clean up. Phase 1.2 already migrates it from `--schema` to `--schemas`.)
+
+### Validation
+
+```bash
+docker run --rm uis-provision-host:local uis deploy postgrest --help 2>&1 | grep -i schema
+```
+
+Expected: no mention of `--schema` or `--schemas` for the deploy subcommand. User confirms.
+
+---
+
+## Phase 6: Tests
+
+Tests live at `provision-host/uis/tests/{unit,deploy}/`. Follow the existing `test-configure-namespace.sh` (unit) / `test-configure-namespace-integration.sh` (integration) naming pattern.
+
+### Tasks
+
+- [ ] 6.1 Add `provision-host/uis/tests/unit/test-configure-postgrest-schemas.sh` covering `_pgrst_normalize_schemas()`: valid lists; whitespace trimming; empty value rejection; empty-component rejection; identifier-regex rejection; duplicate de-dupe with warning to stderr. Plus a CLI-parsing case asserting `--schema` is rejected as an unknown option (no aliasing).
+- [ ] 6.2 Add `provision-host/uis/tests/deploy/test-configure-postgrest-schemas-integration.sh` with the following cases. (Each case is a function in the file; the file mirrors the structure of `test-configure-namespace-integration.sh`.)
+- [ ] 6.3 Case: first-time configure with `--schemas api_v1,marts,raw` — assert all three grants present (`SELECT has_schema_privilege('atlas_web_anon', '<schema>', 'USAGE')` per schema), secret has both keys, secret's `PGRST_DB_SCHEMAS` value equals `api_v1,marts,raw`.
+- [ ] 6.4 Case: re-run with same list — assert no-op message printed, no rows changed (compare `(SELECT array_agg(nspname) FROM pg_namespace WHERE has_schema_privilege('atlas_web_anon', oid, 'USAGE'))` before/after).
+- [ ] 6.5 Case: reconfigure with `--schemas api_v1,marts` — assert `raw` grants gone:
+  ```sql
+  SELECT count(*) = 0 FROM pg_default_acl
+   WHERE defaclnamespace = (SELECT oid FROM pg_namespace WHERE nspname='raw')
+     AND defaclacl::text LIKE '%atlas_web_anon%';
+  SELECT NOT has_schema_privilege('atlas_web_anon', 'raw', 'USAGE');
+  ```
+- [ ] 6.6 Case: order-only change `api_v1,marts,raw` → `marts,raw,api_v1` — assert SQL end-state grants identical (same `pg_namespace` set), secret's `PGRST_DB_SCHEMAS` exactly equals `marts,raw,api_v1`.
+- [ ] 6.7 Case: missing schema in `--schemas` (e.g. `--schemas api_v1,bogus`) — assert pre-validation rejects with a message naming `bogus`; assert no roles created (`SELECT count(*) FROM pg_roles WHERE rolname IN ('atlas_web_anon','atlas_authenticator')` = 0 if first-time, unchanged if reconfigure).
+- [ ] 6.8 Case: `<app>_authenticator → <app>_web_anon` membership survives `DROP OWNED BY`. Configure first-time, run a reconfigure that triggers `DROP OWNED BY`, assert membership still present:
+  ```sql
+  SELECT EXISTS (
+    SELECT 1 FROM pg_auth_members
+     WHERE roleid  = (SELECT oid FROM pg_authid WHERE rolname='atlas_web_anon')
+       AND member  = (SELECT oid FROM pg_authid WHERE rolname='atlas_authenticator')
+  );
+  ```
+- [ ] 6.9 Case: rotate fails with the stated error message when secret has no `PGRST_DB_SCHEMAS` key (simulate by `kubectl patch secret … --type=json -p='[{"op":"remove","path":"/data/PGRST_DB_SCHEMAS"}]'` first).
+- [ ] 6.10 Case: recovery — delete secret manually (`kubectl delete secret atlas-postgrest -n postgrest`), re-run configure with `--schemas api_v1,marts,raw`. Assert: secret rebuilt with both keys; password changed (auth check with the *new* secret's URI succeeds, with the prior captured URI fails); grants correct on all three schemas. Per task 2.5, this hits the "reconfigure with missing secret" sub-path with `ALTER USER … PASSWORD`.
+- [ ] 6.11 Case: PLAN-002-era upgrade — write a secret with only `PGRST_DB_URI` (no `PGRST_DB_SCHEMAS`), then run configure with `--schemas api_v1,marts,raw`. Assert: secret gains `PGRST_DB_SCHEMAS`; original `PGRST_DB_URI` preserved (password unchanged); grants applied correctly.
+- [ ] 6.12 Case: partial-role state — manually `DROP ROLE atlas_authenticator` (leaving `atlas_web_anon`), re-run configure. Assert: error message names the surviving role; no SQL state change; suggests `--purge`.
+- [ ] 6.13 Case: deploy with no schema flags reads `PGRST_DB_SCHEMAS` from secret correctly. After configure with `--schemas api_v1,marts,raw` and `./uis deploy postgrest --app atlas`, assert OpenAPI at `http://api-atlas.localhost/` advertises endpoints from all three schemas (one HEAD or GET per schema returning 200; rows or empty array, both pass).
+
+### Validation
+
+```bash
+docker exec uis-provision-host bash -lc \
+  'cd /mnt/urbalurbadisk/provision-host/uis/tests && ./run-tests.sh postgrest'
+```
+
+All tests pass. User confirms.
+
+---
+
+## Phase 7: Documentation
+
+### Tasks
+
+- [ ] 7.1 In `website/docs/services/integration/postgrest.md`: at lines 77 and 220 (the two `./uis configure postgrest` examples that currently pass `--schema api_v1`), replace `--schema api_v1` with `--schemas api_v1,marts,raw` and update surrounding prose to match. Audit the rest of the page for any other `--schema` references.
+- [ ] 7.2 Add a new subsection "Reconfigure semantics": explain wipe-and-rewrite, the deterministic-end-state contract, and the order-significance note (first schema is PostgREST's default schema served when `Accept-Profile` is omitted).
+- [ ] 7.3 Add a new subsection "Inspecting the current schema list" with the kubectl one-liner: `kubectl get secret <app>-postgrest -n postgrest -o jsonpath='{.data.PGRST_DB_SCHEMAS}' | base64 -d`.
+- [ ] 7.4 Add a "UIS-managed role contract" callout: *"`<app>_web_anon` grants are exclusively UIS-managed. Manual `GRANT … TO <app>_web_anon` will be lost on the next configure."*
+- [ ] 7.5 Add a "Upgrading from PLAN-002 single-schema" subsection: *"Run `./uis configure postgrest --app <app> --schemas <list>` once to populate the new `PGRST_DB_SCHEMAS` secret key before any rotate. Roles persist; the existing `PGRST_DB_URI` (and therefore the password) is preserved; grants are reset to match `<list>` exactly via the wipe-and-rewrite path. If `<list>` includes `api_v1` (the PLAN-002 default), the resulting grants on `api_v1` are functionally identical to before."*
+
+### Validation
+
+```bash
+# Build docs locally if a local docs server is available; otherwise rely on CI's
+# "Generate UIS Documentation" + "Deploy Documentation" workflows.
+cd website && npm run build
+```
+
+User confirms `postgrest.md` renders correctly and the new subsections read cleanly.
+
+---
+
+## Phase 8: End-to-end smoke against atlas's use case
+
+This phase is run by the **tester**, via a `talk*.md` brief in `/Users/terje.christensen/learn/helpers/testing/uis1/talk/`. The contributor writes the brief; tester executes; contributor reviews results.
+
+### Tasks
+
+- [ ] 8.1 Contributor: build local image (`./uis build`) and write the test brief.
+- [ ] 8.2 Tester: ensure atlas's database exists. Run `UIS_IMAGE=uis-provision-host:local ./uis configure postgresql --app atlas --database atlas_db --json` — idempotent; runs once if the cluster has been reset since this plan was written, no-op otherwise.
+- [ ] 8.3 Tester: run `UIS_IMAGE=uis-provision-host:local ./uis configure postgrest --app atlas --database atlas_db --schemas api_v1,marts,raw --url-prefix api-atlas`. Assert clean exit with JSON listing all three schemas.
+- [ ] 8.4 Tester: run `UIS_IMAGE=uis-provision-host:local ./uis deploy postgrest --app atlas --url-prefix api-atlas`. Assert clean PLAY RECAP and pod readiness.
+- [ ] 8.5 Tester: `curl -fsS http://api-atlas.localhost/` returns OpenAPI advertising endpoints from all three schemas. Spot-check one endpoint per schema returns 200 (rows or empty array, both pass — `marts.*` / `raw.*` may be empty in the tester's environment if dbt/ingest hasn't run).
+- [ ] 8.6 Tester: re-run configure with `--schemas api_v1,marts` (drop `raw`). Assert OpenAPI no longer advertises `raw.*`. Assert `pg_default_acl` cleared for `raw`:
+  ```sql
+  SELECT count(*) = 0 FROM pg_default_acl
+   WHERE defaclnamespace = (SELECT oid FROM pg_namespace WHERE nspname='raw')
+     AND defaclacl::text LIKE '%atlas_web_anon%';
+  ```
+- [ ] 8.7 Tester: re-run configure with `--schemas api_v1,marts,raw` (restore). Assert restoration.
+- [ ] 8.8 Contributor: open PR, ensure CI green (Build UIS Container, Test UIS Scripts, Generate UIS Documentation, Deploy Documentation), merge.
+- [ ] 8.9 Surface the rebuilt-image SHA to the user (contributor) once CI publishes it. The user owns cross-repo communication with atlas — they decide when/whether to update `atlas/website/docs/ai-developer/plans/talk/talk.md`. Claude does not proactively write to the atlas talk thread.
+
+### Validation
+
+User (contributor) confirms tester results, CI green, merge complete, atlas pinged.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `./uis configure postgrest --app <app> --schemas <list>` accepts comma-separated lists and runs the normalize/validate pipeline (R4) before any SQL.
+- [ ] First-time configure creates roles + grants + secret (with both `PGRST_DB_URI` and `PGRST_DB_SCHEMAS`) atomically.
+- [ ] Reconfigure with a different list wipes prior grants (including `pg_default_acl` entries for dropped schemas) and re-applies the new list, in one transaction.
+- [ ] No-op short-circuit fires only when both roles + secret exist AND `PGRST_DB_SCHEMAS` exact-string-matches the normalized incoming list.
+- [ ] `--rotate` preserves `PGRST_DB_SCHEMAS`; errors loudly when the key is absent.
+- [ ] `--purge` clears both keys (no change required; verify only).
+- [ ] Deploy CLI no longer accepts `--schema` or `--schemas`; deploy template reads `PGRST_DB_SCHEMAS` via `valueFrom.secretKeyRef`.
+- [ ] `<app>_authenticator → <app>_web_anon` membership survives `DROP OWNED BY` (covered by test 6.8).
+- [ ] `postgrest.md` documents `--schemas`, the wipe-and-rewrite contract, the kubectl listing one-liner, the order-significance note, the UIS-managed-role invariant, and the PLAN-002-upgrade note.
+- [ ] CI workflows green; rebuilt `uis-provision-host:latest` published to GHCR; SHA reported to the user (cross-repo comms with atlas are user-driven, not Claude-driven).
+
+---
+
+## Files to Modify
+
+- `provision-host/uis/lib/configure-postgrest.sh` — normalize/validate helper, no-op short-circuit, role-state detection, three-way path (first-time / reconfigure-with-secret / reconfigure-without-secret), wipe-and-rewrite SQL, secret-with-schemas write, NOTIFY, rotate-preserves-key, error-message updates.
+- `provision-host/uis/lib/configure.sh` — replace `--schema` with `--schemas` in argument parsing; rename internal variable `schema` → `schemas`.
+- `provision-host/uis/manage/uis-cli.sh` — replace `--schema` with `--schemas` on the configure path; remove both `--schema` and `--schemas` from the deploy path.
+- `provision-host/uis/services/integration/service-postgrest.sh` — example commands.
+- `ansible/playbooks/templates/088-postgrest-config.yml.j2` — `PGRST_DB_SCHEMAS` via `valueFrom.secretKeyRef`.
+- `ansible/playbooks/088-setup-postgrest.yml` — drop `_schema` extra-var assertion + debug-line reference.
+- `provision-host/uis/tests/unit/test-configure-postgrest-schemas.sh` — new (Phase 6.1).
+- `provision-host/uis/tests/deploy/test-configure-postgrest-schemas-integration.sh` — new (Phase 6.2 onward).
+- `website/docs/services/integration/postgrest.md` — Phase 7 content.
+
+---
+
+## Implementation Notes
+
+- **SQL identifier safety**: the existing handler bash-substitutes `$schema` directly into SQL (`configure-postgrest.sh:400`). The R4 regex (`^[a-zA-Z_][a-zA-Z0-9_]*$`) is the SQL-injection guard — Phase 1 task 1.3 (the normalizer) must reject before any string interpolation. Do not skip the regex even though Atlas's identifiers are clean today.
+- **Transaction wrapping**: the current handler runs CREATE ROLE inside a DO block, then grants outside it. With `--set ON_ERROR_STOP=on` each top-level statement is its own implicit transaction. Phase 2 task 2.5 must wrap the whole SQL block in explicit `BEGIN; … COMMIT;` so a per-schema GRANT failure rolls back the role creation. Pre-validation (task 2.3, exercised by test 6.7) covers the primary failure mode (missing schema named in `--schemas`); the transaction wrapping is defense-in-depth against a schema being dropped by another process between pre-validation and the GRANT — race-condition territory, not directly exercised by tests.
+- **`DROP OWNED BY` scope**: per-database, drops objects owned by + revokes privileges granted to the role. Run inside the per-app database (the `_pgrst_exec_db` pattern already does this). Does NOT touch cluster-level role memberships — `<app>_authenticator → <app>_web_anon` survives. Test 6.8 verifies.
+- **Secret rewrite atomicity**: `kubectl create secret … --dry-run=client -o yaml | kubectl apply` replaces the entire secret. Read existing keys first; rewrite both. Don't drop `PGRST_DB_URI` accidentally during a `--rotate` or schema-only reconfigure.
+- **NOTIFY scope**: `NOTIFY pgrst, 'reload schema'` runs against the per-app database. PostgREST's `db-channel` defaults to `pgrst` on the database the connection string points at. No special config needed.
+- **`--schema` is gone, not aliased**: any operator passing `--schema` gets a standard "Unknown option" error from the CLI parser. Atlas's setup.md updates to `--schemas` per atlas Message 3; UIS-internal docs are rewritten in this PR.
+
+---
+
+## Out of Scope
+
+- Authenticated schemas / role-pairs (Atlas's `private_marts` / `private_raw`) — PLAN-003 territory.
+- Per-table grant control — `--schemas` is schema-granularity only.
+- Per-instance `./uis status` reporting (Decision #19 from `INVESTIGATE-postgrest.md`) — separate plan.
+- Atlas-side `setup.md` updates — Atlas owns those (atlas Message 3).

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-postgrest-multi-schema-reconciliation.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-postgrest-multi-schema-reconciliation.md
@@ -1,0 +1,213 @@
+# Investigate: PostgREST `--schemas` flag and reconfigure semantics
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Decide what `./uis configure postgrest --app <name> --schemas <list>` means when called more than once with a *changing* list. The single-schema handler that PLAN-002 shipped never had to reconcile across calls; multi-schema does.
+
+**Last Updated**: 2026-05-06 (resolutions recorded; concise rewrite)
+
+**Origin**: Atlas asked for `marts` + `raw` exposure alongside `api_v1` (cross-repo talk thread, atlas Messages 1–3). UIS counter-proposed a per-app `--schemas` flag (uis Message 1). Atlas confirmed direction in Message 3. Before PLAN-XXX drafting, terje raised the reconfigure question: *"can the command be run many times — what happens if it's run with 3 schemas and then I remove one and run again?"* This investigation answers that.
+
+**Depends on**: [INVESTIGATE-postgrest.md](INVESTIGATE-postgrest.md), [PLAN-002-postgrest-deployment.md](../completed/PLAN-002-postgrest-deployment.md), the existing `configure-postgrest.sh` handler.
+
+---
+
+## Resolutions (2026-05-06)
+
+Five decisions settle the design.
+
+### R1 — Wipe + rewrite (not diff)
+
+Every non-no-op configure resolves to:
+
+```sql
+BEGIN;
+DROP OWNED BY <app>_web_anon;          -- clears all schema USAGE/SELECT + pg_default_acl entries in this DB
+GRANT USAGE  ON SCHEMA <s_i> TO <app>_web_anon;
+GRANT SELECT ON ALL TABLES IN SCHEMA <s_i> TO <app>_web_anon;
+ALTER DEFAULT PRIVILEGES IN SCHEMA <s_i> GRANT SELECT ON TABLES TO <app>_web_anon;
+-- ... per schema in --schemas
+COMMIT;
+```
+
+`DROP OWNED BY` revokes all privileges granted to the role (per PG 16 docs), including `pg_default_acl` entries — the stealth-persistence problem from "remove a schema" goes away for free. End state is fully determined by `--schemas`; no diff state needed. Single transaction is naturally atomic. Code is roughly half the size of diff-based reconciliation.
+
+The `<app>_authenticator → <app>_web_anon` role membership survives `DROP OWNED BY` (cluster-level grant in `pg_auth_members`, not a per-database privilege). Verify with a test.
+
+**Tradeoff**: out-of-band `GRANT … TO <app>_web_anon` is wiped on the next configure. Documented as "the role's grants are exclusively UIS-managed."
+
+### R2 — `PGRST_DB_SCHEMAS` lives in the per-app secret
+
+The secret (`<app>-postgrest` in postgrest namespace) gains a second key, `PGRST_DB_SCHEMAS`, holding the comma-separated schema list in operator-specified order.
+
+- Configure writes both `PGRST_DB_URI` and `PGRST_DB_SCHEMAS` on every successful run.
+- Deploy template reads `PGRST_DB_SCHEMAS` via `valueFrom.secretKeyRef`, not from a Jinja substitution.
+- Both `--schemas` and `--schema` are **removed from the deploy CLI surface**. Deploy takes `--app` and `--url-prefix` only. Configure-deploy drift collapses to zero.
+
+The role here is "memorize last applied" — used by deploy + observability, not consumed by reconciliation.
+
+### R3 — No CLI flag for listing schemas; document the kubectl one-liner
+
+Considered a `--list-schemas` query mode on configure. Rejected: the information is one kubectl line away, configure is a state-changing verb (mixing query + mutation muddies semantics), and the natural home for "current state of this PostgREST instance" is the deferred per-instance `./uis status` work flagged in Decision #19 of `INVESTIGATE-postgrest.md`. R1 (wipe-and-rewrite) actively *reduces* the case for a list flag.
+
+**PLAN-XXX commitment**: `postgrest.md` gains an "Inspecting the current schema list" subsection with:
+
+```bash
+kubectl get secret <app>-postgrest -n postgrest \
+  -o jsonpath='{.data.PGRST_DB_SCHEMAS}' | base64 -d
+```
+
+### R4 — Pre-validation, fail-loud
+
+Before `BEGIN;`:
+
+1. Trim whitespace per component, reject empty value, reject empty components after trim.
+2. Reject components that don't match `^[a-zA-Z_][a-zA-Z0-9_]*$`. Closes the existing SQL-injection surface at `configure-postgrest.sh:400` where `$schema` is bash-substituted unquoted.
+3. De-dupe with a logged warning.
+4. For each remaining schema: `SELECT 1 FROM pg_namespace WHERE nspname=$1`. Any miss → reject naming the offender. No `IF EXISTS`, no silent skips.
+
+Catches all input/lookup error scenarios at one chokepoint before any state mutation.
+
+### R5 — `--schemas` is the only flag
+
+`--schema` (singular) is removed entirely from the CLI surface, not aliased. Two flag names doing the same thing is operator confusion for zero benefit. Atlas (the only consumer) updates its `setup.md` to `--schemas` per atlas Message 3; UIS-internal docs and example commands are rewritten in the same PR. Operators passing `--schema` get the standard "unknown option" error from the CLI parser.
+
+This applies to both the configure path and the deploy path. Deploy doesn't take a schema flag at all (R2 puts the list in the secret).
+
+---
+
+## State matrix
+
+The handler must dispatch on two orthogonal state axes: **role state** (cluster-level, per-database irrelevant) and **secret state** (postgrest namespace, per-app). Nine cells. Five distinct paths.
+
+|                                       | Both roles                  | Partial (exactly one)        | Neither role                |
+|---------------------------------------|-----------------------------|------------------------------|-----------------------------|
+| **Secret with `PGRST_DB_SCHEMAS`**    | No-op *or* Reconfigure-preserve-URI | Inconsistent (partial role) | Inconsistent (orphan secret) |
+| **Secret without `PGRST_DB_SCHEMAS`** | Reconfigure-preserve-URI    | Inconsistent (partial role)  | Inconsistent (orphan secret) |
+| **Secret missing**                    | Reconfigure-fresh-password  | Inconsistent (partial role)  | First-time                  |
+
+### Path definitions
+
+**First-time** — `(Neither, Missing)`. No prior state.
+- Single transaction: `CREATE ROLE <app>_web_anon NOLOGIN` → `CREATE ROLE <app>_authenticator LOGIN PASSWORD '<new>' NOINHERIT` → `GRANT <app>_web_anon TO <app>_authenticator` → per-schema `GRANT USAGE` / `GRANT SELECT` / `ALTER DEFAULT PRIVILEGES` in operator order.
+- Generate fresh password in shell before transaction; build `PGRST_DB_URI` from it.
+- Write secret with both `PGRST_DB_URI` and `PGRST_DB_SCHEMAS` keys.
+- `NOTIFY pgrst, 'reload schema'`.
+
+**Reconfigure-preserve-URI** — `(Both, With-key)` when list differs, `(Both, Without-key)` always.
+- Single transaction: `DROP OWNED BY <app>_web_anon` → per-schema `GRANT USAGE` / `GRANT SELECT` / `ALTER DEFAULT PRIVILEGES` in operator order. Password and authenticator role untouched.
+- Read existing secret's `PGRST_DB_URI` value; write back verbatim. Always (re)write `PGRST_DB_SCHEMAS` to the normalized incoming list.
+- `NOTIFY pgrst, 'reload schema'`.
+- This path is also the canonical PLAN-002 → multi-schema upgrade route: existing secret has `PGRST_DB_URI` only, no `PGRST_DB_SCHEMAS`; the path adds the missing key while preserving URI and grant semantics for the previously-configured schema (typically `api_v1`).
+
+**Reconfigure-fresh-password** — `(Both, Missing)`. Recovery from a manually-deleted secret.
+- The password lived only in the deleted secret's URI; it's unrecoverable.
+- Generate fresh password in shell. Single transaction: `ALTER USER <app>_authenticator WITH PASSWORD '<new>'` → `DROP OWNED BY <app>_web_anon` → per-schema GRANTs.
+- Write new secret with both keys (URI built from the new password).
+- `NOTIFY pgrst, 'reload schema'`.
+
+**No-op** — `(Both, With-key)` when secret's `PGRST_DB_SCHEMAS` exact-string-equals the normalized incoming list (string-equal preserves order).
+- No SQL, no secret rewrite.
+- Log "already configured — nothing to do."
+
+**Inconsistent** — every other cell. The handler does not auto-recover from operator-introduced corruption.
+- `(Partial, *)`: one role exists, the other doesn't. Error: *"Inconsistent role state for app '<app>': role `<rolename>` exists but `<other>` does not. Run `./uis configure postgrest --app <app> --purge` to clear and retry."*
+- `(Neither, With-key)` and `(Neither, Without-key)`: roles dropped externally; the secret references nonexistent roles. Error: *"Orphan secret: `<app>-postgrest` exists but neither role exists. Run `./uis configure postgrest --app <app> --purge` to clear and retry."*
+
+In all inconsistent cases, the handler exits non-zero with the named error and changes no state.
+
+### State-detection helpers
+
+The handler needs three boolean queries to place itself on the matrix:
+- `_pgrst_role_exists "<app>_web_anon"` (already exists in PLAN-002 code)
+- `_pgrst_role_exists "<app>_authenticator"` (already exists)
+- `_pgrst_get_secret_schemas "<app>"` returns the `PGRST_DB_SCHEMAS` value, empty if key missing, or a sentinel if the secret itself doesn't exist (e.g., empty + a separate `_pgrst_secret_exists` check, which already exists)
+
+Three helpers, three booleans, nine cells, five paths. Every dispatch decision is one shell-level `case` statement in the handler.
+
+---
+
+## Scenario matrix
+
+Every input scenario maps to one State Matrix cell or to pre-flight rejection.
+
+| # | Scenario | Resolved by |
+|---|---|---|
+| A | First-time configure | First-time path |
+| B | Re-run, identical list | No-op |
+| C | Add a schema | Reconfigure-preserve-URI |
+| D | Remove a schema | Reconfigure-preserve-URI — `DROP OWNED BY` clears stealth `pg_default_acl` for free |
+| E | Replace (C + D) | Reconfigure-preserve-URI |
+| F | First-time with non-existent schema | Pre-validation reject (R4) — never reaches state matrix |
+| G | Re-run after schema dropped externally | Pre-validation reject (R4) — same as F |
+| H | `--rotate` interaction | Preserves `PGRST_DB_SCHEMAS`; fail-loud if key missing (Final contract §6) |
+| I | `--purge` interaction | Unchanged from PLAN-002 |
+| J | Configure ↔ deploy drift | Eliminated by R2 (single source of truth) |
+| K | Whitespace / empty / duplicate input | Pre-validation reject (R4) |
+| L | Order significance | No-op vs Reconfigure-preserve-URI distinguished by string-equal comparison (preserves order) |
+| M | PostgREST schema-cache reload | `NOTIFY pgrst, 'reload schema'` after non-no-op paths (Final contract §4) |
+| N | Recovery: secret deleted manually | Reconfigure-fresh-password (`ALTER USER` + new secret) |
+| O | PLAN-002-era upgrade (secret without `PGRST_DB_SCHEMAS`) | Reconfigure-preserve-URI |
+| P | Partial role state (one role exists, the other doesn't) | Inconsistent — error and refuse to act |
+| Q | Orphan secret (secret exists, neither role does) | Inconsistent — error and refuse to act |
+
+---
+
+## Source of truth
+
+R2 selects S1 (per-app secret). Brief comparison kept for the reasoning trail:
+
+| Option | Verdict |
+|---|---|
+| **S1** ✅ `PGRST_DB_SCHEMAS` key on per-app secret | Wins. Order preserved; deploy reads via `secretKeyRef`; secret lifecycle already aligned with configure. |
+| S2 Derive from `pg_namespace` × `has_schema_privilege` | Can't preserve order; can't distinguish UIS-managed from manual grants. |
+| S3 Annotation on Deployment / per-app ConfigMap | Forces configure to write a k8s object that deploy is supposed to own. |
+| S4 No state — additive only, narrow only via `--purge` | Loses the entire premise of `--schemas` as a reconfigure contract. |
+
+---
+
+## Final contract (PLAN-XXX implements this)
+
+The handler is fully described by the resolutions and state matrix above. This section restates the handler-level invariants — design *consequences* of R1–R5 + the state matrix, not new design.
+
+1. **Pre-flight validation** runs before any state inspection or SQL. See R4 for the normalize/validate sequence. Empty value or any miss → reject; no SQL fires; no state inspected.
+
+2. **State-matrix dispatch** (after pre-flight): three booleans (web_anon exists, authenticator exists, schema-list value from secret) place the call on one of the nine cells. Five paths: First-time, Reconfigure-preserve-URI, Reconfigure-fresh-password, No-op, Inconsistent. Behavior per cell defined in §State Matrix.
+
+3. **Atomicity**: every path that runs SQL wraps the whole block in a single transaction (`BEGIN; … COMMIT;`). On any error inside the transaction, Postgres rolls back; no partial state.
+
+4. **NOTIFY**: every path that commits SQL issues `NOTIFY pgrst, 'reload schema'` at the end (after the secret write). Skipped on No-op and Inconsistent. PostgREST re-parses `PGRST_DB_SCHEMAS` only at startup, so NOTIFY is moot for the order-only case (which falls under Reconfigure-preserve-URI), but the cost is zero and uniform-path is simpler than special-casing.
+
+5. **Order-only change** (same set, different sequence) is just `(Both, With-key)` where the incoming list differs from the secret's stored value — string-equal comparison detects "different even if set-equal." Falls into Reconfigure-preserve-URI. SQL is idempotent for the unchanged grant set; only the secret value changes. Operator must redeploy for PostgREST to pick up the new default schema; the handler does NOT auto-rollout.
+
+6. **`--rotate`** generates a new password and rewrites the secret. Reads existing `PGRST_DB_SCHEMAS` first; preserves it on the rewrite. If the key is **missing** (PLAN-002-era deployment), rotate fails with: *"`PGRST_DB_SCHEMAS` not present in secret. Run `./uis configure postgrest --app <app> --schemas <list>` first to establish the schema list, then retry rotate."* Forces an explicit upgrade-via-configure once; cleaner than a silent fallback to `api_v1`.
+
+7. **`--purge`** unchanged from PLAN-002. `DROP OWNED BY` + `DROP ROLE` clears DB state; the secret-delete already in place removes both keys with the secret.
+
+8. **Deploy CLI** accepts `--app` and `--url-prefix` only (per R2 + R5). Deploy template reads `PGRST_DB_SCHEMAS` via `valueFrom.secretKeyRef`. Configure CLI accepts `--schemas` (per R5), not `--schema`.
+
+9. **Operator contract documented in postgrest.md**:
+    - "The `<app>_web_anon` role's grants are exclusively UIS-managed. `./uis configure postgrest --app <app>` wipes and re-applies grants based on `--schemas`. Manual `GRANT` to this role will be lost on the next configure."
+    - The kubectl listing one-liner from R3.
+    - The order-significance note (first schema is PostgREST's default when `Accept-Profile` is omitted).
+    - The PLAN-002 → PLAN-XXX upgrade note: a no-op `./uis configure postgrest --app <app> --schemas <list>` once populates the new `PGRST_DB_SCHEMAS` secret key (Reconfigure-preserve-URI path; password unchanged).
+
+---
+
+## Open questions
+
+1. **Reconcile-failure half-states.** kubectl/network failure between transaction commit and secret update leaves DB grants ahead of secret. Re-running with same `--schemas` reconciles correctly via §4. Acceptable.
+2. **Concurrent operators.** Two simultaneous `./uis configure postgrest --app atlas`: DB transactions serialise, secret writes don't, last-writer-wins. Real-world likelihood ≈ 0.
+
+---
+
+## Out of scope
+
+- **Authenticated schemas / role-pairs.** Atlas's `private_marts` / `private_raw` belong behind a separate role-pair on a separate PostgREST instance — PLAN-003 (JWT/Authentik) territory.
+- **Per-table grant control.** `--schemas` is schema-granularity; per-table whitelist/blacklist is not in scope.
+- **Schema-list defaults that vary per consumer.** UIS stays domain-agnostic — default is `api_v1`; everything else is the operator's call.
+- **Atlas-side documentation updates.** Atlas owns its `setup.md`; UIS doesn't write into the atlas repo.

--- a/website/docs/ai-developer/plans/completed/PLAN-container-pull-command.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-container-pull-command.md
@@ -4,11 +4,13 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Backlog
+## Status: Completed
 
 **Goal**: Add a `./uis pull` command to the repo-root wrapper that pulls the latest container image and restarts the container
 
-**Last Updated**: 2026-03-11
+**Last Updated**: 2026-05-06
+
+**Completed**: 2026-05-06 — `pull_container()` shipped in both `./uis` (line 174) and `website/static/uis` (line 191); help text in both wrappers documents the command. All phase tasks and acceptance criteria are met by the existing code.
 
 **Related**: [INVESTIGATE-container-pull-command.md](../backlog/INVESTIGATE-container-pull-command.md)
 

--- a/website/docs/ai-developer/plans/completed/PLAN-gravitee-postgresql-deployment.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-gravitee-postgresql-deployment.md
@@ -4,11 +4,13 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Active
+## Status: Completed
 
 **Goal**: After this plan, `./uis deploy postgresql && ./uis deploy gravitee` on a fresh local cluster produces a working Gravitee APIM 4.11 deployment with admin Console, Developer Portal, and API Gateway, backed by PostgreSQL — no MongoDB, no Elasticsearch, no Redis. `./uis undeploy gravitee --purge` cleanly tears down all Gravitee state.
 
-**Last Updated**: 2026-04-30
+**Last Updated**: 2026-05-06
+
+**Completed**: 2026-05-06 — Gravitee close-out shipped to `origin/main` over the gravitee work-stream commits ending at `de872dd` (E2E smoke-test docs). PLAN-001 (org name) and PLAN-002 (portal entrypoint) follow-ups in `plans/completed/` covered the remaining post-deploy config work. All four URLs (Console, Portal, Gateway, Management API) verified live; CI green; rebuilt `uis-provision-host:latest` published.
 
 **Investigation**: [INVESTIGATE-gravitee-fix.md](../backlog/INVESTIGATE-gravitee-fix.md) — 17 decisions resolved, 12 open checks (all empirical, handled during implementation).
 

--- a/website/docs/services/integration/postgrest.md
+++ b/website/docs/services/integration/postgrest.md
@@ -74,8 +74,11 @@ The `<app>_` prefix is required because Postgres roles are cluster-wide. Two app
 # 1. Configure PostgREST (Postgres-side role pair + Secret in postgrest namespace)
 ./uis configure postgrest --app atlas \
     --database atlas_db \
-    --schema api_v1 \
+    --schemas api_v1,marts,raw \
     --url-prefix api-atlas
+#    `--schemas` is a comma-separated list — pass one or many. The list is
+#    stored on the per-app secret (key PGRST_DB_SCHEMAS) and consumed by
+#    deploy automatically; deploy itself takes no schema flags.
 
 # 2. Deploy (Kubernetes objects: Deployment, Service, IngressRoute)
 ./uis deploy postgrest --app atlas
@@ -90,29 +93,42 @@ Step 0 is required before step 1. `./uis configure postgrest` runs a precheck th
 What changes at each step:
 
 - **`configure postgresql`** (step 0) creates `<app>_db`, the `<app>` Postgres role with a generated password, grants the role on the database, and auto-exposes the cluster service at `localhost:35432`. Returns connection JSON (no credentials are printed elsewhere — the JSON is the only output that carries the password). Use `--rotate` to refresh the password.
-- **`configure postgrest`** (step 1) creates the role pair (`atlas_web_anon`, `atlas_authenticator`) and writes the `atlas-postgrest` Secret. Idempotent: a second call with full state (role pair + Secret) is a no-op skip; from a partial-state baseline (roles exist but Secret missing, or vice versa) it takes a recovery path that re-aligns state via `DO` block + `EXISTS` guards (and `ALTER USER … PASSWORD` to refresh credentials). Use `--rotate` to force a new password and update the Secret.
+- **`configure postgrest`** (step 1) creates the role pair (`atlas_web_anon`, `atlas_authenticator`) and writes the `atlas-postgrest` Secret with both `PGRST_DB_URI` and `PGRST_DB_SCHEMAS` keys. The handler dispatches on the cluster's current state — see [Reconfigure semantics](#reconfigure-semantics) for the full contract. Re-running with the **same** `--schemas` is a no-op; with a **different** list it wipes-and-rewrites grants to match. If the secret was deleted manually, configure recovers by rotating the password (Reconfigure-fresh-password). If exactly one of the two roles exists, the handler refuses to act and tells you to `--purge` (the cluster is in an inconsistent state that UIS won't auto-recover from). Use `--rotate` to force a new password and update the Secret without changing schemas.
 - **`deploy`** (step 2) renders per-instance manifests and applies the Deployment, Service, and IngressRoute. Errors out if the instance has not been configured.
 - **`undeploy`** removes only the Kubernetes objects. Postgres roles and the Secret remain, so a follow-up `deploy` works without re-configure.
 - **`configure postgrest --purge`** drops the Postgres roles and removes the Secret. Pass `--database <app>_db` explicitly — without it, purge falls back to `<app>` as the default database name and aborts with "FATAL: database does not exist" (see [Troubleshooting](#troubleshooting)). Use after `undeploy` for a full teardown.
 
 ### Smoke checks
 
-Four canonical checks verify a per-app PostgREST instance is healthy after deploy. Run these from the host machine after step 2:
+Five canonical checks verify a per-app PostgREST instance is healthy after deploy. Run these from the host machine after step 2:
 
 ```bash
-# 1. Spec served, version pinned
+# 1. Spec served, version pinned (default schema = first in --schemas)
 curl -sS http://api-<app>.localhost/ | jq '{swagger, version: .info.version}'
 # expect: {"swagger":"2.0","version":"14.10"}
 
-# 2. Real data flowing through a curated view
+# 2. Real data flowing through a curated view (default schema)
 curl -sS http://api-<app>.localhost/<view-name> | jq 'length'
 # expect: > 0
 
-# 3. Hidden objects stay hidden (only api_v1.* is exposed)
-curl -sS -o /dev/null -w '%{http_code}\n' http://api-<app>.localhost/<some-internal-table>
-# expect: 404
+# 3. Each schema in --schemas is reachable via Accept-Profile
+#    PostgREST exposes one schema per request; the first schema in
+#    PGRST_DB_SCHEMAS is the default (no header needed). Switch to a
+#    non-default schema by setting Accept-Profile per request.
+for profile in api_v1 marts raw; do
+    paths=$(curl -sS -H "Accept-Profile: $profile" http://api-<app>.localhost/ | jq '.paths | length')
+    echo "  $profile -> $paths paths"
+done
+# expect: each schema reports a non-zero path count matching the table
+# count for that schema (one row per /table-or-view + 1 for the root /).
 
-# 4. CORS preflight works for browser callers
+# 4. Hidden objects stay hidden (e.g. private_marts not in --schemas)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+    -H 'Accept-Profile: private_marts' http://api-<app>.localhost/
+# expect: 404 (the schema isn't in PGRST_DB_SCHEMAS, so PostgREST refuses
+# to switch to it).
+
+# 5. CORS preflight works for browser callers
 curl -sS -X OPTIONS \
     -H 'Origin: https://<your-frontend-host>' \
     -H 'Access-Control-Request-Method: GET' \
@@ -120,7 +136,7 @@ curl -sS -X OPTIONS \
 # expect: Access-Control-Allow-Origin: ...
 ```
 
-Check 1 confirms PostgREST is alive and the pinned image is what's actually running. Check 2 confirms the application's `api_v1.*` schema is reachable and populated. Check 3 confirms only `api_v1.*` is in `db-schemas` — everything else (raw tables, internal `marts.*`, secrets) returns 404. Check 4 confirms CORS is open enough for browser apps.
+Check 1 confirms PostgREST is alive and the pinned image is what's actually running. Check 2 confirms the default schema (the first one in `--schemas`) is reachable and populated. Check 3 is the **multi-schema verification**: it walks the full `--schemas` list, fetching the OpenAPI spec under each `Accept-Profile` and asserting each schema has a non-zero path count. **Don't skip this check on a multi-schema instance** — without `Accept-Profile`, root-path probes only verify the *default* schema, which masks broken GRANTs on the other schemas. Check 4 confirms `private_*` schemas (or anything else not in `--schemas`) return 404 even when explicitly requested. Check 5 confirms CORS is open enough for browser apps.
 
 ### Schema reload
 
@@ -136,6 +152,61 @@ Or restart the pods for a clean cycle:
 ```bash
 kubectl rollout restart deployment/<app>-postgrest -n postgrest
 ```
+
+`./uis configure postgrest` automatically issues the NOTIFY at the end of any non-no-op run, so a freshly-configured instance picks up new tables without manual intervention. The kubectl rollout is only needed if you change the **order** of `--schemas` (PostgREST re-parses the env var only at startup; the first schema in the list is the default served when `Accept-Profile` is omitted).
+
+### Reconfigure semantics
+
+`./uis configure postgrest --app <app> --schemas <list>` is the only way to change the schema set served by an instance. The handler is **wipe-and-rewrite**:
+
+1. The list passed via `--schemas` is the complete, ordered set of schemas the instance will expose.
+2. Each non-no-op call drops every grant the `<app>_web_anon` role currently holds in the database (`DROP OWNED BY`), then re-applies `GRANT USAGE` / `GRANT SELECT ON ALL TABLES` / `ALTER DEFAULT PRIVILEGES` for each schema in `--schemas`. All inside a single transaction.
+3. A re-run with the **identical** list (string-equal to the value stored on the secret, order included) is a no-op short-circuit — no SQL fires, no secret is rewritten.
+4. A re-run with a **different** list (added schemas, removed schemas, or just reordered) is a regular reconfigure: the wipe-and-rewrite produces an end state that matches `--schemas` exactly. There's no diff state to manage; the new state is fully determined by the flag value.
+
+This keeps the operator-visible contract simple: *the role's grants are exactly `--schemas`, no more, no less.* No accumulated drift across reconfigures, no stealth `pg_default_acl` entries from removed schemas, no need to track what was previously granted.
+
+The trade-off: any out-of-band `GRANT … TO <app>_web_anon` (e.g., a manual GRANT done from `psql` for debugging) will be wiped on the next configure. See [UIS-managed role contract](#uis-managed-role-contract) below.
+
+### Inspecting the current schema list
+
+The schema list lives on the per-app secret as the `PGRST_DB_SCHEMAS` key. Read it with one kubectl line:
+
+```bash
+kubectl get secret <app>-postgrest -n postgrest \
+    -o jsonpath='{.data.PGRST_DB_SCHEMAS}' | base64 -d
+```
+
+The deploy template reads from this same key via `valueFrom.secretKeyRef`, so what kubectl prints is exactly what PostgREST sees on its next pod startup. (Live PostgREST may be running with a stale value if you reconfigured but haven't rolled out a new pod — `kubectl rollout restart deployment/<app>-postgrest -n postgrest` to refresh.)
+
+### UIS-managed role contract
+
+The `<app>_web_anon` role's privileges are **exclusively UIS-managed**. `./uis configure postgrest --app <app>` is the single source of truth: it wipes and re-applies grants based on `--schemas`. Any manual `GRANT … TO <app>_web_anon` will be lost on the next configure.
+
+If you need an extra grant for debugging or one-off access, prefer:
+- A separate Postgres role (not the UIS-managed pair).
+- An ad-hoc psql session as the `postgres` superuser, scoped to a specific query.
+
+Don't extend the anon role's reach by hand — the configure handler will undo it.
+
+### Upgrading from PLAN-002 single-schema
+
+PLAN-002 shipped a single-schema configure handler with a `--schema` flag. The current multi-schema handler (PLAN-XXX) replaces that with `--schemas` and stores the list on the per-app secret as a new `PGRST_DB_SCHEMAS` key.
+
+If you have a per-app PostgREST instance configured under PLAN-002, the secret has only `PGRST_DB_URI` (no `PGRST_DB_SCHEMAS`). Upgrade in one step:
+
+```bash
+./uis configure postgrest --app <app> --database <app>_db --schemas <list>
+```
+
+This takes the **Reconfigure-preserve-URI** path:
+- The existing `PGRST_DB_URI` is preserved verbatim — password unchanged, no restart needed for credentials.
+- Grants are reset to match `<list>` exactly via `DROP OWNED BY` + per-schema GRANTs.
+- The new `PGRST_DB_SCHEMAS` key is added to the secret.
+
+If `<list>` includes `api_v1` (the PLAN-002 default), the resulting grants on `api_v1` are functionally identical to before. Other schemas in `<list>` get the same `USAGE` + `SELECT` + `DEFAULT PRIVILEGES` treatment.
+
+`--rotate` requires `PGRST_DB_SCHEMAS` to be present on the secret — running it on a PLAN-002-era secret without first running configure with `--schemas` will fail loudly with an explicit "run configure first" error. This is deliberate: rotate is not the upgrade path.
 
 ### Multi-instance coexistence
 
@@ -217,7 +288,7 @@ Atlas does **not** create the `atlas_web_anon` or `atlas_authenticator` roles or
 
 ./uis configure postgrest --app atlas \
     --database atlas_db \
-    --schema api_v1 \
+    --schemas api_v1,marts,raw \
     --url-prefix api-atlas
 ./uis deploy postgrest --app atlas
 ```


### PR DESCRIPTION
## Summary

- Replaces single-schema configure handler from PLAN-002 with multi-schema reconciliation: `./uis configure postgrest --schemas api_v1,marts,raw`. `--schema` (singular) is removed entirely.
- Wipe-and-rewrite via `DROP OWNED BY` + per-schema GRANTs in one transaction; State Matrix dispatch covers five paths (First-time, Reconfigure-preserve-URI, Reconfigure-fresh-password, No-op, Inconsistent). Schema list lives on the per-app secret as `PGRST_DB_SCHEMAS`; deploy template reads via `valueFrom.secretKeyRef`. Configure/deploy drift gone by construction.
- Validated end-to-end against Atlas's real `atlas_db` (13/63/47 tables across api_v1/marts/raw); Atlas confirmed row-flow + privacy boundary (cross-repo talk Message 4). Unblocks PLAN-007 phase 4 frontend rewrite.

## Test plan

- [ ] CI: **Build UIS Container** workflow green (image carries the new handler + tests).
- [ ] CI: **Test UIS Scripts** green (10 static + 22 unit + existing suites pass).
- [ ] CI: **Generate UIS Documentation** green (postgrest.md picks up the new sections).
- [ ] CI: **Deploy Documentation** green (docs publish).
- [ ] After merge: rebuilt `ghcr.io/helpers-no/uis-provision-host:latest` SHA reported back to Atlas via the cross-repo talk thread (per uis Message 1 + atlas Message 4 commitments).

## References

- [INVESTIGATE-postgrest-multi-schema-reconciliation.md](website/docs/ai-developer/plans/backlog/INVESTIGATE-postgrest-multi-schema-reconciliation.md) — five resolutions (R1–R5) and the State Matrix.
- [PLAN-postgrest-multi-schema-reconciliation.md](website/docs/ai-developer/plans/active/PLAN-postgrest-multi-schema-reconciliation.md) — eight phases of execution.
- Atlas cross-repo talk thread — Messages 1–4: design proposal, atlas direction-confirm, uis implementation summary, atlas validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)