### PR TITLE
docs(platforms): sanitize real Azure identifiers in AKS docs

### DIFF
--- a/website/docs/ai-developer/plans/completed/PLAN-001-aks-step1-verification.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-001-aks-step1-verification.md
@@ -78,13 +78,13 @@ The tester runs the full `platforms/azure-aks/` flow against an Azure subscripti
 
 - [x] 2.3 Log into Azure — handled by the wizard's `az_login_if_needed` / device-code flow. The PIM-activation retry loop from `hosts/azure-microk8s/` was ported into `check_owner_or_contributor` ([PLAN-uis-platform-init-azure-aks.md](../completed/PLAN-uis-platform-init-azure-aks.md) Phase 1.4).
 
-- [x] 2.4 Run `platforms/azure-aks/scripts/00-bootstrap-state.sh`. — ran successfully in talk46 R3 as step `▶ 1/3` of `uis platform up azure-aks`. State RG + storage account `sa077d4d1124e14fdctf` + container + versioning all created.
+- [x] 2.4 Run `platforms/azure-aks/scripts/00-bootstrap-state.sh`. — ran successfully in talk46 R3 as step `▶ 1/3` of `uis platform up azure-aks`. State RG + storage account (derived from the subscription ID) + container + versioning all created.
 
 - [x] 2.5 Run `platforms/azure-aks/scripts/01-apply.sh`. — ran successfully in talk46 R3 as step `▶ 2/3`. `tofu apply` created RG + Log Analytics workspace + AKS cluster (Standard_B2s_v2 × 1, k8s 1.34). Subscription-quota check now ported into the wizard (stronger than the originally-deferred plan).
 
-- [x] 2.6 Run `platforms/azure-aks/scripts/02-post-apply.sh`. — ran successfully in talk46 R3 as step `▶ 3/3`. Kubeconfig merged, storage class aliases applied, Traefik installed, external IP `4.245.36.75` provisioned. `kubernetes-secrets.yml` apply gap closed separately by [PLAN-002-aks-secrets-apply-parity.md](../backlog/PLAN-002-aks-secrets-apply-parity.md) (PR #149).
+- [x] 2.6 Run `platforms/azure-aks/scripts/02-post-apply.sh`. — ran successfully in talk46 R3 as step `▶ 3/3`. Kubeconfig merged, storage class aliases applied, Traefik installed, external IP provisioned. `kubernetes-secrets.yml` apply gap closed separately by [PLAN-002-aks-secrets-apply-parity.md](../backlog/PLAN-002-aks-secrets-apply-parity.md) (PR #149).
 
-- [x] 2.7 Verify with `./uis deploy nginx`. — verified in talk46 R3: pod scheduled, service reachable, IngressRoute applied, in-cluster connectivity tests (steps 13 + 15 of `020-setup-nginx.yml`) both succeeded. Public smoke `curl http://4.245.36.75/` returned the catch-all page end-to-end. The F7 cluster-aware banner (PR #157) also rendered the correct LB IP + curl --resolve hint for hostname routes.
+- [x] 2.7 Verify with `./uis deploy nginx`. — verified in talk46 R3: pod scheduled, service reachable, IngressRoute applied, in-cluster connectivity tests (steps 13 + 15 of `020-setup-nginx.yml`) both succeeded. Public smoke `curl http://<external-ip>/` returned the catch-all page end-to-end. The F7 cluster-aware banner (PR #157) also rendered the correct LB IP + curl --resolve hint for hostname routes.
 
 - [x] 2.8 Tear-down via `03-destroy.sh`. — verified in talk46 R3 via `uis platform down azure-aks`. Cluster RG and Log Analytics destroyed; state RG `rg-urbalurba-tfstate` preserved as designed. `az aks list -o table` returned empty afterward.
 

--- a/website/docs/platforms/azure-aks.md
+++ b/website/docs/platforms/azure-aks.md
@@ -82,9 +82,9 @@ Expected closing banner:
 ═══════════════════════════════════════════════════════════
  ✓ AKS setup ready
 ═══════════════════════════════════════════════════════════
-  Subscription: Azure subscription 1
-                (077d4d11-24e1-4fdc-a5f8-051eb6408208)
-  Tenant:       780144c7-ffef-4e8f-93f2-18d3058eab0f
+  Subscription: <Your Subscription Name>
+                (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+  Tenant:       xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   Region:       westeurope
   Config:       .uis.secrets/cloud-accounts/azure-default.env
 
@@ -107,7 +107,7 @@ The flow you'll see:
 ═══════════════════════════════════════════════════════════
  AKS cluster provisioning
  (uis platform up azure-aks)
- Subscription: 077d4d11-24e1-4fdc-a5f8-051eb6408208
+ Subscription: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  Region:       westeurope
 ═══════════════════════════════════════════════════════════
 
@@ -149,7 +149,7 @@ POST-APPLY COMPLETE — CLUSTER READY
 
 Cluster:        azure-aks
 Nodes:          1
-External IP:    20.126.163.208
+External IP:    <a public IP assigned by Azure>
 
 Manage cluster:
   ./uis platform status azure-aks                   # state, external IP, cost
@@ -234,7 +234,7 @@ DESTROY COMPLETE
 ✅ Deleted resource group: rg-urbalurba-aks-weu
 ✅ Removed kubectl context
 
-💾 State preserved in:     sa077d4d1124e14fdctf
+💾 State preserved in:     <your state storage account>
 
 💰 Estimated savings: ~€1/day (Standard_B2s_v2 x 1)
 


### PR DESCRIPTION
## Summary

Replaces real helpers.no Azure identifiers with generic placeholders in the AKS guide and one talk46 historical record. Caught during user review of the freshly-deployed docs.

## What and why

Five real values were embedded in `platforms/azure-aks.md` (from talk51's verbose outputs) plus three in a talk46 record:

| Identifier | Was | Now |
|---|---|---|
| Subscription GUID | `077d4d11-24e1-4fdc-a5f8-051eb6408208` | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
| Tenant GUID | `780144c7-ffef-4e8f-93f2-18d3058eab0f` | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
| State storage account | `sa077d4d1124e14fdctf` | `<your state storage account>` |
| External IPs (4 occurrences) | real Azure LB IPs (`20.126.163.208`, `4.245.36.75`) | `<a public IP assigned by Azure>` / `<external-ip>` |

Reasons:

1. **Clutter** — readers see specific GUIDs in example output and have to mentally substitute their own values.
2. **Indirect leak** — the wizard derives the state storage account name from the subscription ID's first 16 chars. Showing a real sub ID indirectly reveals the real storage account. Even though subscription/tenant GUIDs aren't strictly credentials (they're public-by-design for OAuth flows), there's no upside to embedding them in user-facing docs.

No semantic content changes; just placeholder substitution. Local `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)