### PR TITLE
fix(uis-platform): clean up destroyed platform's context from kubeconf-all (F17)

### DIFF
--- a/platforms/azure-aks/scripts/03-destroy.sh
+++ b/platforms/azure-aks/scripts/03-destroy.sh
@@ -171,9 +171,23 @@ fi
 # ─── Clean up kubeconfig ──────────────────────────────────────────────────────
 print_section "Cleaning up kubeconfig"
 
+# shellcheck source=/dev/null
+source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
+
+# Host kubeconfig (/home/ansible/.kube/config) — defensive cleanup. UIS doesn't
+# normally write the AKS context there, but a user may have run
+# `az aks get-credentials` manually outside UIS.
 if kubectl config get-contexts "$AZURE_AKS_CLUSTER_NAME" >/dev/null 2>&1; then
     kubectl config delete-context "$AZURE_AKS_CLUSTER_NAME" >/dev/null 2>&1 || true
-    print_success "Removed kubectl context: $AZURE_AKS_CLUSTER_NAME"
+    print_success "Removed kubectl context from host kubeconfig: $AZURE_AKS_CLUSTER_NAME"
+fi
+
+# In-container kubeconf-all + legacy bind-mount. Without this, `uis platform
+# list` post-destroy shows the destroyed platform as `✗ unreachable` (probe
+# times out against the dead API URL still in the kubeconfig) instead of
+# `· configured, not running`. F17 from talk49/50.
+if pf_remove_context "$AZURE_AKS_CLUSTER_NAME"; then
+    print_success "Removed $AZURE_AKS_CLUSTER_NAME from kubeconf-all (in-container + legacy)"
 fi
 
 if [[ -f "$KUBECONFIG_FILE" ]]; then
@@ -192,8 +206,6 @@ fi
 # kubectl context.
 print_section "Reset UIS target to rancher-desktop"
 
-# shellcheck source=/dev/null
-source "/mnt/urbalurbadisk/provision-host/uis/lib/platform-switching.sh"
 pf_lockstep_flip "rancher-desktop"
 print_success "cluster-config.sh + kubectl context reset to: rancher-desktop"
 

--- a/provision-host/uis/lib/platform-switching.sh
+++ b/provision-host/uis/lib/platform-switching.sh
@@ -193,6 +193,55 @@ pf_lockstep_flip() {
 }
 
 
+# ----- pf_remove_context ------------------------------------------------------
+# Delete a kubectl context (plus the cluster + user entries it references)
+# from kubeconf-all in-container, then sync to legacy. Idempotent — silent
+# no-op if the context isn't present.
+#
+# Called from per-platform 03-destroy.sh scripts after a successful teardown.
+# Without this cleanup, `uis platform list` post-destroy shows the destroyed
+# platform as `✗ unreachable (API timeout)` against the dead API server URL
+# still in the kubeconfig, instead of the correct `· configured, not running`
+# (env file present, no live context). F17 from talk49/50.
+#
+# Why also delete the cluster + user: kubectl's `delete-context` only removes
+# the context entry, leaving the cluster/user entries behind as orphans. They
+# don't affect platform list semantics but bloat the file over destroy cycles
+# and leak the stale API server URL into anything that reads the merged config.
+pf_remove_context() {
+    local context="${1:?pf_remove_context: missing context argument}"
+
+    [[ -f "$PF_KUBECONFIG" ]] || return 0
+    KUBECONFIG="$PF_KUBECONFIG" kubectl config get-contexts "$context" \
+        >/dev/null 2>&1 || return 0
+
+    # Capture the cluster + user names this context references before deleting
+    # the context (which is what makes them findable).
+    local cluster_ref user_ref
+    cluster_ref="$(KUBECONFIG="$PF_KUBECONFIG" kubectl config view \
+        -o "jsonpath={.contexts[?(@.name=='$context')].context.cluster}" 2>/dev/null)"
+    user_ref="$(KUBECONFIG="$PF_KUBECONFIG" kubectl config view \
+        -o "jsonpath={.contexts[?(@.name=='$context')].context.user}" 2>/dev/null)"
+
+    KUBECONFIG="$PF_KUBECONFIG" kubectl config delete-context "$context" \
+        >/dev/null 2>&1 || true
+    [[ -n "$cluster_ref" ]] && \
+        KUBECONFIG="$PF_KUBECONFIG" kubectl config delete-cluster "$cluster_ref" \
+            >/dev/null 2>&1 || true
+    [[ -n "$user_ref" ]] && \
+        KUBECONFIG="$PF_KUBECONFIG" kubectl config delete-user "$user_ref" \
+            >/dev/null 2>&1 || true
+
+    # Sync to legacy bind-mount. Plain cp — kubectl writes to the bind mount
+    # trigger the lima/9P flock phantom-file bug (see PR #163).
+    if [[ -d "$(dirname "$PF_LEGACY_KUBECONFIG")" ]]; then
+        cp --remove-destination "$PF_KUBECONFIG" "$PF_LEGACY_KUBECONFIG" \
+            2>/dev/null || true
+        chmod 600 "$PF_LEGACY_KUBECONFIG" 2>/dev/null || true
+    fi
+}
+
+
 # ----- pf_list_platforms ------------------------------------------------------
 # Emit the inventory of "potential platforms UIS knows about" to stdout, one
 # name per line. Sources per Q3:
@@ -334,4 +383,5 @@ pf_banner() {
 # Make the functions available to child shells if needed (sub-shell invocations
 # from ansible's `shell` module, etc.). Most callers source this file directly.
 export -f pf_ensure_kubeconf_seeded pf_active_platform pf_probe_reachable
-export -f pf_lockstep_flip pf_list_platforms pf_platform_summary pf_banner
+export -f pf_lockstep_flip pf_remove_context pf_list_platforms
+export -f pf_platform_summary pf_banner


### PR DESCRIPTION
## Summary

**F17** from talk49/50/51 — after `uis platform down azure-aks`, `uis platform list` showed the destroyed platform as `✗ unreachable (API server timeout after 3s)` because the azure-aks context (plus its cluster + user entries) were still in `kubeconf-all` and the legacy bind-mount kubeconfig. The status probe correctly timed out against the now-dead API server URL — but the user expected `· configured, not running`, matching the pre-up cold state.

Phase 0 of [PLAN-multi-platform-docs-restructure.md](https://github.com/helpers-no/urbalurba-infrastructure/blob/main/website/docs/ai-developer/plans/backlog/PLAN-multi-platform-docs-restructure.md) — ship F17 ahead of the docs PR so the docs can quote the polished post-destroy output.

## Fix

New `pf_remove_context` helper in `provision-host/uis/lib/platform-switching.sh`:

- Deletes a kubectl context **plus the cluster + user entries it references** from in-container `kubeconf-all`. Without deleting the cluster/user, the destroyed cluster's API URL stays in the file (orphan entries, file bloat over destroy cycles, leaks the stale URL into anything that reads the merged config).
- Syncs to legacy bind-mount via `cp --remove-destination` (same pattern as PR #163's lockstep — kubectl writes to the bind mount trigger the lima/9P flock issue).
- Idempotent: silent no-op if the context isn't present.

`platforms/azure-aks/scripts/03-destroy.sh` calls `pf_remove_context "$AZURE_AKS_CLUSTER_NAME"` after `tofu destroy` succeeds, before the auto-reset lockstep flip back to rancher-desktop.

## Verification

Reproduced the F17 symptom in the container by injecting a fake azure-aks context with a dead-server URL:

```
=== PRE-CLEANUP — platform list shows ✗ unreachable ===
azure-aks         ✗ unreachable              (API server timeout after 3s; …)

=== Call pf_remove_context azure-aks ===

=== POST-CLEANUP — context gone from both kubeconfigs, list now correct ===
azure-aks         · configured, not running  (run './uis platform up azure-aks' to start it)
```

Both in-container kubeconf-all and the legacy bind-mount kubeconf-all show the context gone after the call.

## Test plan

- [x] Inject fake azure-aks context → `platform list` shows `✗ unreachable`
- [x] `pf_remove_context azure-aks` → context gone from in-container kubeconfig
- [x] Legacy bind-mount kubeconfig also gets the context removed (sync works)
- [x] `platform list` post-cleanup shows `· configured, not running`
- [x] Idempotent: second call is a silent no-op
- [x] Static lint passes
- [ ] **Tester verification** (next round): real `./uis platform up azure-aks` → `./uis platform down azure-aks` → final `./uis platform list` shows `· configured, not running` (no manual injection needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)