### PR TITLE
fix(uis-platform): seed kubeconf-all on cold start (F15)

### DIFF
--- a/provision-host/uis/lib/platform-switching.sh
+++ b/provision-host/uis/lib/platform-switching.sh
@@ -28,10 +28,57 @@ PF_PROBE_TIMEOUT="${PF_PROBE_TIMEOUT:-3s}"
 PF_VALID_STATES_REGEX='^(not-initialized|configured-not-running|running|unreachable)$'
 
 
+# ----- pf_ensure_kubeconf_seeded ----------------------------------------------
+# Bootstrap `kubeconf-all` on a fresh container. The merged kubeconfig is only
+# *built* by 02-post-apply.sh during AKS provisioning, but `platform list` is
+# the discovery command novices use *before* any cluster work. Without a seed
+# step, a fresh container reports rancher-desktop as `not-initialized` even
+# when it's running on the host. F15 from talk48.
+#
+# Strategy: when kubeconf-all is missing, extract the rancher-desktop context
+# from the bind-mounted host kubeconfig at /home/ansible/.kube/config and write
+# it BOTH to:
+#   - rancher-desktop-kubeconf — the per-platform seed file the existing
+#     04-merge-kubeconf.yml playbook picks up. Ensures rancher-desktop survives
+#     the AKS merge that runs at the end of 02-post-apply.sh.
+#   - kubeconf-all directly — so `platform list` / `platform use` work right
+#     now, before any merge has run.
+#
+# Idempotent: returns 0 immediately if kubeconf-all already exists, or if the
+# host kubeconfig is missing / has no rancher-desktop context (clean CI env).
+# Safe to call from any pf_* entry point.
+pf_ensure_kubeconf_seeded() {
+    [[ -f "$PF_KUBECONFIG" ]] && return 0
+
+    local host_kc="/home/ansible/.kube/config"
+    [[ -f "$host_kc" ]] || return 0
+
+    # Does the host have a rancher-desktop context to seed from?
+    KUBECONFIG="$host_kc" kubectl config get-contexts rancher-desktop \
+        >/dev/null 2>&1 || return 0
+
+    local kc_dir
+    kc_dir="$(dirname "$PF_KUBECONFIG")"
+    mkdir -p "$kc_dir" 2>/dev/null || return 0
+
+    # Extract just the rancher-desktop context (--minify drops other contexts
+    # the user might have on their host; --flatten inlines cert/key data so
+    # the file is self-contained).
+    local seed_file="$kc_dir/rancher-desktop-kubeconf"
+    KUBECONFIG="$host_kc" kubectl config view \
+        --minify --context=rancher-desktop --flatten \
+        > "$seed_file" 2>/dev/null || { rm -f "$seed_file"; return 0; }
+
+    cp "$seed_file" "$PF_KUBECONFIG"
+    chmod 600 "$seed_file" "$PF_KUBECONFIG" 2>/dev/null || true
+}
+
+
 # ----- pf_active_platform -----------------------------------------------------
 # Echo the kubectl current-context name (the active platform per Q1). Empty
 # string if unset (e.g. fresh kubeconfig).
 pf_active_platform() {
+    pf_ensure_kubeconf_seeded
     KUBECONFIG="$PF_KUBECONFIG" kubectl config current-context 2>/dev/null || echo ""
 }
 
@@ -223,5 +270,5 @@ pf_banner() {
 
 # Make the functions available to child shells if needed (sub-shell invocations
 # from ansible's `shell` module, etc.). Most callers source this file directly.
-export -f pf_active_platform pf_probe_reachable pf_lockstep_flip
-export -f pf_list_platforms pf_platform_summary pf_banner
+export -f pf_ensure_kubeconf_seeded pf_active_platform pf_probe_reachable
+export -f pf_lockstep_flip pf_list_platforms pf_platform_summary pf_banner

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -914,6 +914,10 @@ cmd_platform() {
 _uis_cluster_banner() {
     type pf_banner >/dev/null 2>&1 || return 0
     command -v kubectl >/dev/null 2>&1 || return 0
+    # F15 — seed kubeconf-all from /home/ansible/.kube/config on first run so
+    # the existence guard below doesn't no-op on a fresh container that DOES
+    # have rancher-desktop reachable.
+    type pf_ensure_kubeconf_seeded >/dev/null 2>&1 && pf_ensure_kubeconf_seeded
     [[ -f "${PF_KUBECONFIG:-/mnt/urbalurbadisk/kubeconfig/kubeconf-all}" ]] || return 0
     pf_banner --silent-if-set --check-reachable || exit "$EXIT_GENERAL_ERROR"
 }


### PR DESCRIPTION
## Summary

**F15** from talk48 R1 — on a fresh container, `uis platform list` classifies rancher-desktop as `· not initialized` even when it's actively running on the host. The probe reads `/mnt/urbalurbadisk/kubeconfig/kubeconf-all`, but that file is only built by `02-post-apply.sh` during an AKS up. Catch-22: `platform list` is the discovery command meant to be used *before* any cluster work.

## The fix

`pf_ensure_kubeconf_seeded` in `platform-switching.sh`. On first invocation:

1. Return immediately if `kubeconf-all` already exists (idempotent fast path).
2. Return immediately if no host kubeconfig at `/home/ansible/.kube/config` (CI / clean env).
3. Return immediately if the host kubeconfig has no `rancher-desktop` context (user hasn't installed it).
4. Otherwise, extract `rancher-desktop` via `kubectl config view --minify --context=rancher-desktop --flatten` and write to **both**:
   - `rancher-desktop-kubeconf` — the per-platform seed file the existing `04-merge-kubeconf.yml` playbook picks up (so rancher-desktop survives the AKS merge that runs at the end of `02-post-apply.sh`).
   - `kubeconf-all` — direct seed so `platform list` / `use` work *now*, before any merge has run.

Called from `pf_active_platform` (the gate every other `pf_*` function flows through) and `_uis_cluster_banner` (so commands like `deploy` / `list` trigger seeding before the existence guard).

## Latent bug also closed

After `02-post-apply.sh` runs `04-merge-kubeconf.yml`, kubeconf-all would contain *only* `azure-aks` (the merge dir had only `azure-aks-kubeconf`). Then `03-destroy.sh`'s `pf_lockstep_flip "rancher-desktop"` would fail — rancher-desktop wasn't in the merged kubeconfig. Seeding `rancher-desktop-kubeconf` means the merge picks it up too, so post-destroy auto-reset to rancher-desktop works.

## Test plan

- [x] Fresh container with no kubeconf-all → `uis platform list` correctly shows `Active: rancher-desktop` + `rancher-desktop ✓ running (active)`
- [x] Files created with right perms — `kubeconf-all` and `rancher-desktop-kubeconf` both `0600` under `/mnt/urbalurbadisk/kubeconfig/`
- [x] `kubectl config current-context --kubeconfig=kubeconf-all` returns `rancher-desktop`
- [x] `cluster-config.sh` already has `CLUSTER_TYPE="rancher-desktop"` (no flip needed since current-context already matches)
- [x] `uis platform use rancher-desktop` recognizes already-active + re-probes
- [x] Banner on `uis list` prints `ℹ  Platform: rancher-desktop (reachable)`
- [x] Static tests pass (no `((var++))` regressions in the new code)
- [ ] **Tester verification**: full talk48 round, starting from the fresh-image state F15 was caught on

🤖 Generated with [Claude Code](https://claude.com/claude-code)