### PR TITLE
feat(uis-platform): list + use + per-command banner

### DIFF
--- a/platforms/azure-aks/scripts/02-post-apply.sh
+++ b/platforms/azure-aks/scripts/02-post-apply.sh
@@ -97,22 +97,19 @@ print_success "Connected — $NODE_COUNT_ACTUAL node(s) ready"
 # the shared playbooks read TARGET_HOST from cluster-config.sh to pick the
 # kubectl context. Without the flip, Traefik (and every later service) would
 # try to deploy to `rancher-desktop`, which isn't even in the merged kubeconfig.
+#
+# Lockstep flip (Q4 of INVESTIGATE-active-cluster-visibility-ux.md): writes
+# both kubectl current-context AND cluster-config.sh in one shared writer.
+# Convergence point with 03-destroy.sh's auto-reset and cmd_platform_use's
+# manual flip — single writer means cluster-config.sh can never silently
+# diverge from the kubectl context.
 print_section "Step 3: Switch UIS target to AKS"
 
-CLUSTER_CONFIG="/mnt/urbalurbadisk/.uis.extend/cluster-config.sh"
-if [[ -f "$CLUSTER_CONFIG" ]]; then
-    sed -i.bak \
-        -e "s|^CLUSTER_TYPE=.*|CLUSTER_TYPE=\"azure-aks\"|" \
-        -e "s|^TARGET_HOST=.*|TARGET_HOST=\"${AZURE_AKS_CLUSTER_NAME}\"|" \
-        "$CLUSTER_CONFIG"
-    rm -f "${CLUSTER_CONFIG}.bak"
-    print_success "cluster-config.sh now points at: CLUSTER_TYPE=azure-aks, TARGET_HOST=${AZURE_AKS_CLUSTER_NAME}"
-    echo "  (Revert manually to switch back to rancher-desktop.)"
-else
-    print_warning "cluster-config.sh not found — skipping auto-flip"
-    echo "  Set CLUSTER_TYPE=\"azure-aks\" and TARGET_HOST=\"${AZURE_AKS_CLUSTER_NAME}\" yourself in:"
-    echo "    $CLUSTER_CONFIG"
-fi
+# shellcheck source=/dev/null
+source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
+pf_lockstep_flip "$AZURE_AKS_CLUSTER_NAME"
+print_success "cluster-config.sh + kubectl context flipped to: $AZURE_AKS_CLUSTER_NAME"
+echo "  (Use './uis platform use rancher-desktop' to switch back.)"
 
 # ─── Step 4: Storage class aliases ────────────────────────────────────────────
 print_section "Step 4: Storage class aliases"

--- a/platforms/azure-aks/scripts/03-destroy.sh
+++ b/platforms/azure-aks/scripts/03-destroy.sh
@@ -185,19 +185,17 @@ fi
 # Symmetric to 02-post-apply.sh's auto-flip: after the AKS cluster is gone,
 # restore the local default so the next `./uis deploy <service>` doesn't
 # target a context that no longer exists.
+#
+# Lockstep flip (Q4 of INVESTIGATE-active-cluster-visibility-ux.md): goes
+# through the same shared writer as 02-post-apply.sh and cmd_platform_use.
+# Single writer means cluster-config.sh can never silently diverge from the
+# kubectl context.
 print_section "Reset UIS target to rancher-desktop"
 
-CLUSTER_CONFIG="/mnt/urbalurbadisk/.uis.extend/cluster-config.sh"
-if [[ -f "$CLUSTER_CONFIG" ]]; then
-    sed -i.bak \
-        -e "s|^CLUSTER_TYPE=.*|CLUSTER_TYPE=\"rancher-desktop\"|" \
-        -e "s|^TARGET_HOST=.*|TARGET_HOST=\"rancher-desktop\"|" \
-        "$CLUSTER_CONFIG"
-    rm -f "${CLUSTER_CONFIG}.bak"
-    print_success "cluster-config.sh reset to: CLUSTER_TYPE=rancher-desktop, TARGET_HOST=rancher-desktop"
-else
-    print_warning "cluster-config.sh not found — skipping reset"
-fi
+# shellcheck source=/dev/null
+source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
+pf_lockstep_flip "rancher-desktop"
+print_success "cluster-config.sh + kubectl context reset to: rancher-desktop"
 
 # ─── Summary ──────────────────────────────────────────────────────────────────
 print_section "DESTROY COMPLETE"

--- a/platforms/azure-aks/scripts/status.sh
+++ b/platforms/azure-aks/scripts/status.sh
@@ -6,6 +6,9 @@
 # This script answers it in one command.
 #
 # Entry point: uis platform status azure-aks
+#
+# --summary flag: emits the C-1 one-line state hint format for consumption
+# by `./uis platform list`. See PLAN-platform-list-use-and-banner.md Phase 2.
 
 set -euo pipefail
 
@@ -13,6 +16,68 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${UIS_REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 ENV_FILE="$REPO_ROOT/.uis.secrets/cloud-accounts/azure-default.env"
+KUBECONFIG_PATH="${UIS_KUBECONFIG:-/mnt/urbalurbadisk/kubeconfig/kubeconf-all}"
+
+# ----- Flag parsing (first — --summary short-circuits before any preflight) -----
+SUMMARY=0
+OFFLINE=0
+DEEP=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --summary) SUMMARY=1; shift ;;
+        --offline) OFFLINE=1; shift ;;
+        --deep)    DEEP=1;    shift ;;
+        *) shift ;;
+    esac
+done
+
+# ----- Summary path (C-1 contract, consumed by `uis platform list`) -----
+# Emits exactly one tab-separated line: <state>\t<hint>. Fast (no cloud-API
+# calls unless --deep). State machine per the investigation's C-1:
+#   1. env file missing                                  → not-initialized
+#   2. env present, kubectl context absent in kubeconf-all → configured-not-running
+#   3. both present, probe succeeds                      → running
+#   4. both present, probe fails                         → unreachable
+#   With --offline, step 3/4 short-circuits to running (assumed; not probed).
+if (( SUMMARY )); then
+    if [[ ! -f "$ENV_FILE" ]]; then
+        printf 'not-initialized\trun '\''./uis platform init azure-aks'\'' to set up\n'
+        exit 0
+    fi
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+    _cluster="${AZURE_AKS_CLUSTER_NAME:-azure-aks}"
+    if ! KUBECONFIG="$KUBECONFIG_PATH" kubectl config get-contexts "$_cluster" >/dev/null 2>&1; then
+        printf 'configured-not-running\trun '\''./uis platform up azure-aks'\'' to start it\n'
+        exit 0
+    fi
+    if (( OFFLINE )); then
+        printf 'running\t(offline — reachability not probed)\n'
+        exit 0
+    fi
+    if ! KUBECONFIG="$KUBECONFIG_PATH" kubectl --context "$_cluster" \
+            --request-timeout=3s get --raw /version >/dev/null 2>&1; then
+        printf 'unreachable\tAPI server timeout after 3s; run '\''./uis platform status azure-aks'\'' for details\n'
+        exit 0
+    fi
+    if (( DEEP )) && command -v az >/dev/null 2>&1 && az account show >/dev/null 2>&1; then
+        _rg="${AZURE_AKS_RESOURCE_GROUP:-rg-urbalurba-aks-weu}"
+        _region="${AZURE_AKS_LOCATION:-${AZURE_REGION:-westeurope}}"
+        mapfile -t _df < <(az aks show -g "$_rg" -n "$_cluster" \
+            --query "[kubernetesVersion, agentPoolProfiles[0].vmSize, agentPoolProfiles[0].count]" \
+            -o tsv 2>/dev/null)
+        if [[ "${#_df[@]}" -eq 3 ]]; then
+            printf 'running\t%s× %s in %s, k8s %s\n' "${_df[2]}" "${_df[1]}" "$_region" "${_df[0]}"
+        else
+            printf 'running\t(deep query failed — re-check Azure login)\n'
+        fi
+    else
+        printf 'running\tk8s cluster reachable\n'
+    fi
+    exit 0
+fi
 
 # ----- Refuse with pointer if env missing (consistent with up/down) -----
 if [[ ! -f "$ENV_FILE" ]]; then

--- a/platforms/rancher-desktop/scripts/status.sh
+++ b/platforms/rancher-desktop/scripts/status.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# status.sh — Rancher Desktop status (the always-present local platform).
+#
+# Spec: PLAN-platform-list-use-and-banner.md Phase 2.2
+# Investigation: INVESTIGATE-active-cluster-visibility-ux.md C-1 (rancher-desktop subsection)
+#
+# Rancher Desktop is installed at the OS level, not provisioned by UIS, so it
+# has no env file and uses **3 of the 4 C-1 states**:
+#
+#   not-initialized: kubectl context absent in kubeconf-all → "Rancher Desktop
+#                    not installed or never started"
+#   running:         context present + probe succeeds
+#   unreachable:     context present + probe fails ("Rancher Desktop installed
+#                    but currently stopped")
+#
+# `configured-not-running` doesn't apply — there's nothing UIS can "configure"
+# for rancher-desktop; installation is the user's OS step.
+
+set -euo pipefail
+
+KUBECONFIG_PATH="${UIS_KUBECONFIG:-/mnt/urbalurbadisk/kubeconfig/kubeconf-all}"
+CONTEXT_NAME="rancher-desktop"
+
+# ----- Flag parsing -----
+SUMMARY=0
+OFFLINE=0
+DEEP=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --summary) SUMMARY=1; shift ;;
+        --offline) OFFLINE=1; shift ;;
+        --deep)    DEEP=1;    shift ;;
+        *) shift ;;
+    esac
+done
+
+# ----- Summary path (C-1 contract) -----
+if (( SUMMARY )); then
+    if ! KUBECONFIG="$KUBECONFIG_PATH" kubectl config get-contexts "$CONTEXT_NAME" >/dev/null 2>&1; then
+        printf 'not-initialized\tinstall Rancher Desktop and start it, then '\''./uis start'\''\n'
+        exit 0
+    fi
+    if (( OFFLINE )); then
+        printf 'running\t(offline — reachability not probed)\n'
+        exit 0
+    fi
+    if ! KUBECONFIG="$KUBECONFIG_PATH" kubectl --context "$CONTEXT_NAME" \
+            --request-timeout=3s get --raw /version >/dev/null 2>&1; then
+        printf 'unreachable\tstart Rancher Desktop\n'
+        exit 0
+    fi
+    # Optional: --deep pulls the k3s version
+    if (( DEEP )); then
+        _ver="$(KUBECONFIG="$KUBECONFIG_PATH" kubectl --context "$CONTEXT_NAME" \
+                version --output=jsonpath='{.serverVersion.gitVersion}' 2>/dev/null \
+                | sed 's/^v//' || true)"
+        if [[ -n "$_ver" ]]; then
+            printf 'running\tlocal k3s, k8s %s\n' "$_ver"
+        else
+            printf 'running\tlocal k3s\n'
+        fi
+    else
+        printf 'running\tlocal k3s\n'
+    fi
+    exit 0
+fi
+
+# ----- Human-readable path (default invocation) -----
+echo "═══════════════════════════════════════════════════════════"
+echo " Rancher Desktop status"
+echo " (uis platform status rancher-desktop)"
+echo "═══════════════════════════════════════════════════════════"
+echo
+
+if ! KUBECONFIG="$KUBECONFIG_PATH" kubectl config get-contexts "$CONTEXT_NAME" >/dev/null 2>&1; then
+    echo "  Status:    not installed (or never started)"
+    echo "  Cost:      €0/day  (local desktop app — no cloud resources)"
+    echo
+    echo "  To install: download Rancher Desktop from https://rancherdesktop.io/"
+    echo "  After install + first start, run: ./uis start"
+    exit 0
+fi
+
+if ! KUBECONFIG="$KUBECONFIG_PATH" kubectl --context "$CONTEXT_NAME" \
+        --request-timeout=3s get --raw /version >/dev/null 2>&1; then
+    echo "  Status:    installed but not running (API server unreachable)"
+    echo "  Cost:      €0/day  (local desktop app — no cloud resources)"
+    echo
+    echo "  Recover:   start Rancher Desktop from your applications, then './uis start'"
+    exit 0
+fi
+
+# Running — pull a few details
+NODES=$(KUBECONFIG="$KUBECONFIG_PATH" kubectl --context "$CONTEXT_NAME" \
+        get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+K8S=$(KUBECONFIG="$KUBECONFIG_PATH" kubectl --context "$CONTEXT_NAME" \
+      version --output=jsonpath='{.serverVersion.gitVersion}' 2>/dev/null | sed 's/^v//' || echo "unknown")
+
+echo "  Status:    ✓ running"
+echo "  Nodes:     $NODES"
+echo "  k8s:       $K8S"
+echo "  Cost:      €0/day  (local desktop app — no cloud resources)"
+echo
+echo "  Switch:    ./uis platform use rancher-desktop"

--- a/provision-host/uis/lib/platform-switching.sh
+++ b/provision-host/uis/lib/platform-switching.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# platform-switching.sh — Shared helpers for `./uis platform list / use` + Layer 1 banner.
+#
+# Spec: website/docs/ai-developer/plans/active/PLAN-platform-list-use-and-banner.md
+# Investigation: website/docs/ai-developer/plans/backlog/INVESTIGATE-active-cluster-visibility-ux.md
+#
+# Functions:
+#   pf_active_platform           Echo kubectl current-context from kubeconf-all.
+#   pf_probe_reachable <ctx>     Return 0 if API reachable (3s timeout), else non-zero.
+#   pf_lockstep_flip <platform>  Atomic write: kubectl context + cluster-config.sh.
+#   pf_list_platforms            Echo platform names (rancher-desktop + platforms/*).
+#   pf_platform_summary <plat>   Invoke <plat>/scripts/status.sh --summary, validate, echo.
+#   pf_banner [opts]             Layer 1 banner to stderr; honors UIS_BANNER_PRINTED.
+#
+# Sourced by: provision-host/uis/manage/uis-cli.sh (cmd_platform_list / cmd_platform_use
+# and every cluster-touching cmd_<verb> for the banner), platforms/azure-aks/scripts/
+# 02-post-apply.sh + 03-destroy.sh (lockstep writer for auto-flip/auto-reset).
+#
+# Container-fixed paths. The kubeconf-all sits at the in-container location (NOT
+# bind-mounted) to keep kubectl's flock working on Rancher Desktop's lima VM —
+# the bind-mounted path under .uis.secrets/generated/kubeconfig/ breaks flock.
+PF_KUBECONFIG="${PF_KUBECONFIG:-/mnt/urbalurbadisk/kubeconfig/kubeconf-all}"
+PF_CLUSTER_CONFIG="${PF_CLUSTER_CONFIG:-/mnt/urbalurbadisk/.uis.extend/cluster-config.sh}"
+PF_PLATFORMS_DIR="${PF_PLATFORMS_DIR:-/mnt/urbalurbadisk/platforms}"
+PF_PROBE_TIMEOUT="${PF_PROBE_TIMEOUT:-3s}"
+
+# C-1 enum — the only valid <state> values status.sh --summary may emit.
+PF_VALID_STATES_REGEX='^(not-initialized|configured-not-running|running|unreachable)$'
+
+
+# ----- pf_active_platform -----------------------------------------------------
+# Echo the kubectl current-context name (the active platform per Q1). Empty
+# string if unset (e.g. fresh kubeconfig).
+pf_active_platform() {
+    KUBECONFIG="$PF_KUBECONFIG" kubectl config current-context 2>/dev/null || echo ""
+}
+
+
+# ----- pf_probe_reachable -----------------------------------------------------
+# The shared primitive for "is this cluster reachable right now?". Used by
+# Layer 1's banner (C-9) and by per-platform status.sh --summary (C-1 state
+# machine). Targets the named context explicitly — never the bare current
+# context (which would give wrong-cluster answers when probing a non-active
+# platform; see F12 from talk46).
+pf_probe_reachable() {
+    local ctx="${1:-}"
+    [[ -z "$ctx" ]] && return 2
+    KUBECONFIG="$PF_KUBECONFIG" kubectl --context "$ctx" \
+        --request-timeout="$PF_PROBE_TIMEOUT" \
+        get --raw /version >/dev/null 2>&1
+}
+
+
+# ----- pf_lockstep_flip -------------------------------------------------------
+# Atomic write of both halves of "the active platform":
+#   1. kubectl current-context in kubeconf-all (truth for reads, Q1)
+#   2. cluster-config.sh's CLUSTER_TYPE + TARGET_HOST fields (cached projection
+#      that ansible playbooks read for inventory; written here in lockstep so
+#      it always agrees with kubectl by construction)
+#
+# Three call sites converge on this function:
+#   - 02-post-apply.sh's auto-flip-on-up
+#   - 03-destroy.sh's auto-reset-on-down
+#   - cmd_platform_use's manual flip
+# Single writer means cluster-config.sh can never silently diverge from the
+# kubectl context — Q4 of the investigation.
+pf_lockstep_flip() {
+    local platform="${1:?pf_lockstep_flip: missing platform argument}"
+
+    # Truth for reads.
+    KUBECONFIG="$PF_KUBECONFIG" kubectl config use-context "$platform" >/dev/null
+
+    # Cached projection. By convention CLUSTER_TYPE == TARGET_HOST == platform
+    # directory name (per the investigation's edge case #10). Write both for
+    # backward compat with existing ansible readers; future work can collapse.
+    if [[ -f "$PF_CLUSTER_CONFIG" ]]; then
+        sed -i.bak \
+            -e "s|^CLUSTER_TYPE=.*|CLUSTER_TYPE=\"$platform\"|" \
+            -e "s|^TARGET_HOST=.*|TARGET_HOST=\"$platform\"|" \
+            "$PF_CLUSTER_CONFIG"
+        rm -f "${PF_CLUSTER_CONFIG}.bak"
+    fi
+}
+
+
+# ----- pf_list_platforms ------------------------------------------------------
+# Emit the inventory of "potential platforms UIS knows about" to stdout, one
+# name per line. Sources per Q3:
+#   - rancher-desktop hard-coded (always present; installed at OS level, no init.sh)
+#   - Every platforms/<name>/scripts/init.sh directory listing, skipping any
+#     name starting with _ or . (hidden/WIP directories — edge case #8)
+#
+# rancher-desktop is emitted first so it lands at the top of `list`'s table.
+pf_list_platforms() {
+    echo "rancher-desktop"
+    local script_path name
+    for script_path in "$PF_PLATFORMS_DIR"/*/scripts/init.sh; do
+        [[ -f "$script_path" ]] || continue
+        name="$(basename "$(dirname "$(dirname "$script_path")")")"
+        case "$name" in
+            _*|.*) continue ;;
+            rancher-desktop) continue ;;  # already emitted above
+        esac
+        echo "$name"
+    done
+}
+
+
+# ----- pf_platform_summary ----------------------------------------------------
+# Invoke <platform>/scripts/status.sh --summary [--offline|--deep] and capture
+# the tab-separated <state>\t<hint> output. Validates field 1 is a valid C-1
+# enum state. Echoes the captured line on stdout, returns 0 on success, non-zero
+# if the script is missing, errors, or emits malformed output (caller renders
+# `? error` for that row).
+#
+# Extra args after $1 are passed through unchanged — supports both
+#   pf_platform_summary azure-aks
+#   pf_platform_summary azure-aks --offline
+#   pf_platform_summary azure-aks --deep
+pf_platform_summary() {
+    local platform="${1:?pf_platform_summary: missing platform argument}"
+    shift
+    local script="$PF_PLATFORMS_DIR/$platform/scripts/status.sh"
+    [[ -x "$script" ]] || return 1
+    local line
+    line="$("$script" --summary "$@" 2>/dev/null)" || return 1
+    local state="${line%%	*}"
+    [[ "$state" =~ $PF_VALID_STATES_REGEX ]] || return 1
+    echo "$line"
+}
+
+
+# ----- pf_banner --------------------------------------------------------------
+# Layer 1 banner (C-9). Writes to stderr per C-9's output-stream decision
+# (success doesn't drown out piped stdout; failure stays visible).
+#
+# Flags:
+#   --silent-if-set    Suppress banner when UIS_BANNER_PRINTED=1 is set (C-4
+#                      child-suppression for `stack install` → child deploys).
+#   --check-reachable  Run the reachability probe and surface the result —
+#                      emits the four C-9 cases. Without this flag the banner
+#                      just names the active platform without probing.
+#
+# Returns 0 on the success/warn cases (1, 3 — caller proceeds). Returns 1 on
+# the abort cases (2, 4 — caller is expected to exit). The function does NOT
+# call `exit` itself so it's composable in any caller (dispatcher / sourced
+# helper / test harness).
+pf_banner() {
+    local silent_if_set=0
+    local check_reachable=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --silent-if-set) silent_if_set=1; shift ;;
+            --check-reachable) check_reachable=1; shift ;;
+            *) shift ;;  # ignore unknown flags
+        esac
+    done
+
+    # C-4 — child invocation under `stack install` etc.
+    if (( silent_if_set )) && [[ "${UIS_BANNER_PRINTED:-0}" == "1" ]]; then
+        return 0
+    fi
+
+    local active
+    active="$(pf_active_platform)"
+
+    # Case 4 — no active context. Abort with the rancher-desktop recovery hint.
+    if [[ -z "$active" ]]; then
+        {
+            echo "⚠  No active kubectl context set."
+            echo "   Run './uis platform use rancher-desktop' (the default) or './uis platform list' to see what you have."
+            echo "   Aborting."
+        } >&2
+        return 1
+    fi
+
+    # Is the active context a UIS-managed platform?
+    local is_uis_platform=0
+    if [[ "$active" == "rancher-desktop" ]] || [[ -f "$PF_PLATFORMS_DIR/$active/scripts/init.sh" ]]; then
+        is_uis_platform=1
+    fi
+
+    # Case 3 — active context is not a UIS platform (personal cluster etc.).
+    # One-liner warning; caller proceeds.
+    if (( ! is_uis_platform )); then
+        echo "⚠  Platform: $active (not a UIS platform — proceeding with kubectl context anyway)" >&2
+        # Mark printed so children don't re-banner.
+        export UIS_BANNER_PRINTED=1
+        return 0
+    fi
+
+    # If --check-reachable wasn't requested, name the platform and return.
+    if (( ! check_reachable )); then
+        echo "ℹ  Platform: $active" >&2
+        export UIS_BANNER_PRINTED=1
+        return 0
+    fi
+
+    # Case 1 — UIS platform AND reachable. One-liner success.
+    if pf_probe_reachable "$active"; then
+        echo "ℹ  Platform: $active (reachable)" >&2
+        export UIS_BANNER_PRINTED=1
+        return 0
+    fi
+
+    # Case 2 — UIS platform BUT unreachable. Multi-line block + abort. Pull
+    # the platform-specific hint from the active platform's status.sh --summary
+    # field 2 (only on this error path; common path doesn't pay this cost).
+    local summary hint=""
+    if summary="$(pf_platform_summary "$active" 2>/dev/null)"; then
+        hint="${summary#*	}"
+    fi
+    {
+        echo "✗  Platform: $active, but the API server is unreachable."
+        [[ -n "$hint" ]] && echo "   $hint"
+        echo "   Recover with: ./uis platform status $active"
+        echo "   Or switch:    ./uis platform use rancher-desktop  (or another reachable platform)"
+        echo "   Aborting."
+    } >&2
+    return 1
+}
+
+
+# Make the functions available to child shells if needed (sub-shell invocations
+# from ansible's `shell` module, etc.). Most callers source this file directly.
+export -f pf_active_platform pf_probe_reachable pf_lockstep_flip
+export -f pf_list_platforms pf_platform_summary pf_banner

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -29,6 +29,7 @@ source "$LIB_DIR/uis-hosts.sh" 2>/dev/null || true
 source "$LIB_DIR/integration-testing.sh" 2>/dev/null || true
 source "$LIB_DIR/expose.sh" 2>/dev/null || true
 source "$LIB_DIR/configure.sh" 2>/dev/null || true
+source "$LIB_DIR/platform-switching.sh" 2>/dev/null || true
 source "$LIB_DIR/template.sh" 2>/dev/null || true
 source "$LIB_DIR/connect.sh" 2>/dev/null || true
 
@@ -116,8 +117,10 @@ Tools:
 
 Platform:
   platform init   <provider>  Interactive setup wizard for a cloud platform (e.g. azure-aks)
+  platform list               Show all potential platforms and their current state
   platform up     <provider>  Provision the cluster end-to-end (bootstrap + apply + post-apply)
   platform status <provider>  Show cluster state, external IP, and cost estimate
+  platform use    [<provider>]   Switch the active platform (interactive picker if no arg)
   platform down   <provider>  Tear down the cluster (delegates to 03-destroy.sh)
 
 Tailscale:
@@ -186,6 +189,7 @@ EOF
 }
 
 cmd_list() {
+    _uis_cluster_banner
     local show_all=false
     local filter_category=""
 
@@ -252,6 +256,7 @@ cmd_list() {
 }
 
 cmd_status() {
+    _uis_cluster_banner
     print_section "Deployed Services Status"
 
     # Show current kubectl context (target cluster)
@@ -301,6 +306,7 @@ cmd_categories() {
 }
 
 cmd_deploy() {
+    _uis_cluster_banner
     local service_id=""
     local app_name=""
     local url_prefix=""
@@ -377,6 +383,7 @@ cmd_deploy() {
 }
 
 cmd_undeploy() {
+    _uis_cluster_banner
     local service_id=""
     local app_name=""
     local purge="false"
@@ -683,6 +690,10 @@ cmd_stack_info() {
 }
 
 cmd_stack_install() {
+    _uis_cluster_banner
+    # C-4 — children (./uis deploy <service> fired by the stack walker) MUST
+    # NOT re-print the banner. Set the env var the helper reads.
+    export UIS_BANNER_PRINTED=1
     local stack_id="${1:-}"
     local skip_optional=false
 
@@ -859,26 +870,46 @@ cmd_platform() {
         init)
             cmd_platform_init "$@"
             ;;
+        list)
+            cmd_platform_list "$@"
+            ;;
         up)
             cmd_platform_up "$@"
             ;;
         status)
             cmd_platform_status "$@"
             ;;
+        use)
+            cmd_platform_use "$@"
+            ;;
         down)
             cmd_platform_down "$@"
             ;;
         "")
-            log_error "Usage: uis platform <subcmd> <provider>"
-            echo "Subcommands: init | up | status | down" >&2
+            log_error "Usage: uis platform <subcmd> [<provider>]"
+            echo "Subcommands: init | list | up | status | use | down" >&2
             exit "$EXIT_GENERAL_ERROR"
             ;;
         *)
             log_error "Unknown platform subcommand: $subcmd"
-            echo "Usage: uis platform [init|up|status|down] <provider>" >&2
+            echo "Usage: uis platform [init|list|up|status|use|down] [<provider>]" >&2
             exit "$EXIT_GENERAL_ERROR"
             ;;
     esac
+}
+
+# Internal helper: emit the Layer 1 platform banner to stderr and abort on
+# unreachable / unset-context cases (per C-9 of INVESTIGATE-active-cluster-
+# visibility-ux.md). Called at the top of every cluster-touching cmd_<verb>
+# function. Honors UIS_BANNER_PRINTED=1 (set by parent invocations like
+# cmd_stack_install before fanning out to child deploys, per C-4).
+#
+# Defensive against pf_banner being unavailable (platform-switching.sh failed
+# to source, e.g. during early-init harness runs) — silently no-ops in that
+# case so cluster-touching commands still work.
+_uis_cluster_banner() {
+    type pf_banner >/dev/null 2>&1 || return 0
+    pf_banner --silent-if-set --check-reachable || exit "$EXIT_GENERAL_ERROR"
 }
 
 # Internal helper: list platforms that have a given script name under
@@ -926,6 +957,10 @@ cmd_platform_init() {
 # The per-platform up.sh handles env-file presence (Q11 refuse-with-pointer)
 # and chains the lifecycle scripts.
 cmd_platform_up() {
+    # No banner — `up` takes an explicit <provider>, doesn't act on the current
+    # kubectl context. Showing the active platform before a `up azure-aks`
+    # invocation would be misleading (the active might be rancher-desktop;
+    # `up` is going to change it).
     local provider="${1:-}"
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -952,6 +987,7 @@ cmd_platform_up() {
 # confirmation prompt + UIS_DESTROY_CONFIRM env-var escape hatch), then prints
 # the config-preservation pointer per Q12.
 cmd_platform_down() {
+    # No banner — explicit <provider>, doesn't act on current kubectl context.
     local provider="${1:-}"
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -977,6 +1013,8 @@ cmd_platform_down() {
 # status.sh answers "is the cluster running and how much is it costing me?"
 # in a single command (F8 from talk45).
 cmd_platform_status() {
+    # No banner — explicit <provider>, this command reports on the named
+    # platform regardless of which is currently active.
     local provider="${1:-}"
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -996,6 +1034,300 @@ cmd_platform_status() {
 
     export UIS_REPO_ROOT="$repo_root"
     exec "$script"
+}
+
+# cmd_platform_list — enumerate potential platforms + their states.
+# Implements Layer 4 of INVESTIGATE-active-cluster-visibility-ux.md.
+# Inventory: pf_list_platforms (platforms/*/scripts/init.sh dirs + rancher-desktop).
+# Per-row status: each platform's status.sh --summary (C-1 contract) called in
+# parallel for the under-500ms budget (C-6).
+cmd_platform_list() {
+    # No banner — `list` IS the discovery command, expected to work even when
+    # no active context is set (helps the user find a platform to switch to).
+    # shellcheck source=/dev/null
+    source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
+
+    # Flag parsing — --offline / --deep mirror status.sh --summary's modes.
+    local offline=0 deep=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --offline) offline=1; shift ;;
+            --deep)    deep=1;    shift ;;
+            *) shift ;;
+        esac
+    done
+    local summary_args=()
+    (( offline )) && summary_args+=("--offline")
+    (( deep ))    && summary_args+=("--deep")
+
+    # Header — `Active: <name>` per C-2 (three cases for kubectl current-context).
+    local active is_uis_platform=0
+    active="$(pf_active_platform)"
+    if [[ -z "$active" ]]; then
+        echo "Active: (none — run './uis platform use <name>' to pick one)"
+    else
+        if [[ "$active" == "rancher-desktop" ]] || \
+           [[ -f "/mnt/urbalurbadisk/platforms/$active/scripts/init.sh" ]]; then
+            is_uis_platform=1
+            echo "Active: $active"
+        else
+            echo "Active: $active (not a UIS platform — use './uis platform use <name>' to switch to one)"
+        fi
+    fi
+    echo
+
+    # Gather summaries in parallel — one background process per platform,
+    # output collected into a tmpdir then read in inventory order. Keeps the
+    # default `list` under 500ms with up to ~8 platforms (C-6).
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' RETURN
+    local platforms=() pf
+    while IFS= read -r pf; do
+        platforms+=("$pf")
+    done < <(pf_list_platforms)
+    local pid
+    for pf in "${platforms[@]}"; do
+        ( pf_platform_summary "$pf" "${summary_args[@]}" 2>/dev/null > "$tmpdir/$pf" ) &
+    done
+    wait
+
+    # Compute max platform-name width for table alignment.
+    local maxw=0 w
+    for pf in "${platforms[@]}"; do
+        w=${#pf}
+        (( w > maxw )) && maxw=$w
+    done
+    (( maxw < 16 )) && maxw=16
+
+    printf "%-${maxw}s  %s\n" "PLATFORM" "STATUS"
+    local row_state row_hint icon state_label
+    for pf in "${platforms[@]}"; do
+        if [[ ! -s "$tmpdir/$pf" ]]; then
+            printf "%-${maxw}s  ? error                       (status.sh --summary failed; run './uis platform status %s' for details)\n" "$pf" "$pf"
+            continue
+        fi
+        # tab-separated <state>\t<hint>
+        IFS=$'\t' read -r row_state row_hint < "$tmpdir/$pf"
+        case "$row_state" in
+            running)
+                icon="✓"
+                state_label="running"
+                ;;
+            configured-not-running)
+                icon="·"
+                state_label="configured, not running"
+                ;;
+            not-initialized)
+                icon="·"
+                state_label="not initialized"
+                ;;
+            unreachable)
+                icon="✗"
+                state_label="unreachable"
+                ;;
+            *)
+                icon="?"
+                state_label="$row_state"
+                ;;
+        esac
+        # Active annotation if this row matches the kubectl current-context (only
+        # when active is a UIS platform; per C-2 external/unset contexts don't
+        # decorate any row).
+        local active_tag=""
+        if (( is_uis_platform )) && [[ "$pf" == "$active" ]]; then
+            active_tag="  (active)"
+        fi
+        # Display hint: for running rows, the hint is descriptive; for non-running
+        # rows, prefix with "run '...' " — but the status.sh already emits the
+        # right text in field 2 per C-1, so we just print it.
+        if [[ "$row_state" == "running" ]]; then
+            printf "%-${maxw}s  %s %s%s    %s\n" \
+                "$pf" "$icon" "$state_label" "$active_tag" "$row_hint"
+        else
+            printf "%-${maxw}s  %s %-23s  (%s)\n" \
+                "$pf" "$icon" "$state_label" "$row_hint"
+        fi
+    done
+}
+
+# cmd_platform_use — switch the active platform with lockstep flip.
+# Implements Q4 (lockstep) + Q5 (refuse-unless-initialized-and-reachable).
+# State decision via pf_platform_summary (the C-1 contract); flip via
+# pf_lockstep_flip (the shared writer 02-post-apply.sh + 03-destroy.sh
+# converge on after Phase 6).
+cmd_platform_use() {
+    # No banner — `use` is the *fix* for the "no active context" abort path
+    # that fires on cluster-touching commands. Banner-then-abort here would
+    # be catch-22.
+    # shellcheck source=/dev/null
+    source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
+
+    local force_offline=0 target=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --offline) force_offline=1; shift ;;
+            -*)        shift ;;  # ignore unknown flags
+            *)         target="$1"; shift ;;
+        esac
+    done
+
+    # No arg → interactive picker over the running rows.
+    if [[ -z "$target" ]]; then
+        _cmd_platform_use_picker
+        return
+    fi
+
+    # Validate that the platform exists (special-case rancher-desktop).
+    if [[ "$target" != "rancher-desktop" ]] && \
+       [[ ! -f "/mnt/urbalurbadisk/platforms/$target/scripts/init.sh" ]]; then
+        log_error "Unknown platform '$target' (no init.sh found at /mnt/urbalurbadisk/platforms/$target/scripts/init.sh)"
+        { _list_available_platforms_with_script init.sh "/mnt/urbalurbadisk"; } >&2
+        echo "  - rancher-desktop" >&2  # not in the init.sh enumeration; mention explicitly
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+
+    # Ask status.sh --summary what state the target is in.
+    local summary state hint
+    if ! summary="$(pf_platform_summary "$target")"; then
+        log_error "Could not query status for '$target' (status.sh --summary errored or emitted invalid output)"
+        echo "  Try: ./uis platform status $target" >&2
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+    state="${summary%%	*}"
+    hint="${summary#*	}"
+
+    # Capture current active for the success-line "from → to" wording.
+    local previous
+    previous="$(pf_active_platform)"
+
+    case "$state" in
+        not-initialized)
+            # Use the hint from status.sh --summary verbatim — the per-platform
+            # script knows what action is needed. Rancher-desktop's hint says
+            # "install Rancher Desktop and start it" (no `platform init` exists
+            # for it), while azure-aks's would say "run './uis platform init …'".
+            echo "✗ $target is not initialized." >&2
+            echo "  $hint" >&2
+            exit "$EXIT_GENERAL_ERROR"
+            ;;
+        configured-not-running)
+            echo "✗ $target is configured but not running." >&2
+            echo "  $hint" >&2
+            exit "$EXIT_GENERAL_ERROR"
+            ;;
+        running)
+            # Already active? No-op + re-probe (per C-8 / Q5 no-op semantics).
+            if [[ "$previous" == "$target" ]]; then
+                if pf_probe_reachable "$target"; then
+                    echo "ℹ  Already active: $target. Re-probing... ✓ still reachable."
+                    exit 0
+                else
+                    echo "✗ $target is no longer reachable (API server timeout after 3s)." >&2
+                    echo "  Check the cluster state with './uis platform status $target'." >&2
+                    exit "$EXIT_GENERAL_ERROR"
+                fi
+            fi
+            pf_lockstep_flip "$target"
+            if [[ -n "$previous" ]]; then
+                echo "✓ Switched: $previous → $target"
+            else
+                echo "✓ Switched to: $target"
+            fi
+            exit 0
+            ;;
+        unreachable)
+            if (( force_offline )); then
+                # User explicitly opted in to switching despite unreachable.
+                pf_lockstep_flip "$target"
+                if [[ -n "$previous" ]]; then
+                    echo "✓ Switched: $previous → $target  (forced; cluster not reachable)"
+                else
+                    echo "✓ Switched to: $target  (forced; cluster not reachable)"
+                fi
+                exit 0
+            fi
+            echo "✗ $target is unreachable (API server timeout after 3s)." >&2
+            echo "  Check the cluster state with './uis platform status $target'." >&2
+            echo "  To switch anyway (e.g. to clean up stale kubectl state), use --offline." >&2
+            exit "$EXIT_GENERAL_ERROR"
+            ;;
+        *)
+            log_error "Unexpected state '$state' from $target's status.sh --summary"
+            exit "$EXIT_GENERAL_ERROR"
+            ;;
+    esac
+}
+
+# Interactive picker for `./uis platform use` with no argument.
+# Per C-8: only running rows get [N] selectors; non-selectable rows appear
+# without selectors with their inline pointer. Plain read -p; no fzf dep.
+_cmd_platform_use_picker() {
+    # shellcheck source=/dev/null
+    source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
+
+    local platforms=() pf
+    while IFS= read -r pf; do
+        platforms+=("$pf")
+    done < <(pf_list_platforms)
+
+    # Gather summaries (sequential is fine for the picker; the user is going
+    # to type a number anyway, the parallel optimization isn't load-bearing).
+    local active selectable=() pf_state pf_hint summary
+    active="$(pf_active_platform)"
+
+    local maxw=0 w
+    for pf in "${platforms[@]}"; do
+        w=${#pf}; (( w > maxw )) && maxw=$w
+    done
+    (( maxw < 16 )) && maxw=16
+
+    echo
+    printf "%-4s %-${maxw}s  %s\n" " " "PLATFORM" "STATUS"
+    local idx=1
+    for pf in "${platforms[@]}"; do
+        if summary="$(pf_platform_summary "$pf" 2>/dev/null)"; then
+            pf_state="${summary%%	*}"
+            pf_hint="${summary#*	}"
+        else
+            pf_state="error"
+            pf_hint="status.sh --summary failed"
+        fi
+        local active_tag=""
+        [[ "$pf" == "$active" ]] && active_tag="  (currently active)"
+        if [[ "$pf_state" == "running" ]]; then
+            printf "[%d] %-${maxw}s  ✓ running%s    %s\n" "$idx" "$pf" "$active_tag" "$pf_hint"
+            selectable+=("$pf")
+            ((idx++))
+        else
+            local icon state_label
+            case "$pf_state" in
+                configured-not-running) icon="·"; state_label="configured, not running" ;;
+                not-initialized)        icon="·"; state_label="not initialized" ;;
+                unreachable)            icon="✗"; state_label="unreachable" ;;
+                *)                      icon="?"; state_label="$pf_state" ;;
+            esac
+            printf "    %-${maxw}s  %s %-23s  (%s)\n" "$pf" "$icon" "$state_label" "$pf_hint"
+        fi
+    done
+    echo
+
+    if [[ "${#selectable[@]}" -eq 0 ]]; then
+        echo "✗ No platforms are currently in 'running' state." >&2
+        echo "  Bring one up with './uis platform up <name>' (see hints above)." >&2
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+
+    local choice
+    read -rp "Pick a platform [1-${#selectable[@]}]: " choice
+    # Validate
+    if ! [[ "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 )) || (( choice > ${#selectable[@]} )); then
+        log_error "Invalid selection: '$choice'"
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+    local picked="${selectable[$((choice-1))]}"
+    # Re-dispatch through the named path so the no-op/lockstep logic runs there.
+    cmd_platform_use "$picked"
 }
 
 # ============================================================
@@ -1476,6 +1808,7 @@ cmd_cloudflare_teardown() {
 # ============================================================
 
 cmd_configure() {
+    _uis_cluster_banner
     run_configure "$@"
 }
 
@@ -1485,6 +1818,7 @@ cmd_configure() {
 # ============================================================
 
 cmd_expose() {
+    _uis_cluster_banner
     local service_or_flag="${1:-}"
     local flag="${2:-}"
 
@@ -1883,6 +2217,9 @@ cmd_secrets() {
 # ============================================================
 
 cmd_test_all() {
+    _uis_cluster_banner
+    # C-4 — children spawned by run_integration_tests should not re-banner.
+    export UIS_BANNER_PRINTED=1
     if ! type run_integration_tests &>/dev/null; then
         log_error "integration-testing.sh not loaded"
         exit "$EXIT_GENERAL_ERROR"

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -907,8 +907,14 @@ cmd_platform() {
 # Defensive against pf_banner being unavailable (platform-switching.sh failed
 # to source, e.g. during early-init harness runs) — silently no-ops in that
 # case so cluster-touching commands still work.
+#
+# Also no-ops when there's no kubectl or no kubeconf-all file at all — that's
+# the host-side test harness running uis-cli.sh on ubuntu-latest CI, not a
+# real cluster-touching context. In the container these always exist.
 _uis_cluster_banner() {
     type pf_banner >/dev/null 2>&1 || return 0
+    command -v kubectl >/dev/null 2>&1 || return 0
+    [[ -f "${PF_KUBECONFIG:-/mnt/urbalurbadisk/kubeconfig/kubeconf-all}" ]] || return 0
     pf_banner --silent-if-set --check-reachable || exit "$EXIT_GENERAL_ERROR"
 }
 
@@ -1298,7 +1304,7 @@ _cmd_platform_use_picker() {
         if [[ "$pf_state" == "running" ]]; then
             printf "[%d] %-${maxw}s  ✓ running%s    %s\n" "$idx" "$pf" "$active_tag" "$pf_hint"
             selectable+=("$pf")
-            ((idx++))
+            ((++idx))
         else
             local icon state_label
             case "$pf_state" in

--- a/website/docs/ai-developer/plans/active/PLAN-platform-list-use-and-banner.md
+++ b/website/docs/ai-developer/plans/active/PLAN-platform-list-use-and-banner.md
@@ -1,0 +1,345 @@
+# Plan: `./uis platform list / use` + per-command platform banner
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active
+
+**Goal**: Add `./uis platform list` (potential platforms + status), `./uis platform use <name>` (refuse-unless-initialized-and-reachable + lockstep flip), and a per-command banner at the top of every cluster-touching `./uis` command — so a user with 2+ platforms can see what they have, switch safely between them, and tell what platform any command is targeting before it runs. **Layer 4 + Layer 1 of [INVESTIGATE-active-cluster-visibility-ux.md](./INVESTIGATE-active-cluster-visibility-ux.md), bundled per Q2 / C-9.**
+
+**Last Updated**: 2026-05-12 — work started on branch `feat/platform-list-use-and-banner`.
+
+**Source**: [INVESTIGATE-active-cluster-visibility-ux.md](./INVESTIGATE-active-cluster-visibility-ux.md) — design questions Q1–Q5 + implementation contracts C-1 through C-9, locked through three gap-and-contradiction sweeps. This PLAN drafts the implementation against those contracts; design decisions don't get revisited here.
+
+**Related (context)**:
+- [INVESTIGATE-aks-novice-onboarding.md](./INVESTIGATE-aks-novice-onboarding.md) — sibling investigation that shipped `./uis platform init / up / status / down` via PRs #154–#159. This PLAN extends the `./uis platform` family with `list` + `use` and threads the banner through every cluster-touching command in the same image.
+
+---
+
+## Problem Summary
+
+talk47 closed the AKS novice-onboarding sequence with one operational gap: once the user has `azure-aks` + `rancher-desktop` both potentially in play (and eventually `google-gke` / `aws-eks` / `azure-microk8s`), there's no command that answers either *"what platforms do I have here and what state is each in?"* or *"let me switch to a different one"* without `cat`-ing config files by hand. And even when the user *knows* which platform they're on, no `./uis` command surfaces it before running — so the talk41 stale-port-forward / talk44 phantom-replay class of bug remains live.
+
+This PLAN closes both:
+
+- **`./uis platform list`** — directory-listing-driven inventory of every platform UIS knows how to onboard (plus the always-present rancher-desktop row). Each row shows a state from the C-1 enum (`not-initialized` / `configured-not-running` / `running` / `unreachable`) plus an inline recovery pointer when the platform isn't ready to use.
+- **`./uis platform use <name>`** — lockstep flip of `kubectl current-context` + `cluster-config.sh` for a `running`-and-reachable platform. Refuses with a pointer otherwise. `--offline` escape for the "I know it's broken, switch anyway" case.
+- **Per-command platform banner** — every cluster-touching `./uis` command (`deploy`, `expose`, `configure`, `undeploy`, `status`, `list`, `stack install`, `test-all`, plus the `./uis platform` family itself) emits a one-line banner before its first action, naming the active platform and confirming reachability. Aborts with a recovery banner if the cluster is unreachable.
+
+The lockstep flip (Q4) is the most invasive piece — it extracts the existing `sed -i` writes from `02-post-apply.sh` (auto-flip on `up`) and `03-destroy.sh` (auto-reset on `down`) into a single shared writer in `provision-host/uis/lib/platform-switching.sh`, then routes all three call sites (`up` / `down` / new `use`) through it. The investigation's "lockstep, never read independently" guarantee for `cluster-config.sh` only holds if all three writers converge.
+
+---
+
+## Out of Scope
+
+- **Layer 2 — coloured PS1 inside `./uis shell`.** Deferred to a separate PLAN (`PLAN-ps1-cluster-tag.md`) — touches the container's bashrc and the Dockerfile, lower priority because Layer 1's banner covers in-shell users too.
+- **Layer 3 — `./uis status` cluster header.** Deferred to `PLAN-uis-status-cluster-header.md` — trivial once banner machinery exists, but distinct enough to ship after Layer 4+1 verifies.
+- **Host-side kubectl integration** (`k9s`, `lens`, raw `kubectl` from macOS Terminal). The lockstep flip targets only `kubeconf-all` inside the container — host's `~/.kube/config` is the user's environment. See the investigation's "Out of scope" section.
+- **Removing `cluster-config.sh` entirely.** Q4's lockstep design makes it a cached projection; a future PLAN could drop it outright once nothing reads it independently. Out of scope here.
+- **Cross-cluster broadcasts** (deploying once to multiple platforms). UIS stays single-cluster-per-invocation.
+- **Production-vs-sandbox enforcement / typed-name confirms** for `use`. Future PLAN once Layer 2's colour scheme tags platforms by sensitivity.
+- **Provisioning new platforms from `list`.** `list` shows what exists; provisioning is `./uis platform up <name>`. No "click to provision" affordance.
+
+---
+
+## Phase 1: Shared helper `provision-host/uis/lib/platform-switching.sh`
+
+The single source of truth for: (1) the reachability probe primitive, (2) the lockstep writer, (3) inventory enumeration, (4) parsing per-platform `status.sh --summary` output. Consumers: `list`, `use`, the per-command banner, `02-post-apply.sh`'s auto-flip-on-up, `03-destroy.sh`'s auto-reset-on-down.
+
+Before writing this file, **read [PLANS.md § Library Reuse Rules](../../PLANS.md#library-reuse-rules)** — verify nothing already in `provision-host/uis/lib/` covers what's needed and that nothing here duplicates `paths.sh` / `utilities.sh` / `logging.sh` functions. New functionality only.
+
+### Tasks
+
+- [ ] 1.1 Create `provision-host/uis/lib/platform-switching.sh` with the following functions. Names are illustrative; the function signatures + behaviors must match the contracts. All functions defensive: `set -euo pipefail` at start of each, no `|| true` masking, no regex on JSON.
+
+  - `pf_active_platform()` — print the active kubectl context to stdout. Empty string if unset. Reads `kubectl config current-context` from `kubeconf-all`.
+  - `pf_probe_reachable <context>` — return 0 if reachable, non-zero otherwise. Implementation: `kubectl --context "$1" --request-timeout=3s get --raw /version >/dev/null 2>&1`. Used by C-9 banner + by C-1 state machine.
+  - `pf_lockstep_flip <platform>` — atomic write of both halves: `kubectl config use-context "$platform"` AND `sed -i` on `cluster-config.sh` updating `CLUSTER_TYPE` + `TARGET_HOST` to `$platform`. Single call site for the three converging writers (Phase 6).
+  - `pf_list_platforms()` — emit the inventory to stdout, one platform name per line. Source: `platforms/*/scripts/init.sh` directory listing, skipping any directory whose name starts with `_` or `.` (per Edge case #8). Hard-codes `rancher-desktop` as the first row (always present).
+  - `pf_platform_summary <platform> [--offline]` — invoke `<platform>/scripts/status.sh --summary [--offline]`, capture the tab-separated `<state>\t<hint>` output, validate field 1 is in the C-1 enum, and emit it on stdout. Non-zero exit if the `status.sh` errors or returns malformed output (caller renders `? error` for that row).
+  - `pf_banner [--silent-if-set] [--check-reachable]` — print the Layer 1 banner to **stderr** per C-9. Honors `UIS_BANNER_PRINTED=1` env var (set by parent dispatcher to suppress in child invocations, per C-4) when `--silent-if-set` is passed. With `--check-reachable`, runs `pf_probe_reachable` on the active context and emits the four C-9 cases (reachable / unreachable+abort / not-in-platforms / unset). The active platform name comes from `pf_active_platform`. For the unreachable case, calls `pf_platform_summary` on the active platform to pull the platform-specific recovery hint from field 2.
+
+- [ ] 1.2 `chmod +x` not applicable (sourced library, not invoked).
+
+### Validation (Phase 1)
+
+- [ ] 1.3 `bash -n provision-host/uis/lib/platform-switching.sh` parses cleanly.
+- [ ] 1.4 Source standalone in a bash subshell, verify each function resolves: `( source provision-host/uis/lib/platform-switching.sh && for f in pf_active_platform pf_probe_reachable pf_lockstep_flip pf_list_platforms pf_platform_summary pf_banner; do type -t "$f" >/dev/null || { echo "missing: $f"; exit 1; }; done && echo "all functions sourceable" )`.
+- [ ] 1.5 Manual smoke against the running container: `pf_active_platform` returns the current context (probably `rancher-desktop` post-talk47 destroy); `pf_probe_reachable rancher-desktop` returns 0; `pf_list_platforms` emits `rancher-desktop` + `azure-aks` on separate lines.
+
+---
+
+## Phase 2: Per-platform `status.sh --summary` contracts (C-1)
+
+Two scripts: extend the existing `azure-aks/scripts/status.sh` with `--summary` and `--offline` flags, and add a new trivial `rancher-desktop/scripts/status.sh` that owns its 3-of-4 state machine per C-1's rancher-desktop subsection.
+
+### Tasks
+
+- [ ] 2.1 Extend `platforms/azure-aks/scripts/status.sh` with a `--summary` flag:
+
+  - Without flag: keeps existing human-readable multi-line banner (no behavior change).
+  - With `--summary`: emits exactly one tab-separated line `<state>\t<hint>` to stdout per the C-1 enum + state-machine discriminator. Reads env file presence at `.uis.secrets/cloud-accounts/azure-default.env`, kubectl context presence in `kubeconf-all`, and runs `pf_probe_reachable azure-aks` only when both above are present. Hard-codes `--context azure-aks` per C-1's cross-context invocation rule (mirrors PR #158's F12 fix).
+  - With `--summary --offline`: same as `--summary` but skips the probe entirely; state outcome follows C-7's reduced table.
+  - With `--summary --deep`: same as `--summary` but additionally runs the cloud-API check (`az aks show`) for richer status (cluster age, node-pool details). Sourced by `list --deep`. Time bound: not constrained.
+
+  Hint text for each state (field 2):
+
+  ```
+  not-initialized       run './uis platform init azure-aks' to set up
+  configured-not-running run './uis platform up azure-aks' to start it
+  running               <node-count>× <vm-size> in <region>, k8s <version>
+  unreachable           API server timeout after 3s; run './uis platform status azure-aks' for details
+  ```
+
+- [ ] 2.2 Create `platforms/rancher-desktop/scripts/status.sh` — minimal status script for the always-present local platform. Mirrors azure-aks's `--summary` behavior but uses the rancher-desktop 3-state machine (no env file; `not-initialized` reinterpreted as "Rancher Desktop not installed or not started"):
+
+  ```bash
+  not-initialized  install Rancher Desktop and start it, then './uis start'
+  running          local k8s, k3s <version>
+  unreachable      start Rancher Desktop
+  ```
+
+  Without `--summary` the script emits a short human-readable banner (matches azure-aks's no-flag shape but rancher-desktop has nothing cluster-cost-related to report).
+
+- [ ] 2.3 `chmod +x platforms/rancher-desktop/scripts/status.sh`.
+
+### Validation (Phase 2)
+
+- [ ] 2.4 `bash -n platforms/azure-aks/scripts/status.sh` and `bash -n platforms/rancher-desktop/scripts/status.sh` parse cleanly.
+- [ ] 2.5 Manual smoke (current state, in the running container):
+  - `bash platforms/rancher-desktop/scripts/status.sh --summary` → `running\tlocal k8s, k3s ...` (since the host's Rancher Desktop is running and probe succeeds).
+  - `bash platforms/azure-aks/scripts/status.sh --summary` → `configured-not-running\trun './uis platform up azure-aks' to start it` (env file from talk47 is preserved; no cluster).
+  - `bash platforms/rancher-desktop/scripts/status.sh` (no flag) → existing banner output, unchanged shape.
+  - `bash platforms/azure-aks/scripts/status.sh` (no flag) → existing banner output, unchanged.
+- [ ] 2.6 `--offline` smoke: `bash platforms/azure-aks/scripts/status.sh --summary --offline` returns the same state as 2.5's azure-aks line, but without running the kubectl probe (measurable as <100ms via `time`).
+
+---
+
+## Phase 3: `./uis platform list` command
+
+New dispatcher case in `uis-cli.sh`, delegating to a new `cmd_platform_list` function.
+
+### Tasks
+
+- [ ] 3.1 In `provision-host/uis/manage/uis-cli.sh`, add a `list)` case to `cmd_platform`'s subcommand switch, parallel to `init / up / status / down`. Route to `cmd_platform_list`.
+
+- [ ] 3.2 Add `cmd_platform_list` after `cmd_platform_status`. Sources `platform-switching.sh`. Accepts `--offline` and `--deep` flags (mutually exclusive). Iterates `pf_list_platforms()` output, invokes `pf_platform_summary <platform> [--offline|--deep]` per row **in parallel** (one background bash per platform, `wait` for all, collect into an indexed array preserving order). Renders the table:
+
+  ```
+  Active: <pf_active_platform output or appropriate C-2 case>
+
+  PLATFORM         STATUS
+  rancher-desktop  ✓ running                   (active)
+  azure-aks        · configured, not running   (run './uis platform up azure-aks' to start it)
+  ```
+
+  Column widths: platform name padded to longest-name + 2 spaces; status icon + state words padded to "configured, not running" length + 3 spaces; hint flush.
+
+  Row visual treatment by C-1 state:
+  - `running` → `✓ running` (green if TTY + not `NO_COLOR=1`)
+  - `not-initialized` → `· not initialized` (dim)
+  - `configured-not-running` → `· configured, not running` (dim)
+  - `unreachable` → `✗ unreachable` (red)
+  - Malformed `status.sh --summary` output → `? error` (yellow)
+
+  Active row gets a trailing `(active)` annotation; per C-2, if active context isn't a UIS platform OR isn't set, NO row gets `(active)` and the header `Active:` line surfaces the external/unset state.
+
+- [ ] 3.3 Update `cmd_help`'s `Platform:` section to include `platform list <provider?>    List potential platforms and their status` between `init` and `up`. Use the host-runnable `./uis ...` form per the talk47 follow-up cosmetic memory.
+
+### Validation (Phase 3)
+
+- [ ] 3.4 `bash -n provision-host/uis/manage/uis-cli.sh` parses cleanly.
+- [ ] 3.5 Inside the container after Phase 2's status scripts ship + the binary is rebuilt:
+  - `uis platform list` → shows rancher-desktop running + azure-aks configured-not-running, completes under 500ms (`time uis platform list`).
+  - `uis platform list --offline` → same rows but no probe runs; under 100ms.
+  - `uis platform list --deep` → same rows but with extended hint text (`1× Standard_B2s_v2 in westeurope, k8s 1.34` for running azure-aks); 2-5s typical when AKS is up.
+  - `uis help` → `platform list` row shown alongside the others, no "not yet implemented" tag.
+
+---
+
+## Phase 4: `./uis platform use <name>` command
+
+New dispatcher case + the lockstep-flip command itself, routing through `pf_lockstep_flip`.
+
+### Tasks
+
+- [ ] 4.1 In `cmd_platform`'s subcommand switch, add a `use)` case routing to `cmd_platform_use`.
+
+- [ ] 4.2 Add `cmd_platform_use` after `cmd_platform_list`. Sources `platform-switching.sh`. Accepts `--offline` flag and an optional `<name>` positional.
+
+  - No `<name>` → interactive picker per C-8: print the same table `list` shows, but only `running` rows get `[N]` selectors; non-selectable rows appear without selectors with their inline pointer. Footer prompt: `Pick a platform [1-N]:`. Plain `read -p`, no `fzf`.
+  - With `<name>` → call `pf_platform_summary "$name"`, parse field 1, dispatch per Q5's enum table:
+    - `not-initialized` → emit `✗ <name> is not initialized.\n  Run './uis platform init <name>' first.` to stderr, exit non-zero. `--offline` does NOT override.
+    - `configured-not-running` → emit `✗ <name> is configured but not running.\n  Run './uis platform up <name>' to start it.` to stderr, exit non-zero. `--offline` does NOT override.
+    - `running` → call `pf_lockstep_flip "$name"`, emit `✓ Switched: <from> → <name>` to stdout (using `pf_active_platform` for the `<from>` value, captured before the flip), exit 0. If `<name>` equals the current active platform, treat as a no-op + reachability re-probe: emit `ℹ  Already active: <name>. Re-probing... ✓ still reachable.` and exit 0. If the re-probe fails, emit `✗ <name> is no longer reachable (API server timeout after 3s).` + recovery hint, exit non-zero (active platform doesn't change).
+    - `unreachable` → emit `✗ <name> is unreachable (API server timeout after 3s).\n  Check the cluster state with './uis platform status <name>'.\n  To switch anyway (e.g. to clean up stale kubectl state), use --offline.` to stderr, exit non-zero. `--offline` overrides this case only: call `pf_lockstep_flip` despite reachability failure, emit the `✓ Switched: ... (forced; cluster not reachable)` form.
+
+- [ ] 4.3 Update `cmd_help` to add a `platform use <provider>` row.
+
+### Validation (Phase 4)
+
+- [ ] 4.4 `bash -n` clean.
+- [ ] 4.5 Inside the container (rancher-desktop running, azure-aks env file present but no cluster):
+  - `uis platform use rancher-desktop` (already active) → `ℹ  Already active... ✓ still reachable.`, exit 0.
+  - `uis platform use azure-aks` → refuses with `configured-not-running` pointer at `./uis platform up azure-aks`, exit 1.
+  - `uis platform use google-gke` → refuses with `not-initialized` pointer at `./uis platform init google-gke`, exit 1.
+  - `uis platform use azure-aks --offline` → also refuses (configured-not-running can't be overridden), exit 1.
+  - `uis platform use` (no arg) → interactive picker with only rancher-desktop selectable, azure-aks shown without `[N]` + its pointer.
+
+---
+
+## Phase 5: Layer 1 banner — inject into every cluster-touching `./uis` command
+
+Per Q2 + C-9: every cluster-touching command emits the banner to stderr before its first action. Implementation: each `cmd_<verb>` function in `uis-cli.sh` calls `pf_banner --silent-if-set --check-reachable` near its top, before delegating. `--silent-if-set` honors `UIS_BANNER_PRINTED=1` for the `stack install`-child case (C-4).
+
+### Tasks
+
+- [ ] 5.1 In `provision-host/uis/manage/uis-cli.sh`, insert `pf_banner --silent-if-set --check-reachable` at the top of each cluster-touching command function, immediately after argument parsing:
+
+  - `cmd_deploy`
+  - `cmd_undeploy`
+  - `cmd_configure`
+  - `cmd_expose`
+  - `cmd_status`
+  - `cmd_list` (the service-list, not `cmd_platform_list`)
+  - `cmd_stack_install` (parent — sets `UIS_BANNER_PRINTED=1` before invoking children)
+  - `cmd_test_all`
+  - `cmd_platform_up`
+  - `cmd_platform_down`
+  - `cmd_platform_status`
+  - `cmd_platform_use`
+  - `cmd_platform_list`
+
+  **Skip** (no banner) — these don't touch any cluster: `cmd_help`, `cmd_version`, `cmd_container`, `cmd_pull`, `cmd_build`, `cmd_start`, `cmd_stop`, `cmd_restart`, `cmd_shell`, `cmd_tools_*`, `cmd_init` (the UIS-level setup wizard, not platform init), `cmd_platform_init` (creates an env file, no cluster touched yet).
+
+  Wait — `cmd_platform_init` deserves a special note: it logs into Azure (cloud API) but doesn't touch a kubernetes cluster. Per Q2 the banner is for *cluster-touching* commands. Mark `init` as not-cluster-touching → no banner. Matches the principle that init writes the env file; nothing kubernetes happens until `up`.
+
+- [ ] 5.2 In `cmd_stack_install` specifically, set `export UIS_BANNER_PRINTED=1` after the parent banner prints, before fanning out to child `./uis deploy <service>` calls. Per C-4 this is the only place the env var is needed.
+
+### Validation (Phase 5)
+
+- [ ] 5.3 Inside the container:
+  - `uis deploy nginx` → banner `ℹ  Platform: rancher-desktop (reachable)` to stderr before the deploy starts. Pipe test: `uis deploy nginx 2>/dev/null` suppresses the banner; `uis deploy nginx >/dev/null` keeps it visible.
+  - `uis help` → no banner (informational command).
+  - `uis tools install azure-aks` (already installed) → no banner (tools commands don't touch clusters).
+  - `uis platform up azure-aks` (no env file → refuses early) → banner not relevant because the command refuses before doing cluster work; need to think about ordering — see Implementation Notes.
+- [ ] 5.4 Manual `unreachable` test: with kubectl context set to something unreachable, run `uis deploy nginx` — expects the unreachable banner block + abort, exit 1. Concrete repro: `kubectl config use-context azure-aks` (without an active cluster), then `uis deploy nginx`.
+
+---
+
+## Phase 6: Converge `02-post-apply.sh` and `03-destroy.sh` onto `pf_lockstep_flip`
+
+The lockstep-flip writer in `platform-switching.sh` now owns the `cluster-config.sh` + kubectl-context write. Replace the existing `sed -i` blocks in `02-post-apply.sh` (auto-flip on up) and `03-destroy.sh` (auto-reset on destroy) with calls to the shared writer.
+
+### Tasks
+
+- [ ] 6.1 In `platforms/azure-aks/scripts/02-post-apply.sh`, replace the existing `sed -i ... cluster-config.sh` block (currently lines 102–115) with:
+  ```bash
+  source /mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh
+  pf_lockstep_flip "$AZURE_AKS_CLUSTER_NAME"   # flips kubectl + cluster-config.sh together
+  ```
+
+- [ ] 6.2 In `platforms/azure-aks/scripts/03-destroy.sh`, replace the existing reset block (currently lines 184–199) with:
+  ```bash
+  source /mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh
+  pf_lockstep_flip "rancher-desktop"   # symmetric reset on tear-down
+  ```
+
+- [ ] 6.3 Move the kubeconfig-context-delete block in `03-destroy.sh` (currently lines 171–177) into `pf_lockstep_flip` itself? **No** — `pf_lockstep_flip` is for switching to an existing context. Context deletion is its own operation. Leave the `kubectl config delete-context` block in `03-destroy.sh` as-is, just before the reset to rancher-desktop.
+
+### Validation (Phase 6)
+
+- [ ] 6.4 `bash -n` on both edited scripts.
+- [ ] 6.5 Live: end-to-end cycle — `uis platform up azure-aks` should auto-flip via the shared writer; `uis platform down azure-aks` should auto-reset via the shared writer. Compare `cluster-config.sh` state before/after each to confirm the writes happen.
+- [ ] 6.6 Defensive: after `up`, manually edit `cluster-config.sh` to point at `rancher-desktop` (simulating external tampering). Then run `uis deploy nginx` — banner should detect the divergence... wait, no: the investigation explicitly drops the divergence banner case per N-C5. So instead: confirm that *despite* the manual edit, kubectl context still says `azure-aks` (because the user only touched the cached projection, not the truth), and `uis deploy nginx` correctly targets azure-aks. The lockstep guarantee holds for reads via kubectl context.
+
+---
+
+## Phase 7: Tester verification round
+
+Single talk round covering everything Layer 4 + Layer 1 ships. Goal is end-to-end against CI-built `:latest` post-merge, mirroring the talk47 protocol.
+
+### Tasks
+
+- [ ] 7.1 File the verification round at `testing/uis1/talk/talk.md`, archiving the previous current round per the talk-naming protocol (`mv talk.md talk<N>.md`, fresh `talk.md`).
+
+- [ ] 7.2 Round outline (final talk.md):
+
+  - **R0** — pull `:latest`, confirm `platform-switching.sh` + `platform/rancher-desktop/scripts/status.sh` + updated `azure-aks/scripts/status.sh` are present in the container; `uis help` shows `platform list` + `platform use` in the Platform section.
+  - **R1 (Tier 1, ~5 min, €0)** — `list` and `use` against the post-talk47 baseline (rancher-desktop running, azure-aks env file present, no cluster):
+    - `uis platform list` → shows both rows correctly with the right states
+    - `uis platform list --offline` → same rows but no probe (verify with `time`)
+    - `uis platform use rancher-desktop` (already active) → no-op + re-probe
+    - `uis platform use azure-aks` (configured-not-running) → refuses with pointer at `up`
+    - `uis platform use google-gke` (not-initialized) → refuses with pointer at `init`
+    - `uis platform use` (no arg) → interactive picker, only rancher-desktop selectable
+    - `uis deploy nginx` → banner shows `Platform: rancher-desktop (reachable)` to stderr, deploy proceeds to rancher-desktop
+  - **R2 (Tier 2, ~25 min, ~€0.05–0.10)** — full novice cycle with `use` flipping between platforms:
+    - `uis platform up azure-aks` (still uses `pf_lockstep_flip` internally via Phase 6) — cluster up
+    - `uis platform list` → both rows now `running`, azure-aks marked `(active)`
+    - `uis platform list --deep` → enhanced status with k8s version + node pool
+    - `uis deploy nginx` → banner shows `Platform: azure-aks (reachable)`, nginx deploys to AKS
+    - `uis platform use rancher-desktop` → success: `✓ Switched: azure-aks → rancher-desktop`
+    - `uis deploy nginx` again → banner now shows `Platform: rancher-desktop`, idempotent skip
+    - `uis platform use azure-aks` → success: switched back
+    - `uis platform down azure-aks` → tear-down + symmetric auto-reset to rancher-desktop via shared writer
+    - `uis platform list` after down → azure-aks back to `configured-not-running`, rancher-desktop active
+  - **R3 (banner safety, ~2 min, no spend)** — simulate the talk41 stale-context scenario by manually breaking kubectl: `KUBECONFIG=/mnt/urbalurbadisk/kubeconfig/kubeconf-all kubectl config use-context <some-nonexistent>`, then `uis deploy nginx`. Banner should fire the unreachable block + abort, exit 1, no deploy attempted.
+
+- [ ] 7.3 Tester rounds close green; any findings filed as F-numbered items follow up.
+
+### Validation (Phase 7)
+
+- [ ] 7.4 Tester confirms R0 + R1 (Tier 1) green at minimum; R2 + R3 close the full bar.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `provision-host/uis/lib/platform-switching.sh` exists with the 6 functions named in Phase 1, all sourceable + invocable standalone.
+- [ ] `platforms/azure-aks/scripts/status.sh` accepts `--summary` / `--offline` / `--deep` flags and emits C-1-conformant output. Backward-compatible: no-flag invocation unchanged.
+- [ ] `platforms/rancher-desktop/scripts/status.sh` exists, runs in <100ms, implements the 3-state rancher-desktop machine.
+- [ ] `./uis platform list` runs in <500ms with 2 platforms; `--offline` <100ms; `--deep` works against a live AKS cluster.
+- [ ] `./uis platform use <name>` correctly refuses for `not-initialized` / `configured-not-running` / `unreachable`; succeeds with lockstep flip for `running`; `--offline` overrides only the unreachable case.
+- [ ] Every cluster-touching `./uis` command emits the Layer 1 banner to stderr before its first action.
+- [ ] `02-post-apply.sh` and `03-destroy.sh` both route their `cluster-config.sh` writes through `pf_lockstep_flip` — no remaining `sed -i ... cluster-config.sh` blocks in either.
+- [ ] Tester closes R0 + R1 + R2 + R3 in the talk round.
+- [ ] CI green on push: Test UIS Scripts, Build UIS Container, Generate UIS Documentation, Deploy Documentation.
+- [ ] Local Docusaurus build clean for this PLAN file.
+
+---
+
+## Implementation Notes
+
+- **Banner before refusal banners.** When `cmd_platform_up azure-aks` is invoked with no env file, `up.sh` refuses early with `✗ No config file found...`. The Layer 1 banner needs to fire *before* this refusal (so the user sees what platform was attempted). The Q2-listed touch points (`cmd_platform_up`, etc.) get the banner at their top, before delegating to the per-platform script. The banner machinery thus needs to compute "active platform" even when the lifecycle script subsequently refuses — that's fine, the banner is about kubectl context, not about whether the platform is set up.
+
+- **Order of dispatch when active context isn't a UIS platform.** If the user's kubectl context is a personal `prod-cluster` and they run `./uis deploy nginx`, the banner emits the C-9 case-3 warning (`not a UIS platform — proceeding with kubectl context anyway`) and the deploy goes ahead against `prod-cluster`. This matches Q5's spirit: UIS doesn't take ownership of contexts it doesn't manage; it just surfaces the situation.
+
+- **`pf_banner` cost on every command.** Default reachability probe is ~50–200ms. For commands that don't actually need a cluster (e.g. `uis status` when no services deployed), this is overhead the user can't opt out of. Acceptable per the investigation's stance — "the cost of one probe per command is the cost of not silently deploying to the wrong cluster".
+
+- **No probe cache.** The investigation explicitly drops the `/tmp` probe cache idea. Each invocation re-probes; staleness can't accumulate. If session-level performance becomes a real problem, revisit with measurements.
+
+- **`status.sh --summary` reads kubeconfig directly, doesn't shell out to `kubectl config get-contexts`.** Parse `kubeconf-all` once with `awk` or a single `kubectl config view --output jsonpath` to get the context list — avoids multiple kubectl invocations per `list` row.
+
+- **Backward compat for `02-post-apply.sh` / `03-destroy.sh`.** The existing `sed -i` writes have been in production through PR #149 and the talk44/45/46/47 cycles. Replacement via `pf_lockstep_flip` must preserve the same outcome (same file contents post-write). Test by diffing `cluster-config.sh` before/after a write in each call site under both old and new code.
+
+- **`cluster-config.sh` CLUSTER_TYPE and TARGET_HOST**. Per the investigation's Edge case #10, both fields always hold the same string. `pf_lockstep_flip` writes both with the same value (matching the existing two `sed -i -e ...` invocations).
+
+- **No need for `cluster-config.sh` locking.** Per Edge case #9, concurrent `use` from two terminals is documented as "last write wins"; the lockstep writer issues both writes (kubectl + sed) back-to-back, sub-millisecond window. Engineering a lock would be overkill for the use case.
+
+---
+
+## Files to Modify
+
+**New:**
+- `provision-host/uis/lib/platform-switching.sh`
+- `platforms/rancher-desktop/scripts/status.sh`
+
+**Modified:**
+- `platforms/azure-aks/scripts/status.sh` — add `--summary` / `--offline` / `--deep` flags (backward-compat preserved)
+- `platforms/azure-aks/scripts/02-post-apply.sh` — replace `sed -i` block with `pf_lockstep_flip` call
+- `platforms/azure-aks/scripts/03-destroy.sh` — replace reset block with `pf_lockstep_flip "rancher-desktop"` call
+- `provision-host/uis/manage/uis-cli.sh` — add `cmd_platform_list` + `cmd_platform_use` + `list)` / `use)` dispatcher cases + banner injection at ~13 command functions + help-banner row additions
+
+**No new platform directories** beyond `platforms/rancher-desktop/` (which is the always-present row from Q3).

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-active-cluster-visibility-ux.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-active-cluster-visibility-ux.md
@@ -4,9 +4,9 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Backlog (Tier 2 — UX safety; scope expanded 2026-05-10 to include cluster switching)
+## Status: Backlog — design questions locked 2026-05-11, ready for child PLAN(s)
 
-**Last Updated**: 2026-05-10
+**Last Updated**: 2026-05-11 — Q1/Q2/Q3/Q4/Q5 decisions locked after talk47 cycle. First gap-sweep settled implementation contracts (status.sh API for `list` consumption, external-context handling, env-file naming convention, banner ownership, performance budget). Second gap-sweep added the C-1 state-machine discriminator + rancher-desktop reinterpretation, renamed flags from `--probe`/`--no-probe` to `--deep`/`--offline` (the two probes are now unambiguous), and added C-9 spelling out that Layer 1's banner is a direct probe (not a `status.sh` consumer). Third gap-sweep unified `use --offline` with `list --offline` (single flag name), dropped `cluster-config.sh` from the `use` success output, specified banner output goes to stderr, fixed banner-format consistency (success one-liner, failure block), added the "no active context" hint pointing at rancher-desktop, and pinned the `use` / `list` consumption flow to `status.sh --summary`. **Layer 4 (`./uis platform list / use`) ships bundled with Layer 1 (per-command banner)** — switching without per-command visibility would leave the same gap talk47 surfaced. Inventory source: `platforms/*/scripts/init.sh` directory listing — see Q3 below.
 
 **Source**: Tester's UX proposal in `testing/uis1/talk/UX-active-cluster-visibility.md` (2026-05-09). Originally triggered by the AKS Tier A verification rounds, where stale kubectl contexts produced silent failures — operators couldn't tell from prompt or command output that they were acting against a dead/wrong cluster.
 
@@ -27,7 +27,8 @@ Today there is **no signal** in the UIS shell or in `./uis` command output that 
 ### Concrete recent incidents this would have prevented
 
 - **Tier A retry №3 silent false positive** (PR #149 testing) — tester's `./uis deploy nginx` ran a phantom replay against rancher-desktop's existing release while the brand-new AKS cluster sat empty. Both the playbook output and the helm chain reported "success". A cluster-banner at the top of `./uis deploy` would have shown `kube_context = rancher-desktop` (not `azure-aks`) and the tester would have caught it before declaring the round green.
-- **Stale port-forward after AKS destroy** (talk41 round) — `kubeconf-all`'s `current-context` still pointed at the destroyed cluster after `03-destroy.sh`. `./uis expose postgresql` happily reported `[SUCCESS]` while `kubectl port-forward` zombied behind the scenes. A reachability probe in Layer 1 (below) would have aborted before the port-forward attempt.
+- **Stale port-forward after AKS destroy** (talk41 round) — `kubeconf-all`'s `current-context` still pointed at the destroyed cluster after `03-destroy.sh`. `./uis expose postgresql` happily reported `[SUCCESS]` while `kubectl port-forward` zombied behind the scenes. **Partially mitigated** by `03-destroy.sh`'s kubeconfig-context-delete + cluster-config.sh-reset added in PR #149 (lines 171–199), but a Layer 1 reachability probe would still catch any divergence introduced manually between flips.
+- **talk47 R7 final state observation** — even with `03-destroy.sh`'s cleanup, the operator coming back to UIS the next day has *no* command that answers "what platforms do I have here, and which one is the next `./uis deploy` going to target?" without `cat`-ing config files by hand. This investigation's Layer 4 (`list / use`) is the answer.
 - **Earlier multi-cluster confusion incidents** — talk37 (postgres purge) and talk23-ish (backstage 401 verify) both involved "where is this command actually going" ambiguity.
 
 ### The switching gap (added 2026-05-10)
@@ -53,7 +54,7 @@ Two candidates:
 
 The truth is **both must agree**, and divergence between them is its own class of bug worth surfacing (the Tier A rounds had this exact divergence).
 
-**Proposal to validate**: surface kubectl current-context as the *primary* signal (it's what actually fires the API calls), and emit a warning when `cluster-config.sh` disagrees. This frames cluster-config as a hint, kubectl context as truth.
+**Decision (2026-05-11)**: `kubectl current-context` is **truth for reads** — every consumer that needs to know "where am I" reads it. `cluster-config.sh.TARGET_HOST` becomes a **cached projection** that's written by `use` (Q4) in lockstep with the kubectl context, and never read independently for "which cluster?" decisions. The two-source class of bug disappears because the only writer is `use`, which keeps them aligned by construction. (Ansible playbooks that today read `TARGET_HOST` from cluster-config keep doing so — they're reading the cached projection, not making an independent decision.)
 
 ### Q2 — Where should the signal live?
 
@@ -61,66 +62,315 @@ The truth is **both must agree**, and divergence between them is its own class o
 - **Per-`./uis` command output** — visible per command, including from outside the shell. Makes logs/screenshots self-describing.
 - **Both** — they serve different audiences. Both are cheap.
 
+**Decision (2026-05-11)**: **per-command banner (Layer 1) is a hard co-ship with Layer 4**, not deferred. The rule: *every `./uis` command that operates on a cluster must display which platform it's targeting before doing anything else*. Without this, Layer 4's `use` would let you switch platforms but the next `./uis deploy` would give no signal of where it's heading — recreating the exact "where does this go?" gap that talk47 surfaced.
+
+Banner applies to all cluster-touching commands: `./uis deploy`, `./uis undeploy`, `./uis configure`, `./uis expose`, `./uis status`, `./uis list`, `./uis stack install`, `./uis test-all`, *and* `./uis platform up / down / status / use`. Excluded: purely-informational commands that touch no cluster (`./uis help`, `./uis version`, `./uis container`, `./uis pull`, `./uis build`).
+
+PS1 (Layer 2) stays deferred — it only helps in-shell users, and the per-command banner already covers them too.
+
 ### Q3 — What's in the cluster inventory?
 
 `./uis platform list` (Layer 4 below) needs to enumerate available clusters from somewhere. Three candidate sources, each with different drift modes:
 
-- **Kubeconfig contexts** (`kubectl config get-contexts`). Authoritative for "what `kubectl` can connect to", but accumulates stale entries from destroyed clusters that nothing prunes.
-- **`.uis.secrets/cloud-accounts/*.env` files**. Tells you "what UIS *can* provision/manage" and survives `down`. Says nothing about whether the cluster is currently up.
+- **Kubeconfig contexts** (`kubectl config get-contexts`). Authoritative for "what `kubectl` can connect to". Drift mode: accumulates stale entries from destroyed clusters — *partially mitigated* by `03-destroy.sh`'s `delete-context` (PR #149), but only for clusters torn down via UIS.
+- **`.uis.secrets/cloud-accounts/*.env` files**. Tells you "what UIS has been told about" via the wizard, survives `down`. Drift mode: shows nothing about platforms the user hasn't yet initialized.
 - **`cluster-config.sh` history**. Only knows about the *last* cluster UIS touched, not the full set.
 
-**Proposal to validate**: union all three. Annotate each entry with reachability (`✓ reachable / ✗ unreachable / · not currently provisioned`) and a "last active" timestamp. Stale kubeconfig entries (in kubeconfig but unreachable, with no live cloud-account) are surfaced as candidates for cleanup.
+**Decision (2026-05-11) — narrowed from "union of three" to a single source: `platforms/*/scripts/init.sh` directory listing**. Reasoning:
+
+- The user's framing (talk47 discussion) is **"potential platforms and their status"** — not "currently-reachable clusters" and not "configured clusters". So the inventory is *every platform UIS knows how to onboard you to*, regardless of whether you've started it. A platform exists in `./uis platform list` from the moment its `init.sh` is added to the repo.
+- Inventory is the directory listing — bulletproof, no drift, no central registry to maintain. When `google-gke`, `aws-eks`, or `azure-microk8s` ships, it appears in `list` automatically.
+- **rancher-desktop is the one special case** — it has no `init.sh` because Rancher Desktop is installed at the OS level, not via UIS. Hard-coded as an always-present row.
+- **Per-row status comes from each platform's own `status.sh`**, not from a central inventory module. Today only `azure-aks/scripts/status.sh` exists; rancher-desktop needs a trivial `status.sh` added (kubeconfig-context-present-and-reachable check). Each platform owns its own status reporting.
+- Kubeconfig and cloud-accounts files are *status inputs*, not inventory sources. `status.sh` reads them to decide which of {not initialized / configured but not running / running / unreachable} to report.
+
+What `list` displays in the post-talk47 world (one initialized platform, rancher-desktop as default, three future platforms not yet in `platforms/`):
+
+```
+$ ./uis platform list
+
+Active: rancher-desktop
+
+PLATFORM         STATUS
+rancher-desktop  ✓ running
+azure-aks        · configured, not running   (run './uis platform up azure-aks' to start it)
+```
+
+If `azure-aks` is up:
+
+```
+PLATFORM         STATUS
+rancher-desktop  ✓ running
+azure-aks        ✓ running                   (active)
+```
+
+If the user never ran `init`:
+
+```
+PLATFORM         STATUS
+rancher-desktop  ✓ running                   (active)
+azure-aks        · not initialized           (run './uis platform init azure-aks' to set up)
+```
+
+Future platforms (`google-gke`, `aws-eks`, `azure-microk8s`) appear automatically once their `platforms/<name>/scripts/init.sh` lands. No table-update work needed.
 
 ### Q4 — How does `use` write the active cluster?
 
 Switching means flipping both `kubectl current-context` and `cluster-config.sh`'s `TARGET_HOST` so they agree. Three options:
 
-- **(a) Lockstep flip.** Concrete and explicit; adds a write path to `cluster-config.sh` that today only `02-post-apply.sh` ever touches.
+- **(a) Lockstep flip.** Concrete and explicit; adds a write path to `cluster-config.sh` that today only `02-post-apply.sh` and `03-destroy.sh` touch (via `sed -i`).
 - **(b) Flip kubectl context only; treat `cluster-config.sh` as derived.** Regenerate `TARGET_HOST` from the new context's name on every read. Simpler invariant but requires that context names map cleanly to UIS cluster types — true today (`rancher-desktop`, `azure-aks`) but fragile if someone renames a context.
 - **(c) Flip kubectl context, then warn if `cluster-config.sh` disagrees** — leaving the user to decide. Punts the problem and breaks Q1's "both must agree" invariant.
 
-**Proposal to validate**: (a) lockstep flip. Bounds Q1: `kubectl current-context` is *truth for reads*, `use` writes both atomically, `cluster-config.sh` becomes a cached projection that's always written by `use` and never read independently for "active cluster" decisions.
+**Decision (2026-05-11)**: **(a) lockstep flip**. Concretely:
+
+- `./uis platform use <name>` writes both `kubectl current-context` (via `kubectl config use-context`) AND `cluster-config.sh.{CLUSTER_TYPE,TARGET_HOST}` (via the same `sed -i` pattern that `02-post-apply.sh` and `03-destroy.sh` already use).
+- `02-post-apply.sh`'s auto-flip-on-up and `03-destroy.sh`'s auto-reset-on-destroy *also* go through this same shared writer once `use` exists — the three call sites converge on one function in `provision-host/uis/lib/platform-switching.sh` so the write logic lives in one place.
+- `cluster-config.sh` becomes a **cached projection** that is *always written by `use`* and *never read independently* for "active cluster" decisions. Ansible playbooks that today read `TARGET_HOST` are reading the cached projection, not making their own decision — by construction it agrees with kubectl.
 
 ### Q5 — What's the switch verb?
 
 `./uis platform use <name>` (kubectl-style, fast, no reachability check) vs `./uis platform switch <name>` (with reachability probe + lockstep flip)? Or just one verb with both behaviours?
 
-**Proposal to validate**: one verb, `use`, with reachability-probe-and-refuse semantics by default. If the user explicitly wants to switch to an unreachable cluster (e.g. to clean up a stale kubeconfig entry), they can pass `--no-probe`. Matches `kubectl config use-context` in feel; matches Layer 1's reachability-aborts-on-unreachable in safety.
+**Decision (2026-05-11)**: one verb, `./uis platform use <name>`, with **refuse-unless-initialized-and-reachable** by default. The state-machine call: `use <name>` invokes `<name>'s status.sh --summary` (the C-1 contract), parses field 1, and dispatches on the enum:
+
+- **`not-initialized`** — refuse with pointer at `./uis platform init <name>`. (`--offline` cannot override this — there's no platform to switch *to*.)
+- **`configured-not-running`** — refuse with pointer at `./uis platform up <name>`. The inverse of `init` — you can't `use` a platform that isn't actually running. (`--offline` cannot override this either; the kubectl context doesn't even exist in kubeconf-all yet.)
+- **`running`** — lockstep flip (Q4), success banner showing the transition.
+- **`unreachable`** — refuse with pointer at `./uis platform status <name>` + recovery hint. **`--offline` overrides this case only** — switches anyway, for the "I know it's broken, I want to inspect / clean up" workflow.
+- **No-op + reachability re-probe** if you `use` the already-active platform — useful as an "is my cluster still up?" check. If the re-probe fails, emit `✗ <name> is no longer reachable` + recovery hint, exit non-zero; the active platform doesn't change (it was already the target).
+
+For **rancher-desktop** specifically, only 3 of the 4 cases fire per C-1's rancher-desktop subsection — `configured-not-running` never applies (Rancher Desktop is installed at the OS level, not provisioned by UIS).
+
+Flag name `--offline` (not `--no-probe`) is intentional — it matches `list --offline`. Both flags mean "skip the kubectl reachability probe"; the operational difference is the consumer (`list` shows all platforms optimistically vs. `use` switches to *one* platform optimistically). Same underlying mechanic, same flag name.
+
+Verb name `use` matches `kubectl config use-context` in feel and `./uis platform up/down/init/status/use` keeps the family consistent.
+
+---
+
+## Implementation contracts (settled 2026-05-11)
+
+Decisions on the shapes the child PLAN must respect. Pulled out of "implementation deferred" because each of these has at least one consumer (`list`, `use`, banner) that can't be designed without them.
+
+### C-1 — `status.sh --summary` contract
+
+Each platform's `platforms/<name>/scripts/status.sh` gains a `--summary` flag. Without the flag it keeps emitting today's human-readable multi-line banner (azure-aks already does this, unchanged). With the flag it emits **exactly one line** to stdout, tab-separated:
+
+```
+<state>\t<one-line-hint>
+```
+
+Where `<state>` is one of a fixed enum:
+
+| State | Meaning | Example second-field hint |
+|---|---|---|
+| `not-initialized` | No env file or equivalent setup; UIS has never been told about this platform | `run './uis platform init azure-aks' to set up` |
+| `configured-not-running` | Initialized (env file present) but no cluster is currently provisioned | `run './uis platform up azure-aks' to start it` |
+| `running` | Cluster is provisioned and reachable | `1× Standard_B2s_v2 in westeurope, k8s 1.34` |
+| `unreachable` | Cluster expected up (kubectl context exists in kubeconf-all) but the API server is unreachable | `API server timeout after 3s; run './uis platform status azure-aks' for details` |
+
+#### State-machine discriminator
+
+Two signals fully determine the state for a cloud-managed platform — no other inputs needed:
+
+1. **Env file presence** at the cloud's path (per C-3): `.uis.secrets/cloud-accounts/<cloud>-default.env`
+2. **kubectl context presence** in `kubeconf-all` (matching the platform directory name per C-5)
+3. **Reachability probe** (only when both above are present): `kubectl --context <name> --request-timeout=3s get --raw /version`
+
+The mapping:
+
+| Env file | kubectl context in kubeconf-all | Reachability probe | State |
+|---|---|---|---|
+| absent | — | — | `not-initialized` |
+| present | absent | — | `configured-not-running` |
+| present | present | succeeds | `running` |
+| present | present | fails | `unreachable` |
+
+This works because `02-post-apply.sh` adds the kubectl context to `kubeconf-all` only when the cluster is actually provisioned, and `03-destroy.sh` removes it on tear-down. So *kubectl-context-in-kubeconf-all* is a reliable proxy for "cluster was successfully provisioned" — without it we couldn't distinguish "configured but not yet up" from "configured and running but currently broken".
+
+#### Rancher-desktop is special
+
+Rancher Desktop is installed at the OS level, not by UIS, so it has no env file (C-3). Its `status.sh --summary` uses **3 of the 4 states** with `not-initialized` reinterpreted:
+
+| kubectl context `rancher-desktop` in kubeconf-all | Reachability probe | State for rancher-desktop |
+|---|---|---|
+| absent | — | `not-initialized` — semantically "Rancher Desktop not installed or never started"; hint: `install Rancher Desktop and start it, then './uis start'` |
+| present | succeeds | `running` |
+| present | fails | `unreachable` — Rancher Desktop is installed but not currently running; hint: `start Rancher Desktop` |
+
+`configured-not-running` doesn't apply to rancher-desktop (there's nothing UIS can "configure" — installation is the user's OS step).
+
+#### Cross-context kubectl invocation
+
+When `azure-aks/scripts/status.sh --summary` runs while the operator is currently on the rancher-desktop context, the probe MUST explicitly target the platform's own context: `kubectl --context azure-aks --request-timeout=3s get --raw /version`. Bare `kubectl` would probe the active context (rancher-desktop), giving wrong-cluster answers — exact F12 from talk46. Each platform's status.sh hard-codes `--context <its own platform name>`.
+
+#### Output, exit codes, performance
+
+`list` parses field 1 to pick the row's visual treatment (✓ / · / ✗), prints field 2 verbatim as the right-hand hint. Exit code: 0 in all four states (`--summary` is a state report, not a check; the state itself encodes "healthy or not"). Non-zero exit only if the script itself errors (missing tools, malformed env file, etc.) — in which case `list` shows `? error` for that row and the user runs the script bare for the full diagnostic.
+
+`--summary` MUST be fast (target: under 200 ms). It reads local files (env file presence, kubectl context list) and at most does one short-timeout kubectl probe against the platform's own context. **It does NOT call cloud APIs** (`az aks show`, `gcloud container clusters describe`, etc.) — those go in the no-flag deep-status path. This bounds `list`'s total time to ~200 ms × N-platforms / parallelism.
+
+A `status.sh --summary --deep` variant additionally runs cloud-API calls for richer status (cluster age, node-pool details, cost estimate), invoked by `list --deep` (see C-7). Default `list` skips it.
+
+### C-2 — Active platform when kubectl points outside `platforms/`
+
+Possible states of kubectl current-context vs the platforms inventory:
+
+| kubectl current-context state | `Active:` header in `list` | `(active)` row annotation |
+|---|---|---|
+| Matches one of the listed platforms | `Active: <name>` | Yes, on that row |
+| Matches a context not in `platforms/` (e.g. user's personal `prod-cluster`) | `Active: <name> (not a UIS platform — use './uis platform use <name>' to switch to one)` | No row gets it |
+| Unset / empty | `Active: (none — run './uis platform use <name>' to pick one)` | No row gets it |
+
+`list` does not surface non-UIS contexts as rows (Q3 — inventory is `platforms/*/scripts/init.sh`, not kubeconfig). It only acknowledges them in the `Active:` header so the user isn't confused when no row says `(active)`.
+
+### C-3 — Env-file naming convention (per-cloud, not per-platform)
+
+`.uis.secrets/cloud-accounts/<cloud>-default.env` files are **per-cloud**, not per-platform. One file serves every platform on that cloud. So:
+
+| File | Serves |
+|---|---|
+| `azure-default.env` | `azure-aks`, `azure-microk8s` (the latter when it lands) |
+| `google-default.env` | `google-gke` (and any future `google-*` platforms) |
+| `aws-default.env` | `aws-eks` (and any future `aws-*` platforms) |
+
+Reasoning: identity (tenant/subscription/region) is cloud-scoped, not platform-scoped. The wizard for `azure-microk8s` would re-use the same `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` the AKS wizard wrote. Forcing a separate `azure-aks-default.env` and `azure-microk8s-default.env` would either duplicate identity values or require the user to pick which one to write.
+
+Per-platform overrides (e.g. `AZURE_AKS_NODE_SIZE`, `AZURE_AKS_CLUSTER_NAME`) sit inside the same file as commented optional overrides — the existing AKS pattern, extended cloud-wide when new platforms ship. `rancher-desktop` doesn't have an env file (it's installed at the OS level, not by UIS).
+
+`status.sh --summary` for each platform reads its cloud's env file by hard-coded path: `azure-aks/scripts/status.sh` reads `azure-default.env`, `google-gke/scripts/status.sh` reads `google-default.env`. The mapping is platform-internal, not centrally registered.
+
+### C-4 — Banner ownership: dispatcher prints, playbooks never
+
+The Layer 1 banner is emitted **exactly once per `./uis` invocation**, by the dispatcher layer (`uis-cli.sh`'s `cmd_<verb>` function), before delegating to anything else. Ansible playbooks, helm chains, and sub-shell scripts the dispatcher invokes never emit their own banner — they inherit it by virtue of running underneath the parent invocation.
+
+This sidesteps the `UIS_BANNER_PRINTED=1` env-var propagation question: there's no inheritance needed because the banner is a dispatcher-layer concern, not a playbook-layer concern. The playbooks keep emitting their own `[INFO]` / `[SUCCESS]` / per-task output — different signal, different layer.
+
+`./uis stack install` (which fans out to multiple `./uis deploy <service>` calls) is the one exception: it'd want a single banner at the parent invocation, then *suppress* the per-deploy banners that follow. Implementation: the parent sets `UIS_BANNER_PRINTED=1` in its environment before invoking children; child dispatchers check it and skip. This is the only place the env var is needed.
+
+### C-5 — Convention: platform directory name == kubectl context name
+
+`./uis platform use azure-aks` assumes the kubectl context named `azure-aks` exists in `kubeconf-all`. This is true today (`02-post-apply.sh` writes `kubeconf-all` with context name = `${AZURE_AKS_CLUSTER_NAME:-azure-aks}` = the platform directory name). The convention is: **each platform's `init.sh` / lifecycle scripts MUST write a kubectl context whose name equals the platform's directory name under `platforms/`**.
+
+Future platforms that need to deviate (e.g. multi-cluster setups where one platform spawns several contexts) get a separate design conversation. For the current 5-platform horizon, the convention holds.
+
+### C-6 — `list` performance budget + the three list modes
+
+There are two distinct "probes" in this design and the flag names must keep them straight:
+
+- **kubectl reachability probe** — cheap (~200 ms), in-cluster, runs by default. Fires the C-1 state machine's reachability check.
+- **cloud-API deep check** — expensive (~2-5 s), hits Azure/GCP/AWS APIs, off by default. Fetches rich status (cluster age, node-pool details, cost).
+
+Three `list` modes flow from this:
+
+| Command | kubectl probe? | Cloud-API check? | Target time | When to use |
+|---|---|---|---|---|
+| `list` (default) | yes | no | ~500 ms | normal case |
+| `list --offline` | no | no | under 100 ms | offline / "just show me the inventory, don't connect" |
+| `list --deep` | yes | yes | 2-5 s typical | "give me everything"; platform-dependent |
+
+The same `--offline` flag is honored by `./uis platform use` per Q5 — both consumers skip the reachability probe under that flag. `--deep` is `list`-only (it'd be wasted on `use`, which only cares about one platform's reachability).
+
+**Performance target for the default `list`**: under 500 ms with up to 8 platforms.
+
+Achieved by:
+- Each `status.sh --summary` call is under 200 ms (no cloud-API calls — see C-1)
+- `list` invokes them in parallel (one background process per platform, `wait`, collect outputs)
+- Total time ≈ max-single-status-summary-time + a small parallel-coordination overhead
+
+### C-7 — `list --offline` semantics
+
+`list --offline` skips the kubectl reachability probe entirely. Each platform's row state is decided by the C-1 discriminator's first two columns only (env file presence + kubectl context presence in kubeconf-all). State outcomes change:
+
+| Env file | kubectl context | State under `--offline` |
+|---|---|---|
+| absent | — | `not-initialized` |
+| present | absent | `configured-not-running` |
+| present | present | `running` (assumed — we don't actually check) |
+
+The `unreachable` state never fires under `--offline`. The trade-off is explicit: when the user adds the flag, they accept "I'll find out later if these clusters are actually up". Useful when the user is offline, knows the clusters are up, or just wants the inventory list fast for a script.
+
+Internally, `--offline` is propagated to each platform's `status.sh --summary --offline` so each script can short-circuit its own probe.
+
+### C-8 — `use` interactive picker
+
+`./uis platform use` with no argument prints the same table `list` shows, but **only the rows in state `running` get numbered `[N]` selectors**. Other rows appear in the table without selectors, with their inline pointer (e.g. `run './uis platform up azure-aks' to start it`) visible — no dimming, no ANSI tricks, just absence of the `[N]`. A footer line tells the user how to make unreachable rows selectable. Implementation: plain numbered `read -p` prompt. No `fzf` dependency.
+
+Example with one running platform + one configured-but-not-running platform:
+
+```
+$ ./uis platform use
+
+PLATFORM             STATUS
+[1] rancher-desktop  ✓ running                   (currently active)
+    azure-aks        · configured, not running   (run './uis platform up azure-aks' to start it)
+
+Pick a platform [1-1]: 1
+ℹ  Already active: rancher-desktop. Re-probing... ✓ still reachable.
+```
+
+### C-9 — Layer 1 banner: probe model, output stream, format
+
+Layer 1's banner asks a different question from `list`'s rows. `list` enumerates platforms and renders per-row status; the banner names the *currently active* one and confirms it's reachable, before whatever command the user just typed runs.
+
+**Probe model**: in the common case (active context reachable), Layer 1 directly reads `kubectl current-context` and runs the cheap reachability probe — does NOT route through `status.sh --summary`. That would be one indirection too many for a per-command banner that fires ~50 times in a typical session. **Only in the unreachable case** does the banner call `<active-platform>'s status.sh --summary` to pull the platform-specific recovery hint (cost: one extra ~200 ms call, only on the rare error path).
+
+The shared primitive both Layer 1 and `status.sh --summary` use lives in `provision-host/uis/lib/platform-switching.sh`:
+
+```bash
+pf_probe_reachable <context>   # 0 if reachable, non-zero otherwise; timeout 3s
+```
+
+Both consumers call this same function. Layer 1 wraps it to print the banner; `status.sh --summary` wraps it to decide the C-1 state.
+
+**Output stream**: banner writes to **stderr**, not stdout. Users piping `./uis deploy <service> > log.txt` (or `| grep ...`) get the data on stdout and the banner stays visible in their terminal. Matches Unix convention for status/diagnostic output.
+
+**Format by case** (success cases one-liner, fail cases multi-line block with recovery — deliberate asymmetry: success doesn't need instructions, failure does):
+
+| Active context state | Banner |
+|---|---|
+| In `platforms/` AND reachable | one-liner: `ℹ  Platform: azure-aks (reachable)` |
+| In `platforms/` BUT unreachable | multi-line block: `✗ Platform: <name>, but the API server is unreachable.` + recovery hint from `<name>'s status.sh --summary` field 2 + abort |
+| Not in `platforms/` (e.g. user's personal context) | one-liner: `⚠  Platform: <name> (not a UIS platform — proceeding with kubectl context anyway)` |
+| Unset | multi-line block: `⚠  No active kubectl context set.` + `Run './uis platform use rancher-desktop' (the default) or './uis platform list' to see what you have.` + abort |
+
+For the unset case, the hint specifically names `rancher-desktop` because it's the always-present default (per Q3) — a fresh-from-zero user with no Azure setup yet can recover by switching to rancher-desktop without needing to first run `init`.
+
+Divergence between kubectl context and `cluster-config.sh` is **not** a banner case — post-lockstep it's impossible by construction, and surfacing `cluster-config.sh` (an internal cached projection) to the user would leak implementation. The banner targets only the kubectl context (Q1's truth).
 
 ---
 
 ## Layered design sketch
 
-### Layer 1 — `./uis` output banner (do first, lowest risk, broadest reach)
+### Layer 1 — `./uis` output banner (co-ships with Layer 4)
 
-Every `./uis` subcommand that touches a cluster prints a one-line banner before its first action:
+Every `./uis` subcommand that touches a cluster prints a one-line banner before its first action. Per C-9, the banner is driven by kubectl current-context + the cheap reachability probe — it does NOT route through `status.sh --summary`. Four cases per C-9; the most common two:
 
-```
-ℹ  Cluster: rancher-desktop  (kubectl: rancher-desktop, config: rancher-desktop)
-```
-
-Divergence:
+Active and reachable:
 
 ```
-⚠  Cluster mismatch — kubectl: azure-aks, cluster-config.sh: rancher-desktop
-   These should agree. Continuing with kubectl context.
+ℹ  Platform: rancher-desktop  (reachable)
 ```
 
-API server unreachable (talk41 case):
+Active but API server unreachable (talk41 case):
 
 ```
-✗  Cluster: azure-aks (kubectl), but the API server is unreachable.
-   Likely the cluster was destroyed. Run './uis cluster reset' or fix kubeconfig.
+✗  Platform: azure-aks, but the API server is unreachable.
+   Likely the cluster was destroyed or stopped.
+   Recover with: ./uis platform status azure-aks
+   Or switch:    ./uis platform use rancher-desktop  (or another reachable platform)
    Aborting.
 ```
 
-**Implementation shape**: a sourced helper (`provision-host/uis/lib/cluster-banner.sh`, ~30 lines) called at the top of each cluster-touching command. One-shot reachability probe (`kubectl --request-timeout=3s get --raw /version`); fails fast.
+The remaining two cases (active context isn't a UIS platform / no active context) are in C-9. Divergence between kubectl context and `cluster-config.sh` is **not** a banner case — post-lockstep it's impossible by construction, and surfacing `cluster-config.sh` (an internal cached projection) to the user would just leak implementation.
 
-**Touches**: `./uis deploy`, `./uis undeploy`, `./uis configure`, `./uis expose`, `./uis status`, `./uis list`, `./uis stack install`, `./uis test-all`. Skip purely informational commands (`./uis help`, `./uis version`, `./uis container`).
+**Implementation shape**: shared primitive in `provision-host/uis/lib/platform-switching.sh` (`pf_probe_reachable <context>`). Same primitive used by `status.sh --summary` per C-1.
+
+**Touches**: every cluster-touching command from Q2 — `./uis deploy`, `./uis undeploy`, `./uis configure`, `./uis expose`, `./uis status`, `./uis list`, `./uis stack install`, `./uis test-all`, plus the `./uis platform` family (`up`, `down`, `status`, `use`). Skip purely informational commands (`./uis help`, `./uis version`, `./uis container`, `./uis pull`, `./uis build`).
 
 ### Layer 2 — coloured PS1 inside `./uis shell`
 
-Modify the container's bashrc so PS1 includes a cluster tag:
+Modify the container's bashrc so PS1 includes a platform tag:
 
 ```
 [rancher-desktop] ansible@uis:/mnt/urbalurbadisk$
@@ -128,13 +378,13 @@ Modify the container's bashrc so PS1 includes a cluster tag:
 
 Colour by sensitivity:
 
-| Cluster type | Colour | Why |
+| Platform type | Colour | Why |
 |---|---|---|
-| `rancher-desktop` (or anything tagged "local" in cluster types) | green | safe sandbox |
-| `azure-aks`, `aws-eks`, `gcp-gke` (sandbox tier) | yellow | cloud, real cost, but disposable |
+| `rancher-desktop` (or anything tagged "local" in platform types) | green | safe sandbox |
+| `azure-aks`, `aws-eks`, `google-gke`, `azure-microk8s` (sandbox tier) | yellow | cloud, real cost, but disposable |
 | Anything explicitly tagged `production` in cluster-config.sh | red, with the word `PROD` | maximum visibility |
 
-Driven off two sources, with kubectl-context winning. Re-evaluated on each prompt; switches mid-session update immediately.
+Driven by kubectl current-context (Q1's source of truth). Re-evaluated on each prompt; switches mid-session update immediately.
 
 While we're touching the prompt: replace the misleading `lima-rancher-desktop` hostname (`\h` shows the lima VM, not the cluster). Either drop `\h` or substitute a fixed `uis` literal.
 
@@ -146,74 +396,119 @@ Today's `./uis status` shows deployed services. The header should be:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 UIS Status
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Cluster:    rancher-desktop  (reachable, k8s v1.32.0)
-Context:    rancher-desktop
-Config:     rancher-desktop  ✓ matches kubectl
+Platform:   rancher-desktop  (reachable, k8s v1.32.0)
 Namespace:  default
 
 Deployed services:
   …
+
+Other platforms: 'uis platform list'
 ```
 
-Makes "where am I" the first thing the operator sees on the standard "what's going on" command.
+Makes "where am I" the first thing the operator sees on the standard "what's going on" command. Drops the separate `Context:` / `Config:` lines from the original sketch — post-lockstep (Q4) they're always in sync, so surfacing them as separate values is just noise. The footer pointer links to `list` for users who want to see the full inventory.
 
-### Layer 4 — `./uis platform list / use` (the switching half)
+### Layer 4 — `./uis platform list / use` (the agreed first-ship)
 
-Two new commands, parallel to `./uis platform up/down/init` from the novice-onboarding investigation.
+Two new commands, parallel to `./uis platform up/down/init/status` from the AKS novice-onboarding investigation.
 
-**`./uis platform list`** — enumerate available clusters with status:
+**`./uis platform list`** — enumerate every platform UIS knows how to onboard, plus rancher-desktop, with current status per row:
 
 ```
+$ ./uis platform list
+
 Active: rancher-desktop
 
-CLUSTER          KUBECTL          STATUS         LAST ACTIVE
-azure-aks        azure-aks        ✓ reachable    2 hours ago
-rancher-desktop  rancher-desktop  ✓ reachable    now (active)
-azure-aks-old    azure-aks-old    ✗ unreachable  destroyed?  (stale; 'use --no-probe' to clean)
+PLATFORM         STATUS
+rancher-desktop  ✓ running                   (active)
+azure-aks        · configured, not running   (run './uis platform up azure-aks' to start it)
 ```
 
-Sources unioned per Q3. Reachability per row uses Layer 1's `kubectl --request-timeout=3s get --raw /version` probe (in parallel for fast `list`).
+Inventory source per Q3: `platforms/*/scripts/init.sh` directory listing + hard-coded rancher-desktop row. Status per row comes from each platform's own `status.sh` (rancher-desktop gets a trivial one added). Reachability probes run in parallel for fast `list`.
 
-**`./uis platform use <name>`** — switch the active cluster:
+State-to-display mapping:
+
+| Platform state | Row status |
+|---|---|
+| No `init.sh` for this name, not rancher-desktop | (not listed — UIS can't onboard you) |
+| `init.sh` exists, no env file | `· not initialized` + pointer to `./uis platform init <name>` |
+| Env file exists, cluster not provisioned | `· configured, not running` + pointer to `./uis platform up <name>` |
+| Cluster running, reachable | `✓ running` (with `(active)` annotation if it matches kubectl current-context) |
+| Cluster expected running but unreachable | `✗ unreachable` + recovery hint |
+
+**`./uis platform use <name>`** — switch the active platform (per Q4 lockstep, per Q5 refuse-unless-initialized-and-reachable):
 
 ```
 $ ./uis platform use azure-aks
-ℹ  Probing azure-aks ... ✓ reachable (k8s v1.32.0)
-✓  Active cluster: rancher-desktop → azure-aks
-   kubectl current-context: azure-aks
-   cluster-config.sh:       azure-aks (synced)
+ℹ  Probing azure-aks ... ✓ reachable (k8s v1.34)
+✓  Switched: rancher-desktop → azure-aks
 ```
 
-Per Q4 — flips kubectl context and `cluster-config.sh` in lockstep. Per Q5 — refuses to switch to an unreachable cluster unless `--no-probe` is passed. With no argument, presents an interactive picker (numbered list; `fzf` if available, plain `read` prompt otherwise).
+The success line names only the active platform (not the internal kubectl context name or `cluster-config.sh` state) — per N-C5/C-9, internal projections don't surface to the user. By the lockstep flip's construction (Q4) the kubectl context and `cluster-config.sh` are always in sync after `use`; there's nothing to display separately.
 
-**Implementation shape**: `cmd_platform_list` and `cmd_platform_use` in `provision-host/uis/manage/uis-cli.sh`, delegating to a shared helper at `provision-host/uis/lib/platform-switching.sh` (~60 lines). Re-uses the reachability probe from `cluster-banner.sh` (Layer 1). No external dependencies beyond `kubectl` and `bash`.
+Refusal modes:
 
-**Edge cases this layer adds**:
-- Switching to a context that exists in kubeconfig but no longer exists as a UIS cluster (e.g. tester's personal cluster) — allowed, but the post-switch banner notes "kubectl-only context, no `cluster-config.sh` entry".
-- Concurrent `use` from two terminals — last write wins; `cluster-config.sh` has no locking. Document this; don't engineer it.
-- `use` to the *current* active cluster — no-op + cheap reachability re-probe; useful as a "is my cluster still up?" probe.
+```
+$ ./uis platform use google-gke
+✗ google-gke is not initialized.
+  Run './uis platform init google-gke' first.
+
+$ ./uis platform use azure-aks   # platform initialized but cluster not running
+✗ azure-aks is configured but not running.
+  Run './uis platform up azure-aks' to start it.
+
+$ ./uis platform use azure-aks   # cluster expected up but unreachable
+✗ azure-aks is unreachable (API server timeout after 3s).
+  Check the cluster state with './uis platform status azure-aks'.
+  To switch anyway (e.g. to clean up stale kubectl state), use --offline.
+```
+
+With no argument, `use` presents an interactive numbered picker over the same set `list` shows — per C-8, only `running` rows get `[N]` selectors; others appear without selectors (no dimming, no ANSI tricks).
+
+**Note on `Active:` header + `(active)` row annotation**: the same information appears twice — once in the `Active: <name>` header above the table, once as `(active)` on the matching row. This is deliberate redundancy. The header is what the user reads first; the per-row annotation is what they scan for when comparing rows. Both stay.
+
+**Implementation shape**: `cmd_platform_list` and `cmd_platform_use` in `provision-host/uis/manage/uis-cli.sh`, delegating to a shared helper at `provision-host/uis/lib/platform-switching.sh`. That same helper hosts both:
+- the lockstep writer (Q4) — also called by `02-post-apply.sh` and `03-destroy.sh` so all three call sites (`up`'s auto-flip, `down`'s auto-reset, `use`'s manual flip) converge on one writer
+- the reachability-probe primitive — also called by Layer 1's banner code (which co-ships)
+
+Sourcing pattern is the same one `02-post-apply.sh` already uses: `source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"` — the bind mount makes the path stable from any script running inside the container.
+
+**Decision flow for `use` and `list`** — both consume the C-1 contract:
+
+- `list` calls each platform's `status.sh --summary` (in parallel), parses field 1 per row to pick the visual treatment, prints field 2 as the hint. `--offline` flag propagates so each `status.sh --summary --offline` skips its probe.
+- `use <name>` calls *just* `<name>'s status.sh --summary`, parses field 1, and dispatches per Q5's enum table (refuse for `not-initialized` / `configured-not-running`, lockstep-flip for `running`, refuse-with-`--offline`-hint for `unreachable`). With `--offline`, `use` skips the probe and proceeds even on `unreachable` — but still refuses on `not-initialized` / `configured-not-running` (there's no kubectl context to switch *to* in those states).
+
+Layer 1's banner is the only consumer that bypasses `status.sh --summary` (per C-9) — it probes kubectl directly for the common reachable case and only escalates to a `status.sh --summary` call on the unreachable path (for the platform-specific recovery hint).
+
+**Scope of "kubeconfig" in this design**: every kubeconfig reference above means **the merged kubeconfig inside the `uis-provision-host` container** at `/mnt/urbalurbadisk/kubeconfig/kubeconf-all`. The lockstep flip updates *that* file via `kubectl config use-context`, which is enough for every tool that runs inside the container (`./uis deploy`, `./uis shell` → `kubectl`/`helm`, ansible playbooks). **Host-side tools (`k9s`, `lens`, raw `kubectl` from a macOS terminal) are explicitly out of scope** — see "Out of scope" below. The host's `~/.kube/config` is untouched by `./uis platform use`.
+
+**Edge cases this layer adds**: see the global "Edge cases to think through during design" section below — items #7 (`use` to active that's now unreachable), #8 (hidden directories), #9 (concurrent `use`), #10 (CLUSTER_TYPE vs TARGET_HOST) cover everything Layer 4 introduces. Kept in one place to avoid drift.
 
 ---
 
 ## Edge cases to think through during design
 
-1. **No cluster reachable at all** (e.g. Rancher Desktop stopped). Layer 1's probe should detect this and tell the user "no cluster reachable; start Rancher Desktop" rather than emit cryptic kubectl timeouts.
-2. **Multiple kubeconfig files** — UIS uses `kubeconf-all` (merged) but operators sometimes override `KUBECONFIG`. The probe should respect whatever `KUBECONFIG` resolves to, not hard-code a path.
-3. **Performance** — adding a kubectl probe to every UIS command costs ~50–200 ms. Acceptable for safety; mitigate with a 10s probe cache in `/tmp` if it becomes noisy.
+1. **No cluster reachable at all** (e.g. Rancher Desktop installed but stopped). Layer 1's probe of the active context returns `unreachable`; the banner emits the "API server unreachable" block + abort (see C-9). For rancher-desktop specifically, the recovery hint reads `start Rancher Desktop` rather than the generic `./uis platform status` (rancher-desktop's status.sh emits this hint per C-1's rancher-desktop subsection).
+2. **Multiple kubeconfig files** — UIS pins the in-container `KUBECONFIG` to `/mnt/urbalurbadisk/kubeconfig/kubeconf-all` for the cluster-touching layer; that's the single file Q4's lockstep flip targets. Operators who override `KUBECONFIG` inside the container to point elsewhere are doing it as a power-user escape — Layer 1's banner will probe whatever's set, but `./uis platform use` ignores the override and writes to `kubeconf-all` (so the user's override and UIS's view can diverge until they unset it). Host-side `KUBECONFIG` is irrelevant to this design (see "Out of scope").
+3. **Performance** — `--summary` is under 200 ms per platform (C-6) and Layer 1's banner is the same single probe (C-9). No caching needed for the default `list` or the per-command banner. (An earlier sketch proposed a `/tmp` probe cache for the banner — dropped because C-1's design already bounds the per-command cost.)
 4. **CI / non-interactive contexts** — colour codes should respect `NO_COLOR=1` and detect non-TTY (`[[ -t 1 ]]`). Banner stays, just without ANSI.
 5. **`./uis` invoked from outside `./uis shell`** — the wrapper docker-execs into the container; PS1 doesn't help there. Layer 1 covers this.
-6. **Nested invocations** — `./uis test-all` or `./uis stack install` runs many sub-commands. Banner per sub-command is noisy. Print once at the parent invocation; sub-commands inherit silently via env var (`UIS_BANNER_PRINTED=1`).
+6. **Nested invocations** — only `./uis stack install` (which fans out to many `./uis deploy <service>` children) needs banner suppression in children. Per C-4 the parent sets `UIS_BANNER_PRINTED=1` before invoking children; child dispatchers check it and skip the banner. Ansible playbooks and other sub-shells the dispatcher invokes never print a banner to begin with — banner is a dispatcher-layer concern, not a playbook one.
+7. **`use` to currently-active platform that's *now* unreachable** — the re-probe path of C-8's no-op behavior. If the user picks the already-active row and it now fails the probe, emit `✗ <name> is no longer reachable (API server timeout after 3s)` + recovery hint, exit non-zero. The active platform doesn't get changed (it was already the target); the user knows their session is now broken and what to do.
+8. **Hidden / under-development platform directories** — `list` skips any `platforms/<name>/` whose name starts with `_` or `.`. Lets contributors prototype a new platform without it showing up in user output until they're ready to rename.
+9. **Concurrent `use` from two terminals** — last write wins on both halves of the lockstep flip (kubectl context, cluster-config.sh). The shared writer in `platform-switching.sh` issues both writes back-to-back; interleaving is *possible* in theory but the window is sub-millisecond. Document the limitation, don't engineer a lock.
+10. **`cluster-config.sh` CLUSTER_TYPE vs TARGET_HOST** — by convention since PR #146-era, both fields always hold the same string (the platform directory name). The lockstep writer writes both for backward compat with existing readers, but they're effectively the same value. Future work could collapse the two; out of scope here.
 
 ---
 
-## Suggested rollout
+## Suggested rollout (revised 2026-05-11 after talk47)
 
-1. **Layer 1 first.** Covers everyone — in-shell users, host-side `./uis` invokers, future automation. Lowest implementation cost. Tracer-bullet through `./uis deploy` first; if that reads cleanly, fan out to the rest.
-2. **Layer 4 next.** `./uis platform list / use` ships once Layer 1's reachability probe is reusable as a sourced helper. Unblocks anyone with 2+ clusters from manually editing kubeconfig + `cluster-config.sh` to rotate the active cluster.
-3. **Layer 3 third.** `./uis status` becomes the obvious "where am I and what else is reachable?" command once `list` exists — single-script change to add the cluster header (and a one-line "other clusters: …" pointer to `list`).
-4. **Layer 2 last.** Touching the container's bashrc coordinates with the container build.
+The talk47 discussion flipped the original Layer-1-first ordering and tightened the Layer-1/Layer-4 coupling. The primary user need surfaced by talk47 is *"I have 2+ platforms; let me see them, let me switch, and tell me which one I'm on whenever I run a command"* — that's Layer 4 AND Layer 1 as one cohesive UX, not two sequenced shipments.
 
-Each layer ships independently — Layer 1 alone delivers most of the visibility value, Layer 4 alone delivers the switching value.
+1. **Layer 4 + Layer 1 ship together** (or back-to-back PRs same day) — `./uis platform list / use` for the switching half, banner-at-top-of-every-cluster-command for the per-command visibility half. Bundle the lockstep-flip refactor: extract `cluster-config.sh` writing from `02-post-apply.sh` / `03-destroy.sh` into the shared helper at `provision-host/uis/lib/platform-switching.sh` so all three call sites (`up`'s auto-flip, `down`'s auto-reset, `use`'s manual flip) converge on one writer. The reachability-probe primitive lands here too, used by both layers.
+2. **Layer 3 next** — `./uis status` (the global status command, not `./uis platform status <provider>`) becomes "where am I and what else is reachable?" The cluster header reuses Layer 1's banner machinery; a one-liner "other platforms: ..." pointer at the bottom links to Layer 4's `list`.
+3. **Layer 2 last** — coloured PS1 inside `./uis shell`. Touching the container's bashrc coordinates with the container build; lowest-priority because it only helps in-shell users (and Layer 1's banner already covers them too).
+
+Layer 4 + Layer 1 together deliver the "potential platforms + active visibility + safe switching" loop end-to-end. Layers 2/3 are polish on top.
 
 ---
 
@@ -223,22 +518,36 @@ Each layer ships independently — Layer 1 alone delivers most of the visibility
 - **Production-vs-sandbox enforcement.** Once Layer 2's colour scheme is in, building actual confirmation prompts ("Type the cluster name to continue against PROD") is a natural follow-up but separate.
 - **Removing `cluster-config.sh` entirely.** Q4's lockstep-flip proposal bounds the source-of-truth question (kubectl context = truth for reads, `use` writes both atomically, `cluster-config.sh` is a derived projection). A larger refactor that removes `cluster-config.sh` outright (everything reads kubectl context, nothing reads `cluster-config.sh`) is a separate question. Mostly an Ansible-inventory-shape change rather than a UX one.
 - **Provisioning new clusters from `list`.** `list` shows what exists; provisioning is `./uis platform up <name>` (separate command, scoped in [INVESTIGATE-aks-novice-onboarding.md](./INVESTIGATE-aks-novice-onboarding.md)). No "click to provision" affordance from inside `list`.
+- **Host-side kubectl integration (`k9s`, `lens`, raw `kubectl` from macOS Terminal).** The lockstep flip in Q4 updates the kubeconfig *inside the `uis-provision-host` container* (`kubeconf-all`), which is enough for every tool that runs inside the container — including everything UIS itself invokes. The host's `~/.kube/config` is **not** touched and host-side tools won't see the selected platform unless the user wires `KUBECONFIG` up themselves (e.g. by pointing at the bind-mounted copy under `.uis.secrets/generated/kubeconfig/`). Cross-boundary kubeconfig sync (e.g. an `./uis env` helper that emits `export KUBECONFIG=...` for host shells, or a host-side merge of UIS contexts into `~/.kube/config`) is its own design problem and outside this investigation. The decision: target only the in-container `kubeconf-all`; host-side is the user's environment to manage.
 
 ---
 
 ## What this investigation needs to produce
 
-A child PLAN (or two — one for visibility layers, one for switching) that decides:
+**Status 2026-05-11**: Q1/Q2/Q3/Q4/Q5 all decided above. Rollout order locked (Layer 4 + Layer 1 together, then Layer 3, then Layer 2). Ready for child PLANs.
 
-1. Whether kubectl context is the canonical signal — see Q1, bounded by Q4's lockstep-flip proposal.
-2. Inventory source for `list` — see Q3.
-3. Switch atomicity — see Q4. Lockstep vs derived.
-4. Switch verb + reachability semantics — see Q5.
-5. Which layer (1 / 2 / 3 / 4) ships first, and in what PR order.
-6. Where the reachability probe lives (per-command at top of cluster-touching commands, vs. a single shared `cluster-touch` guard) — and how `platform-switching.sh` re-uses it.
-7. The exact API of `cluster-banner.sh` and `platform-switching.sh` (function signatures, env-var contract for nesting, colour-strip rules).
+**Next concrete piece** — natural follow-on to the AKS novice-onboarding sequence (PRs #154–#159):
 
-Once those settle, Layer 1 is a small PR (~30 lines of bash for the banner helper + a few dozen call sites). Layer 4 is a similar-sized PR (~60 lines of `platform-switching.sh` + two thin `cmd_platform_*` dispatchers in `uis-cli.sh`). Layers 2 and 3 are smaller still.
+- **PLAN-platform-list-use-and-banner.md** (Layers 4 + 1, bundled) — covers:
+  - `./uis platform list` (inventory + status from per-platform `status.sh`, plus the rancher-desktop special case)
+  - `./uis platform use <name>` (refuse-unless-initialized-and-reachable + lockstep flip)
+  - `provision-host/uis/lib/platform-switching.sh` shared helper hosting the lockstep writer + reachability probe
+  - Convergence of `02-post-apply.sh` and `03-destroy.sh`'s existing `sed -i` flips onto the shared writer
+  - **Banner-at-top of every cluster-touching `./uis` command** (Layer 1) reusing the same reachability probe — single tracer-bullet through `./uis deploy` first, then fan out
+  - Trivial `platforms/rancher-desktop/scripts/status.sh` so the row can report its state
+
+  Estimated scope: ~150 lines of bash across `platform-switching.sh` + two `cmd_platform_*` dispatchers + banner-injection at ~8 cluster-touching command call sites + one new rancher-desktop status script. Single PR is doable; splitting into two same-day PRs (switching first, banner second) is also fine.
+
+Subsequent PLANs (smaller, post-Layer-4+1):
+
+- **PLAN-uis-status-cluster-header.md** (Layer 3) — one-script change to add a cluster header to `./uis status`. Trivial once banner machinery exists.
+- **PLAN-ps1-cluster-tag.md** (Layer 2) — container bashrc change; coordinated with the Dockerfile.
+
+Implementation contracts settled in "Implementation contracts" section above (C-1 through C-9). The child PLAN drafts the function signatures and ANSI-stripping details against those contracts.
+
+Remaining open question, deferred to the PLAN (not a blocker):
+
+1. **Exact internal API of `platform-switching.sh`** — function names + signatures. Sketch: `pf_active_platform()`, `pf_probe_reachable <context>`, `pf_lockstep_flip <context> <platform>`, `pf_platform_summary <platform>` (parses the platform's `status.sh --summary` output), `pf_list_platforms()` (returns the inventory honoring the `_` / `.` hidden-directory skip). Names are the PLAN's call; the **contracts they implement** are settled above.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds `uis platform list`, `uis platform use [<name>]`, and a one-line "you are deploying to `<X>`" banner on every cluster-touching command. Eliminates the silent-wrong-cluster footgun when a user has both `rancher-desktop` and `azure-aks` active.

Implements PLAN-platform-list-use-and-banner.md / INVESTIGATE-active-cluster-visibility-ux.md (Q1–Q5 + contracts C-1…C-9).

## What's in the box

- **`provision-host/uis/lib/platform-switching.sh`** — shared `pf_*` helpers. Single writer for `kubectl current-context` + `cluster-config.sh` (CLUSTER_TYPE / TARGET_HOST). `02-post-apply.sh` and `03-destroy.sh` now go through `pf_lockstep_flip` so the two can never silently diverge (Q4).
- **`status.sh --summary` contract (C-1)** added to `platforms/azure-aks/scripts/status.sh`; new `platforms/rancher-desktop/scripts/status.sh` (rancher-desktop uses 3-of-4 states — no `configured-not-running`, since it's installed at the OS level, not provisioned by UIS). Emits `<state>\t<hint>` so callers can render their own UI.
- **`uis platform list`** — parallel `--summary` across all platforms, active-row annotated per C-2. `--offline` and `--deep` mirror `status.sh --summary` modes.
- **`uis platform use [<name>]`** — lockstep flip (Q4); refuses `not-initialized` / `configured-not-running` / `unreachable` per Q5 with the platform's own state-appropriate hint. No-arg invocation gets an interactive picker over `running` rows.
- **Banner (Layer 1, stderr)** on `deploy`, `undeploy`, `configure`, `expose`, `list`, `status`, `stack install`, `test all`. Aborts with hint when no active kubectl context is set. Suppressed inside the stack walker via `UIS_BANNER_PRINTED=1` (C-4). Walked out of platform-family commands — `list` IS the discovery path and `use` is the fix path, so banner-then-abort there would be catch-22.

## Test plan

- [x] `uis platform list` works with empty kubeconfig (no abort)
- [x] `uis platform list --offline` skips reachability probe
- [x] `uis platform use rancher-desktop` (when not-initialized) prints rancher-desktop's own hint, not a hardcoded `platform init` instruction
- [x] `uis platform use azure-aks` (when configured-not-running) prints "run './uis platform up azure-aks'"
- [x] `uis platform use unknown-foo` lists available platforms
- [x] `uis platform use` (no arg) shows picker; bails cleanly when no row is running
- [x] `uis deploy nginx` aborts with banner when no active context
- [x] `uis status` / `uis list` ditto
- [x] `uis help` shows new `platform list` and `platform use` rows
- [ ] **Tester verification (Phase 7)** — full novice cycle: init → up → list → use → deploy → down → list, in `testing/uis1/talk/talk.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)