### PR TITLE
AKS follow-ups: F7 cluster-aware deploy, F8 status command, F9 destroy safety

### DIFF
--- a/ansible/playbooks/020-setup-nginx.yml
+++ b/ansible/playbooks/020-setup-nginx.yml
@@ -161,24 +161,53 @@
       ansible.builtin.debug:
         var: ingressroute_check.stdout_lines
 
+    # F7 from talk45: the "To test" hint must be cluster-aware. On rancher-desktop
+    # Traefik responds on localhost; on AKS/GKE/EKS the external LB IP is the
+    # right address and the user needs a curl --resolve hint for hostname-based
+    # routes. Look up the Traefik LoadBalancer IP best-effort (same lookup as
+    # platforms/azure-aks/scripts/02-post-apply.sh:147), then branch the banner.
+    - name: 18b. Look up Traefik LoadBalancer external IP (best effort)
+      ansible.builtin.shell: |
+        kubectl get svc traefik -n kube-system --context {{ kube_context }} \
+          -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: traefik_lb_ip
+      changed_when: false
+      failed_when: false
+
     - name: 19. Success message
       ansible.builtin.debug:
         msg: |
           NGINX SETUP COMPLETE
-          
+
           Pod name: {{ nginx_pod.stdout }}
-          Service endpoint: {{ nginx_endpoint.stdout }}
+          Cluster: {{ kube_context }}
+          Internal endpoint: {{ nginx_endpoint.stdout }} (in-cluster ClusterIP — not externally reachable)
           IngressRoute: nginx-root-catch-all (catch-all routing with priority 1)
-          
+
           Nginx is now running and serving the web content from the PVC.
           The IngressRoute follows cluster ingress standards (traefik.io/v1alpha1).
-          
+
           Routing behavior:
           - Specific domain routes (like whoami.localhost) take precedence
           - Catch-all routing serves nginx content for unmatched requests
-          
-          To test:
+
+          {% if kube_context == 'rancher-desktop' %}
+          To test (rancher-desktop / local):
           curl http://[any-undefined-domain].localhost  # Should show nginx content
+          # or open http://nginx.localhost/ in a browser
+          {% elif traefik_lb_ip.stdout | trim | length > 0 %}
+          To test ({{ kube_context }}, Traefik LoadBalancer at {{ traefik_lb_ip.stdout | trim }}):
+          curl http://{{ traefik_lb_ip.stdout | trim }}/                                    # catch-all → nginx
+          curl --resolve nginx.localhost:80:{{ traefik_lb_ip.stdout | trim }} http://nginx.localhost/   # hostname-routed → nginx
+          # or open http://{{ traefik_lb_ip.stdout | trim }}/ in a browser
+          {% else %}
+          To test ({{ kube_context }}):
+          # Traefik LoadBalancer IP not yet provisioned. Check with:
+          kubectl get svc traefik -n kube-system --context {{ kube_context }}
+          # Once an external IP is assigned, hit: curl http://<external-ip>/
+          {% endif %}
           
           To reload the website content without redeploying Nginx:
           ansible-playbook playbooks/020-setup-web-files.yml -e kube_context={{ kube_context }}

--- a/platforms/azure-aks/scripts/02-post-apply.sh
+++ b/platforms/azure-aks/scripts/02-post-apply.sh
@@ -178,4 +178,5 @@ echo "  ./uis deploy <service>"
 echo "  ./uis stack install <stack>"
 echo
 echo "Manage cluster:"
-echo "  ./platforms/azure-aks/scripts/03-destroy.sh       # tear down"
+echo "  uis platform status azure-aks                     # state, external IP, cost"
+echo "  uis platform down   azure-aks                     # tear down"

--- a/platforms/azure-aks/scripts/03-destroy.sh
+++ b/platforms/azure-aks/scripts/03-destroy.sh
@@ -109,7 +109,10 @@ else
 fi
 if [[ "$typed" != "$AZURE_AKS_CLUSTER_NAME" ]]; then
     print_warning "Name did not match — aborted"
-    exit 0
+    # Exit non-zero so callers (especially `uis platform down`) know the
+    # destroy did NOT happen and can show the correct "aborted" banner instead
+    # of a false "✓ destroyed" success message (F9 from talk45).
+    exit 1
 fi
 
 # ─── Azure login ──────────────────────────────────────────────────────────────

--- a/platforms/azure-aks/scripts/down.sh
+++ b/platforms/azure-aks/scripts/down.sh
@@ -50,9 +50,22 @@ echo
 
 # ----- Delegate to 03-destroy.sh -----
 # It owns the typed-name confirmation prompt + UIS_DESTROY_CONFIRM env-var
-# escape hatch for non-interactive flows. Not exec'd because we want to
-# print the config-preservation pointer below on success.
-"$SCRIPT_DIR/03-destroy.sh"
+# escape hatch for non-interactive flows. Defensive: explicit if-check on the
+# exit code so the success banner below cannot fire if the inner script
+# aborted (F9 from talk45 — wrapper had been falsely claiming '✓ destroyed'
+# when the user mistyped the cluster name and 03-destroy.sh bailed).
+if ! "$SCRIPT_DIR/03-destroy.sh"; then
+    echo
+    echo "═══════════════════════════════════════════════════════════"
+    echo " ✗ Tear-down aborted or failed"
+    echo "═══════════════════════════════════════════════════════════"
+    echo "  The AKS cluster may still be running and incurring cost."
+    echo "  Check current state with:"
+    echo "    az aks list -o table"
+    echo "  Re-run when ready:"
+    echo "    uis platform down azure-aks"
+    exit 1
+fi
 
 # ----- Summary (Q12 — config preservation) -----
 echo

--- a/platforms/azure-aks/scripts/status.sh
+++ b/platforms/azure-aks/scripts/status.sh
@@ -21,6 +21,13 @@ if [[ ! -f "$ENV_FILE" ]]; then
     exit 1
 fi
 
+# ----- Preflight: az is required (kubectl is best-effort below) -----
+if ! command -v az >/dev/null 2>&1; then
+    echo "✗ Azure CLI (az) is required for 'uis platform status azure-aks'." >&2
+    echo "  Run 'uis tools install azure-aks' to install it." >&2
+    exit 1
+fi
+
 set -a
 # shellcheck source=/dev/null
 source "$ENV_FILE"

--- a/platforms/azure-aks/scripts/status.sh
+++ b/platforms/azure-aks/scripts/status.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# status.sh — Show AKS cluster status, cost, and quick actions.
+#
+# Spec: F8 from talk45 — "is the meter running, and how much will this cost
+# me overnight?" is the headline novice question after `uis platform up`.
+# This script answers it in one command.
+#
+# Entry point: uis platform status azure-aks
+
+set -euo pipefail
+
+# ----- Resolve paths -----
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${UIS_REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+ENV_FILE="$REPO_ROOT/.uis.secrets/cloud-accounts/azure-default.env"
+
+# ----- Refuse with pointer if env missing (consistent with up/down) -----
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "✗ No config file found at $ENV_FILE" >&2
+    echo "  Run 'uis platform init azure-aks' first to set one up." >&2
+    exit 1
+fi
+
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+# Defensive fallbacks (mirror 00-bootstrap-state.sh / 01-apply.sh / 03-destroy.sh)
+if [[ -z "${AZURE_STATE_STORAGE_ACCOUNT:-}" ]]; then
+    _stripped_sub="${AZURE_SUBSCRIPTION_ID//-/}"
+    AZURE_STATE_STORAGE_ACCOUNT="sa${_stripped_sub:0:16}tf"
+    unset _stripped_sub
+fi
+AZURE_AKS_LOCATION="${AZURE_AKS_LOCATION:-${AZURE_REGION:-westeurope}}"
+CLUSTER_NAME="${AZURE_AKS_CLUSTER_NAME:-azure-aks}"
+RG="${AZURE_AKS_RESOURCE_GROUP:-rg-urbalurba-aks-weu}"
+
+# Make subsequent az calls target the right subscription
+az account set --subscription "$AZURE_SUBSCRIPTION_ID" >/dev/null
+
+
+# ----- Cost helpers ------------------------------------------------------------
+# Daily EUR estimate for AKS-eligible VM sizes in westeurope (rough on-demand
+# rounding; update if Azure pricing shifts materially). Unknown sizes → "?".
+_node_daily_eur() {
+    case "$1" in
+        Standard_B2s_v2)   echo "0.85" ;;
+        Standard_B2ms)     echo "0.95" ;;
+        Standard_B4ms)     echo "1.90" ;;
+        Standard_D2s_v3)   echo "1.20" ;;
+        Standard_D2s_v5)   echo "1.10" ;;
+        Standard_D4s_v5)   echo "2.20" ;;
+        *)                 echo "?"    ;;
+    esac
+}
+
+# Per-day fixed overhead (rough): public IP + LB rule 1 + managed disks
+_FIXED_DAILY_EUR="0.15"
+
+# Convert ISO8601 (e.g. 2026-05-11T07:12:00Z) → seconds-since-epoch in a way
+# that works on both GNU date (Linux container) and BSD date (macOS host, in
+# case anyone ever sources this on the host).
+_iso_to_epoch() {
+    local iso="${1%.*}"     # strip fractional seconds if present
+    iso="${iso%Z}Z"          # ensure trailing Z
+    local epoch
+    epoch=$(date -u -d "$iso" +%s 2>/dev/null) \
+        || epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) \
+        || epoch=0
+    echo "$epoch"
+}
+
+_format_age() {
+    local then_ts now_ts diff
+    then_ts=$(_iso_to_epoch "$1")
+    [[ "$then_ts" -eq 0 ]] && { echo "unknown"; return; }
+    now_ts=$(date -u +%s)
+    diff=$((now_ts - then_ts))
+    if   (( diff < 60 ));    then echo "${diff}s ago"
+    elif (( diff < 3600 ));  then echo "$((diff / 60)) min ago"
+    elif (( diff < 86400 )); then printf "%dh %dm ago\n" $((diff / 3600)) $(((diff % 3600) / 60))
+    else                          printf "%dd %dh ago\n" $((diff / 86400)) $(((diff % 86400) / 3600))
+    fi
+}
+
+_estimate_spent() {
+    # $1: daily EUR (or "?"); $2: ISO timestamp
+    [[ "$1" == "?" ]] && { echo "?"; return; }
+    local then_ts now_ts seconds
+    then_ts=$(_iso_to_epoch "$2")
+    [[ "$then_ts" -eq 0 ]] && { echo "?"; return; }
+    now_ts=$(date -u +%s)
+    seconds=$((now_ts - then_ts))
+    awk -v daily="$1" -v secs="$seconds" 'BEGIN { printf "%.2f", daily * secs / 86400 }'
+}
+
+
+# ----- Render: cluster not provisioned -----------------------------------------
+if ! az aks show -g "$RG" -n "$CLUSTER_NAME" >/dev/null 2>&1; then
+    echo "═══════════════════════════════════════════════════════════"
+    echo " AKS cluster status"
+    echo " (uis platform status azure-aks)"
+    echo "═══════════════════════════════════════════════════════════"
+    echo
+    echo "  Cluster:        $CLUSTER_NAME  (configured but not provisioned)"
+    echo "  Region:         $AZURE_AKS_LOCATION"
+    echo "  Subscription:   $AZURE_SUBSCRIPTION_ID"
+    echo "  Cost:           €0/day  (no Azure resources running)"
+    echo
+    echo "  Bring it up:    uis platform up azure-aks"
+    exit 0
+fi
+
+
+# ----- Pull cluster facts ------------------------------------------------------
+# Single az call, multi-projection via JMESPath. Returns tab-separated values.
+_facts=$(az aks show -g "$RG" -n "$CLUSTER_NAME" \
+    --query "[provisioningState, kubernetesVersion, agentPoolProfiles[0].vmSize, agentPoolProfiles[0].count, systemData.createdAt]" \
+    -o tsv 2>/dev/null)
+IFS=$'\t' read -r STATE K8S NODE_SIZE NODE_COUNT CREATED <<<"$_facts"
+CREATED="${CREATED:-unknown}"
+
+
+# ----- Look up Traefik external IP (best effort) -------------------------------
+# Matches the kube-system/traefik install from 02-post-apply.sh:147.
+EXT_IP=""
+if kubectl get svc traefik -n kube-system >/dev/null 2>&1; then
+    EXT_IP=$(kubectl get svc traefik -n kube-system \
+        -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
+fi
+EXT_IP="${EXT_IP:-not yet provisioned}"
+
+
+# ----- Cost math ---------------------------------------------------------------
+NODE_DAILY=$(_node_daily_eur "$NODE_SIZE")
+if [[ "$NODE_DAILY" == "?" ]]; then
+    EST_DAILY="?"
+    SPENT="?"
+else
+    EST_DAILY=$(awk -v n="$NODE_DAILY" -v c="$NODE_COUNT" -v f="$_FIXED_DAILY_EUR" \
+        'BEGIN { printf "%.2f", n * c + f }')
+    SPENT=$(_estimate_spent "$EST_DAILY" "$CREATED")
+fi
+AGE=$(_format_age "$CREATED")
+
+
+# ----- Render: full status -----------------------------------------------------
+echo "═══════════════════════════════════════════════════════════"
+echo " AKS cluster status"
+echo " (uis platform status azure-aks)"
+echo "═══════════════════════════════════════════════════════════"
+echo
+echo "  Cluster:        $CLUSTER_NAME  ($STATE, k8s $K8S)"
+echo "  Region:         $AZURE_AKS_LOCATION"
+echo "  Subscription:   $AZURE_SUBSCRIPTION_ID"
+echo "  Node pool:      ${NODE_COUNT}× $NODE_SIZE"
+echo "  External IP:    $EXT_IP"
+if [[ "$CREATED" != "unknown" ]]; then
+    echo "  Running since:  $CREATED ($AGE)"
+fi
+echo "  Est. daily:     ~€${EST_DAILY}/day  (${NODE_COUNT}× $NODE_SIZE + IP/LB/disk overhead)"
+echo "  Spent so far:   ~€${SPENT}"
+echo
+echo "  Tear down:      uis platform down azure-aks"

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -115,9 +115,10 @@ Tools:
   tools install <tool>    Install an optional tool
 
 Platform:
-  platform init <provider>    Interactive setup wizard for a cloud platform (e.g. azure-aks)
-  platform up   <provider>    Provision the cluster end-to-end (bootstrap + apply + post-apply)
-  platform down <provider>    Tear down the cluster (delegates to 03-destroy.sh)
+  platform init   <provider>  Interactive setup wizard for a cloud platform (e.g. azure-aks)
+  platform up     <provider>  Provision the cluster end-to-end (bootstrap + apply + post-apply)
+  platform status <provider>  Show cluster state, external IP, and cost estimate
+  platform down   <provider>  Tear down the cluster (delegates to 03-destroy.sh)
 
 Tailscale:
   tailscale expose <service>    Expose a service via Tailscale Funnel
@@ -861,17 +862,20 @@ cmd_platform() {
         up)
             cmd_platform_up "$@"
             ;;
+        status)
+            cmd_platform_status "$@"
+            ;;
         down)
             cmd_platform_down "$@"
             ;;
         "")
             log_error "Usage: uis platform <subcmd> <provider>"
-            echo "Subcommands: init | up | down" >&2
+            echo "Subcommands: init | up | status | down" >&2
             exit "$EXIT_GENERAL_ERROR"
             ;;
         *)
             log_error "Unknown platform subcommand: $subcmd"
-            echo "Usage: uis platform [init|up|down] <provider>" >&2
+            echo "Usage: uis platform [init|up|status|down] <provider>" >&2
             exit "$EXIT_GENERAL_ERROR"
             ;;
     esac
@@ -962,6 +966,31 @@ cmd_platform_down() {
     if [[ ! -f "$script" ]]; then
         log_error "Platform '$provider' has no down.sh (looked at $script)"
         { _list_available_platforms_with_script down.sh "$repo_root"; } >&2
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+
+    export UIS_REPO_ROOT="$repo_root"
+    exec "$script"
+}
+
+# cmd_platform_status — same shape as cmd_platform_up/down. The per-platform
+# status.sh answers "is the cluster running and how much is it costing me?"
+# in a single command (F8 from talk45).
+cmd_platform_status() {
+    local provider="${1:-}"
+    local repo_root
+    repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+    if [[ -z "$provider" ]]; then
+        log_error "Usage: uis platform status <provider>"
+        { _list_available_platforms_with_script status.sh "$repo_root"; } >&2
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+
+    local script="$repo_root/platforms/$provider/scripts/status.sh"
+    if [[ ! -f "$script" ]]; then
+        log_error "Platform '$provider' has no status.sh (looked at $script)"
+        { _list_available_platforms_with_script status.sh "$repo_root"; } >&2
         exit "$EXIT_GENERAL_ERROR"
     fi
 


### PR DESCRIPTION
## Summary
Five follow-up fixes from talk45 testing of the AKS novice flow:

- **F9 (safety)** — `uis platform down azure-aks` falsely printed "✓ destroyed" when `03-destroy.sh` aborted on a name-mismatch. `03-destroy.sh` exited 0 on mismatch, and the wrapper had no exit-code check. Now `03-destroy.sh` returns 1 on mismatch, and the wrapper explicitly branches on it, printing an "✗ aborted — cluster may still be running" message with recovery hints.
- **F8 (UX)** — new `uis platform status azure-aks` answers the headline novice question after `up`: "is the meter running, and how much will this cost me overnight?" Renders cluster state, external IP, age, estimated daily €, and spent-so-far in one command. Friendly preflight when `az` or the config file is missing.
- **F7 (UX)** — `./uis deploy nginx` success banner is now cluster-aware. On `rancher-desktop` it points at `*.localhost`; on AKS (or any cluster with a Traefik LoadBalancer IP) it shows the actual external IP plus a `curl --resolve` hint for hostname-routed services. Also clarifies that the internal ClusterIP printed by step 12 is in-cluster only.
- **Cosmetic** — `02-post-apply.sh` "Manage cluster" hint now uses the wrapper commands (`uis platform status azure-aks` / `uis platform down azure-aks`) instead of the legacy script paths.
- **status.sh preflight** — refuse with a pointer at `uis tools install azure-aks` if `az` isn't on PATH, matching init/up/down.

## Test plan
- [x] F9 verified locally: `03-destroy.sh` with mismatched typed name now exits 1; wrapper's if-check fires
- [x] F8 verified locally: env-missing branch shows init pointer; env-present + no `az` shows tools-install pointer
- [x] F7 verified via Jinja conditionals around `kube_context` and Traefik LB IP lookup
- [x] Image rebuilt locally and smoke-tested
- [ ] Tester to verify post-CI against `:latest` (no novice path regression; new `status` command renders correctly mid-cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)