### PR TITLE
docs(platforms): match real status hint + correct up timing

### DIFF
--- a/website/docs/platforms/azure-aks.md
+++ b/website/docs/platforms/azure-aks.md
@@ -27,7 +27,7 @@ For the helpers.no nonprofit grant subscription specifically, the Contributor ro
 ./uis pull                        # 1. get the latest provision-host image
 ./uis tools install azure-aks     # 2. installs azure-cli + opentofu
 ./uis platform init azure-aks     # 3. interactive wizard writes the config file
-./uis platform up azure-aks       # 4. provisions the cluster end-to-end (~5 min)
+./uis platform up azure-aks       # 4. provisions the cluster end-to-end (~7 min)
 ./uis deploy nginx                # 5. verify with a real service
 ./uis platform down azure-aks     # 6. tear down when finished (cluster cost stops)
 ```
@@ -179,7 +179,7 @@ Active: azure-aks
 
 PLATFORM          STATUS
 rancher-desktop   ✓ running    local k3s
-azure-aks         ✓ running  (active)    Azure AKS, k8s 1.32
+azure-aks         ✓ running  (active)    k8s cluster reachable
 ```
 
 ### 5. Verify with `./uis deploy nginx`

--- a/website/docs/platforms/index.md
+++ b/website/docs/platforms/index.md
@@ -25,7 +25,7 @@ The status column uses four state values:
 
 | State | Meaning | Typical hint |
 |---|---|---|
-| `✓ running` | Cluster is live and reachable from inside the provision-host container | platform-specific (e.g. `local k3s`, `Azure AKS, k8s 1.32`) |
+| `✓ running` | Cluster is live and reachable from inside the provision-host container | platform-specific (e.g. `local k3s`, `k8s cluster reachable`) |
 | `· configured, not running` | Setup completed (env file or platform config exists), no live cluster | `run './uis platform up <name>' to start it` |
 | `· not initialized` | UIS doesn't have configuration for this platform yet | `run './uis platform init <name>' to set up` (rancher-desktop says "install Rancher Desktop and start it" — no init wizard needed for the local-only case) |
 | `✗ unreachable` | Setup exists but the API server didn't respond within 3 seconds | `run './uis platform status <name>' for details` |


### PR DESCRIPTION
## Summary

Two doc-only fixes from the talk50 review round. Both are real contradictions between what the docs claim and what `:latest` actually does.

| Page | Was | Now | Why |
|---|---|---|---|
| `platforms/index.md` four-state table | example hint `Azure AKS, k8s 1.32` | `k8s cluster reachable` | Real `azure-aks/scripts/status.sh --summary` doesn't emit the k8s version; matches actual output |
| `platforms/azure-aks.md` Step 4 platform list example | same as above | `k8s cluster reachable` | same reason |
| `platforms/azure-aks.md` Quick start | `(~5 min)` | `(~7 min)` | The same page's Step 4 body already says 7 min (5 min cluster create + 2 min post-apply + 1 min bootstrap). Inline comment now agrees. |

Other items tester surfaced (missing `Reset UIS target` block in destroy example, subscription line wrap, picker/list active-string consistency, `platform status` example output, `uis help` flag advertising) are cosmetic / additions. Deferred to keep AKS done and move on to the next thing.

Local `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)