### PR TITLE
fix(docs): remove stale links to deleted STATUS-platform-roadmap

### DIFF
--- a/website/blog/2026-03-13-ai-development.md
+++ b/website/blog/2026-03-13-ai-development.md
@@ -89,6 +89,5 @@ The entire AI development workflow is documented and visible on this site:
 - [Creating Plans](/docs/ai-developer/PLANS) — plan templates and structure
 - [Talk Protocol](/docs/ai-developer/TALK) — how the two-session testing works
 - [Plans Overview](/docs/ai-developer/plans-overview) — browse all plans and investigations
-- [Platform Roadmap](/docs/ai-developer/plans/backlog/STATUS-platform-roadmap) — what's next
 
 The plans, investigations, and talk protocol aren't specific to UIS. Any project can use this pattern: plan before you code, test with a fresh perspective, and keep written records of what was built and why.

--- a/website/docs/ai-developer/plans/index.md
+++ b/website/docs/ai-developer/plans/index.md
@@ -23,7 +23,3 @@ Implementation plans and investigations for the UIS platform. Plans follow the w
 | [Active](active/index.md) | Currently being worked on (max 1-2 at a time) |
 | [Backlog](backlog/index.md) | Approved plans and investigations waiting for work |
 | [Completed](completed/index.md) | Done — kept for reference |
-
-## Platform Roadmap
-
-See [STATUS-platform-roadmap.md](backlog/STATUS-platform-roadmap.md) for the prioritized list of open investigations and completed work.


### PR DESCRIPTION
## Summary
- PR #142 removed `STATUS-platform-roadmap.md` as part of its "STATUS removal" cleanup but left two markdown links still pointing at the deleted doc.
- Docusaurus rejects unresolved doc IDs, so every push to main since `909365f` (2026-05-07) has failed the docs build — 5 consecutive failed runs.
- Removes the "Platform Roadmap" section from `plans/index.md` and the matching bullet from `blog/2026-03-13-ai-development.md`. No replacement: the "platform roadmap" concept was retired by PR #142, and `backlog/1PRIORITY.md` explicitly says "triage tool, not a roadmap" — so there is nothing to repoint at.

## Test plan
- [ ] CI: `Generate UIS Documentation` workflow passes on this PR's commit
- [ ] CI: `Deploy Documentation` workflow passes on merge to main
- [ ] `cd website && npm start` — confirm `/docs/ai-developer/plans-overview` renders without the deleted Platform Roadmap section, and the blog post renders without the removed bullet
- [ ] Visual: no other broken links visible on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)