### PR TITLE
chore(plans): sync platform-provisioning-layer status with reality

### DIFF
--- a/website/docs/ai-developer/plans/backlog/1PRIORITY.md
+++ b/website/docs/ai-developer/plans/backlog/1PRIORITY.md
@@ -62,7 +62,7 @@ INVESTIGATEs that still live in `backlog/` because their work isn't fully shippe
 
 | # | Investigation | State |
 |---|---|---|
-| — | [platform-provisioning-layer](INVESTIGATE-platform-provisioning-layer.md) | Status: ACTIVE on `feature/platform-aks-opentofu`. AKS Step 1 in progress. |
+| — | [platform-provisioning-layer](INVESTIGATE-platform-provisioning-layer.md) | Status: ACTIVE. AKS Step 1 shipped to main (PR #120, 2026-04-09); Step 2 (ACR + Key Vault) and the other platforms (gke, eks, microk8s-vm/metal/rpi) not started. |
 | — | [remote-deployment-targets](INVESTIGATE-remote-deployment-targets.md) | Status: Investigation Complete. Child PLAN drafting next; do not open as new investigation work. |
 | — | [authentik-user-config](INVESTIGATE-authentik-user-config.md) | Status: Investigation Complete — Ready for PLAN. Child PLAN drafting next. Unblocks #12. |
 

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-platform-provisioning-layer.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-platform-provisioning-layer.md
@@ -5,8 +5,8 @@
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
 **Created**: 2026-04-09
-**Updated**: 2026-04-09
-**Status**: ACTIVE — AKS Step 1 in progress on `feature/platform-aks-opentofu`
+**Updated**: 2026-05-07
+**Status**: ACTIVE — AKS Step 1 shipped to `main` (PR #120, merged 2026-04-09); Step 2 (ACR + Key Vault) and the other platforms (gke, eks, microk8s-vm/metal/rpi) not started.
 
 ---
 
@@ -175,13 +175,15 @@ out. Migration happens platform by platform:
 
 AKS is the first platform. It is being built iteratively:
 
-### Step 1 (current): Minimal working cluster ✅
+### Step 1: Minimal working cluster ✅ Shipped (PR #120, 2026-04-09)
 
 - Resource group
 - AKS cluster (matches original `az aks create` flags)
 - Azure Blob remote state
 - Storage class aliases
 - Traefik via Helm in `02-post-apply.sh`
+
+Code lives in `platforms/aks/`. The `feature/platform-aks-opentofu` branch was merged and is now stale; it can be deleted from origin.
 
 ### Step 2: ACR + Key Vault
 


### PR DESCRIPTION
## Summary

Status drift fix — no code changes, docs only.

The investigation's header read *"AKS Step 1 in progress on `feature/platform-aks-opentofu`"*, but that work shipped via PR #120 on 2026-04-09. `platforms/aks/` is fully present on main and the feature branch was 0 ahead / 67 behind.

- `INVESTIGATE-platform-provisioning-layer.md`: Updated date bumped to today, Status rewritten to call out what's shipped vs what's not, Step 1 marker upgraded from "(current)" to "Shipped (PR #120, 2026-04-09)".
- `1PRIORITY.md` Tier 0 row: re-summarises actual state — Step 1 done, Steps 2-4 + other platforms still untouched.
- Stale `feature/platform-aks-opentofu` branch already deleted from origin in the same pass.

## Test plan

- [x] No code paths touched
- [x] Status header matches reality on disk (`platforms/aks/` exists with full Step 1 layout)
- [x] Tier 0 row in 1PRIORITY.md no longer points at a deleted branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)