### PR TITLE
fix(status): full-panel data + login preflight (F10/F11/F12) + bootstrap no-TTY (F13)

### DIFF
--- a/.github/workflows/build-uis-container.yml
+++ b/.github/workflows/build-uis-container.yml
@@ -20,6 +20,7 @@ on:
       - 'cloud-init/**'
       - 'networking/**'
       - 'provision-host/**'
+      - 'platforms/**'
       - 'scripts/**'
       - 'provision-host/uis/templates/**'
       - 'Dockerfile.uis-provision-host'

--- a/platforms/azure-aks/scripts/00-bootstrap-state.sh
+++ b/platforms/azure-aks/scripts/00-bootstrap-state.sh
@@ -92,8 +92,12 @@ if [[ "${UIS_NONINTERACTIVE:-0}" == "1" ]]; then
 elif [[ -t 0 ]]; then
     read -p "Continue? (y/N): " confirm
 else
-    # No TTY — read from piped stdin (e.g. `printf 'y\n' | docker exec -i …`)
-    read -r confirm
+    # No TTY — read from piped stdin (e.g. `printf 'y\n' | docker exec -i …`).
+    # `|| confirm=""` is load-bearing: with `set -euo pipefail`, a bare
+    # `read -r` on closed stdin (no `-i` and no env var) exits 1 *before*
+    # the friendly "Aborted" line below ever runs, leaving the user staring
+    # at a silent exit-1.
+    read -r confirm || confirm=""
 fi
 [[ "${confirm,,}" != "y" ]] && { print_warning "Aborted"; exit 0; }
 

--- a/platforms/azure-aks/scripts/status.sh
+++ b/platforms/azure-aks/scripts/status.sh
@@ -43,6 +43,16 @@ AZURE_AKS_LOCATION="${AZURE_AKS_LOCATION:-${AZURE_REGION:-westeurope}}"
 CLUSTER_NAME="${AZURE_AKS_CLUSTER_NAME:-azure-aks}"
 RG="${AZURE_AKS_RESOURCE_GROUP:-rg-urbalurba-aks-weu}"
 
+# F10 — Preflight: must be logged in. The R0 testing protocol (./uis pull &&
+# docker rm && ./uis start) wipes ~/.azure, so this is the first thing the
+# user hits after every image refresh. Without it, `az account set` errors
+# with a misleading "subscription doesn't exist in cloud 'AzureCloud'".
+if ! az account show >/dev/null 2>&1; then
+    echo "✗ Not signed in to Azure." >&2
+    echo "  Run 'az login' (or re-run 'uis platform init azure-aks') first." >&2
+    exit 1
+fi
+
 # Make subsequent az calls target the right subscription
 az account set --subscription "$AZURE_SUBSCRIPTION_ID" >/dev/null
 
@@ -121,19 +131,37 @@ fi
 
 
 # ----- Pull cluster facts ------------------------------------------------------
-# Single az call, multi-projection via JMESPath. Returns tab-separated values.
-_facts=$(az aks show -g "$RG" -n "$CLUSTER_NAME" \
+# Single az call, multi-projection via JMESPath. `-o tsv` over an array
+# projection emits one value per LINE (not tab-separated despite the name),
+# so we read with mapfile and index by position.
+mapfile -t _facts < <(az aks show -g "$RG" -n "$CLUSTER_NAME" \
     --query "[provisioningState, kubernetesVersion, agentPoolProfiles[0].vmSize, agentPoolProfiles[0].count, systemData.createdAt]" \
     -o tsv 2>/dev/null)
-IFS=$'\t' read -r STATE K8S NODE_SIZE NODE_COUNT CREATED <<<"$_facts"
+STATE="${_facts[0]:-}"
+K8S="${_facts[1]:-}"
+NODE_SIZE="${_facts[2]:-}"
+NODE_COUNT="${_facts[3]:-}"
+CREATED="${_facts[4]:-}"
+# az renders JSON null as literal "None" in TSV — coerce to empty so the
+# downstream `unknown` fallback fires and the `Running since:` line is
+# correctly suppressed.
+[[ "$CREATED" == "None" ]] && CREATED=""
 CREATED="${CREATED:-unknown}"
 
 
 # ----- Look up Traefik external IP (best effort) -------------------------------
-# Matches the kube-system/traefik install from 02-post-apply.sh:147.
+# Matches the kube-system/traefik install from 02-post-apply.sh:147. Must
+# explicitly target the UIS merged kubeconfig + the AKS context — otherwise
+# kubectl falls through to ~/.kube/config (bind-mounted from the host, only
+# contains rancher-desktop) and silently returns rancher-desktop's k3s
+# Traefik IP because the service names happen to collide.
 EXT_IP=""
-if kubectl get svc traefik -n kube-system >/dev/null 2>&1; then
-    EXT_IP=$(kubectl get svc traefik -n kube-system \
+_kubeconfig="${UIS_KUBECONFIG:-/mnt/urbalurbadisk/kubeconfig/kubeconf-all}"
+if [[ -f "$_kubeconfig" ]] && \
+   KUBECONFIG="$_kubeconfig" kubectl --context "$CLUSTER_NAME" \
+       get svc traefik -n kube-system >/dev/null 2>&1; then
+    EXT_IP=$(KUBECONFIG="$_kubeconfig" kubectl --context "$CLUSTER_NAME" \
+        get svc traefik -n kube-system \
         -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
 fi
 EXT_IP="${EXT_IP:-not yet provisioned}"


### PR DESCRIPTION
## Summary
Four findings from talk46 Tier 2. The PR #157 spec'd fixes all passed; these are bugs the brief didn't reach until R3 actually had a live AKS cluster.

- **F10** — `status.sh` missing "az logged-in" preflight. The R0 testing protocol (`./uis pull && docker rm && ./uis start`) wipes `~/.azure`, so the first `uis platform status azure-aks` after every image refresh errors with the misleading `subscription doesn't exist in cloud 'AzureCloud'` message from `az account set`. New `az account show` preflight refuses with a pointer to `az login` or `uis platform init azure-aks`.
- **F11** — `az aks show -o tsv` over an array projection emits values **newline-separated** (despite the format name), not tab-separated. Old `IFS=$'\t' read -r ...` captured only `STATE`; k8s version, vmSize, count, createdAt all empty. Switched to `mapfile -t`. Also coerce `None` (az's TSV rendering of JSON null on `systemData.createdAt`) to empty so the existing `unknown` fallback fires.
- **F12** — `kubectl get svc traefik` had no `KUBECONFIG` and no `--context`, so it fell through to the host's bind-mounted `~/.kube/config` (only contains `rancher-desktop`). The k3s install there also has a `traefik` in `kube-system`, so the call silently returned `192.168.64.2` instead of the real AKS LB. Now explicitly targets `/mnt/urbalurbadisk/kubeconfig/kubeconf-all` + `--context "$CLUSTER_NAME"`.
- **F13** — `00-bootstrap-state.sh:96` `read -r confirm` on closed stdin under `set -euo pipefail` exits 1 before the friendly `Aborted` line. Only bites no-TTY automation that also forgot `UIS_NONINTERACTIVE=1`. Trivial `|| confirm=""` guard.

## Test plan
- [x] Smoke-tested locally (`uis-provision-host:local`):
  - env-missing → init pointer, exit 1
  - az-missing → tools-install pointer, exit 1
  - **F10** not-logged-in (after `uis tools install azure-aks`, no `az login`) → `az login` pointer, exit 1
  - logged-in + no cluster → "configured but not provisioned" + `Cost: €0/day`, exit 0 (also exercises F11's mapfile read path syntactically)
- [ ] Tester to verify F11 (data correctness — k8s version, node pool, age) and F12 (real AKS LB IP) against a live cluster in talk47 Tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)