### PR TITLE
fix(aks): novice-output polish — F14 + path display + ./uis consistency

### DIFF
--- a/platforms/azure-aks/scripts/01-apply.sh
+++ b/platforms/azure-aks/scripts/01-apply.sh
@@ -192,8 +192,14 @@ if [[ "${UIS_NONINTERACTIVE:-0}" == "1" ]]; then
 elif [[ -t 0 ]]; then
     read -p "Review the plan above. Apply? (y/N): " confirm
 else
-    # No TTY — read from piped stdin (e.g. `printf 'y\n' | docker exec -i …`)
-    read -r confirm
+    # No TTY — read from piped stdin (e.g. `printf 'y\n' | docker exec -i …`).
+    # `|| confirm=""` is load-bearing: with `set -euo pipefail`, a bare
+    # `read -r` on closed stdin (no `-i` and no env var) exits 1 *before*
+    # the friendly "Aborted" line below ever runs. This bites the chained
+    # `uis platform up azure-aks` flow when bootstrap consumes the first
+    # piped `y` and apply then sees EOF — exact F14 from talk47. Same
+    # shape as the F13 fix in 00-bootstrap-state.sh.
+    read -r confirm || confirm=""
 fi
 [[ "${confirm,,}" != "y" ]] && { print_warning "Aborted — no changes made"; exit 0; }
 

--- a/platforms/azure-aks/scripts/02-post-apply.sh
+++ b/platforms/azure-aks/scripts/02-post-apply.sh
@@ -178,5 +178,5 @@ echo "  ./uis deploy <service>"
 echo "  ./uis stack install <stack>"
 echo
 echo "Manage cluster:"
-echo "  uis platform status azure-aks                     # state, external IP, cost"
-echo "  uis platform down   azure-aks                     # tear down"
+echo "  ./uis platform status azure-aks                   # state, external IP, cost"
+echo "  ./uis platform down   azure-aks                   # tear down"

--- a/platforms/azure-aks/scripts/03-destroy.sh
+++ b/platforms/azure-aks/scripts/03-destroy.sh
@@ -211,4 +211,4 @@ echo
 echo "💰 Estimated savings: ~€1/day (${AZURE_AKS_NODE_SIZE} x $AZURE_AKS_NODE_COUNT)"
 echo
 echo "To recreate the cluster:"
-echo "  uis platform up azure-aks"
+echo "  ./uis platform up azure-aks"

--- a/platforms/azure-aks/scripts/down.sh
+++ b/platforms/azure-aks/scripts/down.sh
@@ -23,7 +23,7 @@ ENV_FILE="$REPO_ROOT/.uis.secrets/cloud-accounts/azure-default.env"
 
 # ----- Refuse with a pointer if there's no config -----
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "✗ No config file found at $ENV_FILE" >&2
+    echo "✗ No config file found at ${ENV_FILE#$REPO_ROOT/}" >&2
     echo "  No AKS cluster appears to be configured. Nothing to tear down." >&2
     echo "  (If you have a cluster from a manual run, fall back to" >&2
     echo "  './platforms/azure-aks/scripts/03-destroy.sh' directly.)" >&2
@@ -63,20 +63,23 @@ if ! "$SCRIPT_DIR/03-destroy.sh"; then
     echo "  Check current state with:"
     echo "    az aks list -o table"
     echo "  Re-run when ready:"
-    echo "    uis platform down azure-aks"
+    echo "    ./uis platform down azure-aks"
     exit 1
 fi
 
 # ----- Summary (Q12 — config preservation) -----
+# Display env path as host-relative (same file via the bind mount — the
+# /mnt/urbalurbadisk/ prefix is in-container noise for the novice).
+ENV_FILE_DISPLAY="${ENV_FILE#$REPO_ROOT/}"
 echo
 echo "═══════════════════════════════════════════════════════════"
 echo " ✓ AKS cluster destroyed"
 echo "═══════════════════════════════════════════════════════════"
 echo "  Cluster cost stopped. The config file is preserved:"
-echo "    $ENV_FILE"
+echo "    $ENV_FILE_DISPLAY"
 echo
 echo "  To recreate the cluster with the same subscription + region:"
-echo "    uis platform up azure-aks"
+echo "    ./uis platform up azure-aks"
 echo
 echo "  To fully reset (e.g. before switching tenants), delete the file:"
-echo "    rm $ENV_FILE"
+echo "    rm $ENV_FILE_DISPLAY"

--- a/platforms/azure-aks/scripts/init.sh
+++ b/platforms/azure-aks/scripts/init.sh
@@ -50,6 +50,11 @@ register_providers              # block until all four Registered (Q6)
 write_env_atomically "$ENV_FILE"
 
 # ----- Summary -----
+# Show the env file as a host-relative path (the user runs `./uis` from their
+# repo root, so `.uis.secrets/...` is what they'd `cat` or `ls`). The bind
+# mount means the in-container `/mnt/urbalurbadisk/.uis.secrets/...` is the
+# *same file* — but displaying the container prefix to a novice on the host
+# side is just noise.
 echo
 echo "═══════════════════════════════════════════════════════════"
 echo " ✓ AKS setup ready"
@@ -58,6 +63,6 @@ echo "  Subscription: $AZURE_SUBSCRIPTION_NAME"
 echo "                ($AZURE_SUBSCRIPTION_ID)"
 echo "  Tenant:       $AZURE_TENANT_ID"
 echo "  Region:       $AZURE_REGION"
-echo "  Config:       $ENV_FILE"
+echo "  Config:       ${ENV_FILE#$REPO_ROOT/}"
 echo
-echo "Next: uis platform up azure-aks"
+echo "Next: ./uis platform up azure-aks"

--- a/platforms/azure-aks/scripts/status.sh
+++ b/platforms/azure-aks/scripts/status.sh
@@ -16,15 +16,15 @@ ENV_FILE="$REPO_ROOT/.uis.secrets/cloud-accounts/azure-default.env"
 
 # ----- Refuse with pointer if env missing (consistent with up/down) -----
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "✗ No config file found at $ENV_FILE" >&2
-    echo "  Run 'uis platform init azure-aks' first to set one up." >&2
+    echo "✗ No config file found at ${ENV_FILE#$REPO_ROOT/}" >&2
+    echo "  Run './uis platform init azure-aks' first to set one up." >&2
     exit 1
 fi
 
 # ----- Preflight: az is required (kubectl is best-effort below) -----
 if ! command -v az >/dev/null 2>&1; then
-    echo "✗ Azure CLI (az) is required for 'uis platform status azure-aks'." >&2
-    echo "  Run 'uis tools install azure-aks' to install it." >&2
+    echo "✗ Azure CLI (az) is required for './uis platform status azure-aks'." >&2
+    echo "  Run './uis tools install azure-aks' to install it." >&2
     exit 1
 fi
 
@@ -49,7 +49,7 @@ RG="${AZURE_AKS_RESOURCE_GROUP:-rg-urbalurba-aks-weu}"
 # with a misleading "subscription doesn't exist in cloud 'AzureCloud'".
 if ! az account show >/dev/null 2>&1; then
     echo "✗ Not signed in to Azure." >&2
-    echo "  Run 'az login' (or re-run 'uis platform init azure-aks') first." >&2
+    echo "  Run 'az login' (or re-run './uis platform init azure-aks') first." >&2
     exit 1
 fi
 
@@ -125,7 +125,7 @@ if ! az aks show -g "$RG" -n "$CLUSTER_NAME" >/dev/null 2>&1; then
     echo "  Subscription:   $AZURE_SUBSCRIPTION_ID"
     echo "  Cost:           €0/day  (no Azure resources running)"
     echo
-    echo "  Bring it up:    uis platform up azure-aks"
+    echo "  Bring it up:    ./uis platform up azure-aks"
     exit 0
 fi
 
@@ -197,4 +197,4 @@ fi
 echo "  Est. daily:     ~€${EST_DAILY}/day  (${NODE_COUNT}× $NODE_SIZE + IP/LB/disk overhead)"
 echo "  Spent so far:   ~€${SPENT}"
 echo
-echo "  Tear down:      uis platform down azure-aks"
+echo "  Tear down:      ./uis platform down azure-aks"

--- a/platforms/azure-aks/scripts/up.sh
+++ b/platforms/azure-aks/scripts/up.sh
@@ -21,8 +21,8 @@ ENV_FILE="$REPO_ROOT/.uis.secrets/cloud-accounts/azure-default.env"
 
 # ----- Q11: refuse with a pointer if init has not been run -----
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "✗ No config file found at $ENV_FILE" >&2
-    echo "  Run 'uis platform init azure-aks' first to set one up." >&2
+    echo "✗ No config file found at ${ENV_FILE#$REPO_ROOT/}" >&2
+    echo "  Run './uis platform init azure-aks' first to set one up." >&2
     exit 1
 fi
 
@@ -41,7 +41,7 @@ echo " Region:       ${AZURE_REGION:-unset}"
 echo "═══════════════════════════════════════════════════════════"
 echo
 echo "⚠  This will create or update Azure resources and may incur cost (~€1/day)."
-echo "   Run 'uis platform down azure-aks' to tear down when finished."
+echo "   Run './uis platform down azure-aks' to tear down when finished."
 echo
 
 # ----- 1/3 Bootstrap remote tofu state -----
@@ -64,6 +64,6 @@ echo "════════════════════════�
 echo " ✓ AKS cluster is up"
 echo "═══════════════════════════════════════════════════════════"
 echo "  Try: kubectl get nodes"
-echo "       uis deploy nginx"
+echo "       ./uis deploy nginx"
 echo
-echo "  Tear down: uis platform down azure-aks"
+echo "  Tear down: ./uis platform down azure-aks"

--- a/provision-host/uis/lib/azure-discovery.sh
+++ b/provision-host/uis/lib/azure-discovery.sh
@@ -33,7 +33,7 @@ require_tools_or_die() {
     command -v tofu >/dev/null 2>&1 || missing+=("opentofu")
     if (( ${#missing[@]} > 0 )); then
         echo "✗ Missing required tool(s): ${missing[*]}"
-        echo "  Run 'uis tools install azure-aks' to install the AKS dependencies."
+        echo "  Run './uis tools install azure-aks' to install the AKS dependencies."
         exit 1
     fi
 }
@@ -47,9 +47,8 @@ require_interactive_or_die() {
     if [[ -n "${UIS_NONINTERACTIVE:-}" ]] || [[ ! -t 0 ]]; then
         echo "✗ This wizard requires an interactive terminal."
         if [[ -n "${UIS_NONINTERACTIVE:-}" ]]; then
-            echo "  UIS_NONINTERACTIVE is set, but uis platform init does not yet support"
-            echo "  non-interactive mode. (See Q5 in INVESTIGATE-aks-novice-onboarding.md."
-            echo "  Non-interactive mode lands when a real CI/scripted consumer surfaces.)"
+            echo "  UIS_NONINTERACTIVE is set, but './uis platform init' does not yet support"
+            echo "  non-interactive mode."
         else
             echo "  No TTY attached to stdin. Run this command directly from your terminal,"
             echo "  not via 'docker exec' without -it or piped from a script."
@@ -209,7 +208,7 @@ check_owner_or_contributor() {
     echo "✗ Role check failed after 3 attempts. Aborting."
     echo "  Either pick a different subscription, request a role assignment,"
     echo "  or activate Owner/Contributor via the PIM link above and re-run"
-    echo "  'uis platform init azure-aks'."
+    echo "  './uis platform init azure-aks'."
     exit 1
 }
 
@@ -284,7 +283,7 @@ check_quota() {
         echo
         echo "  Request a quota increase here:"
         echo "  https://portal.azure.com/#view/Microsoft_Azure_Capacity/QuotaMenuBlade/~/myQuotas"
-        echo "  Or pick a different region by re-running 'uis platform init azure-aks'."
+        echo "  Or pick a different region by re-running './uis platform init azure-aks'."
         exit 1
     fi
     echo "✓ Quota OK: $available vCPUs available in Standard_B family (need $total_vcpus)"


### PR DESCRIPTION
## Summary
Three tightly-themed talk47 follow-ups + one drive-by cleanup the user flagged:

- **F14 (real bug)** — `01-apply.sh` `read -r confirm` between \`tofu plan\` and \`tofu apply\` exits 1 silently on closed stdin under \`set -euo pipefail\`. Same bug shape as F13 (which PR #158 fixed in bootstrap), one script over. Reproducible: \`echo y | uis platform up azure-aks\` — bootstrap consumes the piped \`y\`, apply hits EOF and dies silently before the friendly "Aborted" message ever runs. One-line fix: \`read -r confirm || confirm=""\`.
- **Path display** — five user-facing spots (init's \`Config:\` line, up/down/status env-missing errors, down's preserved-config + reset hints) printed the full container path \`/mnt/urbalurbadisk/.uis.secrets/cloud-accounts/azure-default.env\`. Now print host-relative \`.uis.secrets/cloud-accounts/azure-default.env\` via \`\${ENV_FILE#\$REPO_ROOT/}\` parameter expansion. Same file (bind mount), but matches what the user would \`ls\` from their repo root.
- **\`./uis\` vs bare \`uis\`** — 13 user-actionable lines across init.sh / up.sh / down.sh / status.sh / 02-post-apply.sh / 03-destroy.sh / azure-discovery.sh emitted bare \`uis platform ...\` / \`uis deploy ...\` / \`uis tools install ...\`. Those don't work from a fresh checkout where \`uis\` isn't on PATH. Banner-label parens like \`(uis platform init azure-aks)\` stay bare — they're titles, not commands.
- **Drive-by** — \`require_interactive_or_die\` pointed the user at \`(See Q5 in INVESTIGATE-aks-novice-onboarding.md.\` when refusing on \`UIS_NONINTERACTIVE=1\`. That's a contributor-planning doc + internal jargon (Q5) in user-facing output. Stripped entirely.

## Test plan
- [x] Locally verified on \`uis-provision-host:local\`:
  - All three env-missing branches (up/down/status) now print host-relative path + \`./uis platform init azure-aks\` pointer.
  - \`UIS_NONINTERACTIVE=1 uis platform init azure-aks\` refuses without leaking Q5/INVESTIGATE.
  - Bash syntax check clean across all 7 changed scripts.
- [ ] Tester verifies F14 against a real cold cycle in talk47 follow-up: \`echo y | uis platform up azure-aks\` should now run through both prompts without silent exit-1 between plan and apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)