### PR TITLE
fix(network): talk52 follow-ups — F4 playbook strings + replicas:1 + docs friction patch

### DIFF
--- a/ansible/playbooks/820-deploy-network-cloudflare-tunnel.yml
+++ b/ansible/playbooks/820-deploy-network-cloudflare-tunnel.yml
@@ -58,10 +58,8 @@
 
           To fix:
           1. Create a tunnel in the Cloudflare dashboard (Zero Trust > Networks > Tunnels)
-          2. Copy the tunnel token
-          3. Set CLOUDFLARE_TUNNEL_TOKEN in .uis.secrets/secrets-config/00-common-values.env.template
-          4. Run: uis secrets generate && uis secrets apply
-          5. Then: uis deploy cloudflare-tunnel
+          2. Run: uis network init cloudflare   (paste the tunnel token when prompted)
+          3. Then: uis network up cloudflare
       when: >-
         cf_tunnel_token is not defined or
         cf_tunnel_token == "" or
@@ -160,6 +158,6 @@
           - ""
           - "Cloudflare dashboard: Zero Trust > Networks > Tunnels"
           - ""
-          - "To verify: uis cloudflare verify"
-          - "To remove: uis undeploy cloudflare-tunnel"
+          - "To verify: uis network verify cloudflare"
+          - "To remove: uis network down cloudflare"
           - "==================================================="

--- a/ansible/playbooks/820-deploy-network-cloudflare-tunnel.yml
+++ b/ansible/playbooks/820-deploy-network-cloudflare-tunnel.yml
@@ -5,7 +5,7 @@
 # This playbook:
 # 1. Validates prerequisites (kubeconfig, secrets)
 # 2. Verifies CLOUDFLARE_TUNNEL_TOKEN is set and not a placeholder
-# 3. Applies the static manifest (2 replicas of cloudflared)
+# 3. Applies the static manifest (1 replica of cloudflared)
 # 4. Waits for pods to be running
 # 5. Tests end-to-end connectivity through the tunnel
 #

--- a/ansible/playbooks/821-remove-network-cloudflare-tunnel.yml
+++ b/ansible/playbooks/821-remove-network-cloudflare-tunnel.yml
@@ -75,5 +75,5 @@
           - "To fully clean up, delete the tunnel in:"
           - "  Cloudflare dashboard > Zero Trust > Networks > Tunnels"
           - ""
-          - "To redeploy: uis deploy cloudflare-tunnel"
+          - "To redeploy: uis network up cloudflare"
           - "==================================================="

--- a/ansible/playbooks/822-verify-cloudflare.yml
+++ b/ansible/playbooks/822-verify-cloudflare.yml
@@ -115,7 +115,7 @@
       vars:
         running_pods: "{{ cf_pods.resources | default([]) | selectattr('status.phase', 'equalto', 'Running') | list }}"
         pod_result: >-
-          {% if cf_pods.resources | default([]) | length == 0 %}INFO: Pods - not deployed (deploy with: uis deploy cloudflare-tunnel)
+          {% if cf_pods.resources | default([]) | length == 0 %}INFO: Pods - not deployed (deploy with: uis network up cloudflare)
           {% elif running_pods | length == cf_pods.resources | length %}PASS: Pods - {{ running_pods | length }}/{{ cf_pods.resources | length }} running
           {% else %}WARN: Pods - {{ running_pods | length }}/{{ cf_pods.resources | length }} running ({{ cf_pods.resources | map(attribute='status.phase') | list | join(', ') }}){% endif %}
 
@@ -188,9 +188,9 @@
           - "{% for result in check_results %}  {{ result | trim }}\n{% endfor %}"
           - ""
           - "Commands:"
-          - "  Deploy:   uis deploy cloudflare-tunnel"
-          - "  Remove:   uis undeploy cloudflare-tunnel"
-          - "  Teardown: uis cloudflare teardown"
+          - "  Status:   uis network status cloudflare"
+          - "  Verify:   uis network verify cloudflare"
+          - "  Remove:   uis network down cloudflare"
           - "  Logs:     kubectl logs -n default -l app=cloudflared --tail=50"
           - ""
           - "==================================================="

--- a/manifests/820-cloudflare-tunnel-base.yaml
+++ b/manifests/820-cloudflare-tunnel-base.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     app: cloudflared
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: cloudflared

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-uis-network-export-import.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-uis-network-export-import.md
@@ -1,0 +1,73 @@
+---
+status: backlog
+created: 2026-05-13
+source: talk52 F10 (UIS-USER1 Message 12)
+related:
+  - PLAN-cloudflare-network-port-and-docs-lift-up.md
+---
+
+# INVESTIGATE: `uis network export/import <provider>` for portable provider state
+
+## Problem
+
+`uis network init <provider>` writes credentials to two host files:
+
+- `.uis.secrets/service-keys/<provider>.env` — the canonical record
+- `.uis.secrets/secrets-config/00-common-values.env.template` — patched lines for the secrets pipeline
+
+Both survive container recycles (host bind mount), but neither survives:
+
+- Deleting the test folder
+- Cloning to a fresh test folder for clean-state re-verification
+- Anyone picking up the work on a different machine
+
+In practice, every fresh clone or test-folder reset re-pays the dashboard-and-token ceremony (~20–45 min for Cloudflare per talk52 F6/F7/F9). The Cloudflare-side state (tunnel, hostname routes, DNS records) is persistent — but the local cred files are not.
+
+The talk52 tester's workaround:
+
+```bash
+# After init, copy the canonical env file to a stable location
+mkdir -p ~/.uis-state/cloudflare-<tunnel-name>
+cp .uis.secrets/service-keys/cloudflare.env ~/.uis-state/cloudflare-<tunnel-name>/
+chmod 600 ~/.uis-state/cloudflare-<tunnel-name>/cloudflare.env
+
+# On a fresh test folder, restore + deploy
+cp ~/.uis-state/cloudflare-<tunnel-name>/cloudflare.env <newfolder>/.uis.secrets/service-keys/
+cd <newfolder>
+./uis network up cloudflare
+```
+
+That works (the env file alone is enough — `up.sh` chains `uis secrets generate` which re-patches the master template), but it's a manual step the user has to remember and a path UIS doesn't sanction.
+
+## Proposed shape
+
+Two new subcommands under `uis network`:
+
+| Command | Behavior |
+|---|---|
+| `uis network export <provider> [--out <path>]` | Bundle the per-provider env file + the matching `00-common-values.env.template` lines into a portable file (default: `~/.uis-state/<provider>-<name>/<provider>.env`). Optional `--encrypt` flag to passphrase-protect. |
+| `uis network import <provider> <path>` | Restore the env file into the current test folder's `.uis.secrets/`, patch the common-values template, and (optionally) chain `uis secrets generate` + `uis secrets apply`. |
+
+Open questions for the investigation:
+
+1. **Scope**: Cloudflare-only, all providers under `networking/`, or generalize to any secrets bundle (`uis state export/import <thing>`)?
+2. **Format**: a single env file, or a small bundle with metadata (provider, tunnel-name, created-at, host fingerprint for safety)?
+3. **Encryption**: passphrase-based (age, gpg, openssl) — or pin to OS keychain (macOS Keychain / Linux secret-service)?
+4. **Default location**: `~/.uis-state/<provider>/<name>/` or `~/.config/uis/state/<provider>/<name>/`? Both are stable per-user; XDG-compliant matters if anyone runs UIS on a multi-tenant box.
+5. **Conflict policy on import**: refuse if the target env file exists? Force-overwrite with `--force`? Show a 3-option menu like `uis network init`?
+
+## Out of scope
+
+- Cloudflare-side state export (tunnel UUID, hostname routes, DNS records) — that's on the Cloudflare dashboard and stable. Local-side only.
+- Cluster-side secret backup (`urbalurba-secrets` k8s Secret) — already regenerable from the local env files via `uis secrets generate && uis secrets apply`.
+- Generalizing to non-network providers (PostgREST JWT secret, db credentials, etc.). That's the "general feature" framing the tester proposed; tackle it as a follow-up if the network-only version proves the pattern.
+
+## Not urgent
+
+The manual workaround is trivial. This investigation matters when:
+
+- A second tester / contributor / customer needs the cloudflare path on their machine
+- We start running automated end-to-end tests against a real Cloudflare tunnel (each test run starts from a clean folder)
+- The DCT / TMP template-system work surfaces the same "where do the credentials live" question for non-network secrets
+
+Until one of those lands, the workaround documented in talk52 Message 12 is enough.

--- a/website/docs/networking/cloudflare-setup.md
+++ b/website/docs/networking/cloudflare-setup.md
@@ -86,11 +86,13 @@ Save it somewhere safe — you'll put it in the UIS secrets config in Step 4.
 
 ## Step 3: Configure Public Hostname Routes
 
-After saving the tunnel, you'll be on the tunnel configuration page. Navigate to the **Hostname routes** tab (or "Published application routes").
+After saving the tunnel, you'll be on the tunnel configuration page. Click the **Hostname routes** tab.
+
+> **Important: the Beta "Hostname routes" tab has TWO sections.** Scroll down to **"Published application routes"** (the lower section). The upper section, titled "Your hostname routes", is for **Cloudflare One / WARP-client private access** — it has a simpler form (just hostname + description) and is **not** what UIS needs. Adding a route in the upper section will trigger a "Cloudflare One Client device profile" popup and will *not* create the public DNS record you need. If you see a form without Service Type / URL fields, you're in the wrong section.
 
 ### Add wildcard route (all subdomains)
 
-Click **"Add a published application route"**:
+In the **Published application routes** section, click **"Add a published application route"**:
 
 | Field | Value |
 |-------|-------|
@@ -101,6 +103,8 @@ Click **"Add a published application route"**:
 | **URL** | `traefik.kube-system.svc.cluster.local:80` |
 
 Click **Save**.
+
+> **If a "Cloudflare One Client device profile" popup appears** asking about Split Tunnels and the `100.64.0.0/10` CGNAT range — click **Confirm**. This is a generic Zero Trust warning that fires whenever you point a route at a `.cluster.local` origin. It does **not** apply to UIS's public-tunnel use case (no WARP client involved). Clicking Cancel will abort the save.
 
 ### Add root domain route
 
@@ -116,19 +120,27 @@ Click **"Add a published application route"** again:
 
 Click **Save**.
 
-### DNS record conflict error
+### Verify both halves: published route AND DNS record
 
-If you see: *"Error: An A, AAAA, or CNAME record with that host already exists"*
+A Cloudflare tunnel route needs **two** things to actually serve traffic, and they live in different places:
 
-This means an old DNS record exists (e.g., from a previously deleted tunnel). Fix it:
+1. A **Published Application Route** (you just added these) — tells the tunnel which origin URL to forward each hostname's traffic to.
+2. A **DNS record** under `DNS → Records` — tells Cloudflare's edge which tunnel to send traffic for that hostname to.
 
-1. Go to the main Cloudflare dashboard: `dash.cloudflare.com`
-2. Select your domain → **DNS → Records**
-3. Find the conflicting record (CNAME or Tunnel type pointing to the old tunnel)
-4. Click **Edit** → **Delete** the old record
-5. Go back to the tunnel config and try adding the route again
+When you save a published route, Cloudflare *normally* auto-creates the matching DNS record (displayed as `Type: Tunnel`). **This auto-create is not 100% reliable** — it sometimes silently skips for wildcards, apex/root domains, or when conflicting records already exist.
 
-Cloudflare will automatically create the correct DNS record when the route is saved.
+**After saving each route, verify** by going to `dash.cloudflare.com → <your-domain> → DNS → Records`. You should see two rows added by the tunnel:
+
+| Type | Name | Content | Proxy status |
+|------|------|---------|--------------|
+| Tunnel | `*` | `<your-tunnel-name>` | Proxied (orange cloud) |
+| Tunnel | `<your-domain>` (or `@`) | `<your-tunnel-name>` | Proxied (orange cloud) |
+
+**If a row is missing**, add it manually: click **Add record**, set Type to `CNAME`, Name to `*` (or `@` for root), Target to `<your-tunnel-uuid>.cfargotunnel.com` (find the UUID on the tunnel's Overview tab), and **Proxy status: Proxied (orange cloud)**. Save.
+
+> **The "record already exists" error** (*"An A, AAAA, or CNAME record with that host already exists"*) happens in two cases:
+> - There's a stale DNS record from a previous tunnel or another service (e.g., Squarespace A records, an old CNAME). **Fix**: in DNS → Records, find and delete the conflicting row, then re-save the route.
+> - You manually added a DNS record before saving the matching Published Application Route, and the route's auto-create is now trying to create a duplicate. **Fix**: delete your manual DNS record, then save the route — Cloudflare will auto-create the correct one.
 
 ### Verify your routes
 
@@ -138,6 +150,10 @@ Your tunnel should now show two published application routes:
 |---|-------|------|---------|
 | 1 | `*.urbalurba.no` | `*` | `http://traefik.kube-system.svc.cluster.local:80` |
 | 2 | `urbalurba.no` | `*` | `http://traefik.kube-system.svc.cluster.local:80` |
+
+…and matching `Type: Tunnel` rows in DNS → Records.
+
+> **"No connection detected yet" / Continue button disabled** during tunnel creation — Cloudflare's tunnel wizard shows install instructions for `cloudflared` and a Connection Status panel that polls for the connector. The Continue button stays disabled until the connector connects. In UIS the connector is the K8s pod that gets deployed in Step 5 below — not running yet. **You can configure hostname routes on the tunnel's detail page without finishing the wizard**: click "Cancel" on the install screen (the tunnel itself is already saved), navigate back to `Networks → Tunnels → <your tunnel>`, and proceed with Step 3 from there. After Step 5, the dashboard will show the connector as Healthy.
 
 ## Step 4: Configure UIS Secrets
 
@@ -187,11 +203,16 @@ This runs 5 checks:
 You can also test manually:
 
 ```bash
-curl https://whoami.urbalurba.no
+# whoami's IngressRoute uses HostRegexp(whoami-public.*) — note the "-public" suffix
+curl https://whoami-public.urbalurba.no
+
+# Root domain hits Traefik's catch-all (typically the nginx landing page)
 curl https://urbalurba.no
 ```
 
 The tunnel status in the Cloudflare dashboard should change from **Inactive** to **Healthy**.
+
+> **Common mistake**: the whoami service's IngressRoute matches `HostRegexp(whoami-public.*)`, **not** `whoami.*`. A curl to `https://whoami.urbalurba.no` will return 404 because no IngressRoute matches that exact hostname. Same applies to other services — check the actual IngressRoute pattern (`kubectl get ingressroutes -A`) before forming URLs.
 
 ---
 
@@ -226,6 +247,65 @@ This removes Kubernetes resources and prints instructions for deleting the tunne
 | Connection timeout | Port 7844 blocked by network | See "Port 7844 Blocked" below |
 | DNS record conflict | Old CNAME from deleted tunnel | Delete old DNS record, re-add route |
 | "Worker is Running!" on root domain | Cloudflare Worker intercepting traffic | Check Workers & Pages, remove Worker routes |
+| `NXDOMAIN` / "Could not resolve host" for subdomain | Wildcard DNS record missing (auto-create failed) | See "DNS auto-create didn't fire" below |
+| `HTTP/2 404` from `server: cloudflare` despite DNS resolving | Published Application Route missing, or stale Private hostname route | See "404 from Cloudflare edge" below |
+| Continue button greyed out during tunnel creation | Wizard expects connector to connect first | Cancel the wizard and configure routes from the tunnel detail page — see Step 3 |
+| "Cloudflare One Client device profile" popup on route save | You're in the wrong section (Private hostnames) | Use "Published application routes" section, not "Your hostname routes" — see Step 3 |
+| Whoami curl returns 404 from traefik (not Cloudflare) | Wrong hostname — IngressRoute uses `whoami-public.*`, not `whoami.*` | Use `https://whoami-public.<your-domain>` |
+
+### DNS auto-create didn't fire
+
+After saving a Published Application Route, Cloudflare *should* automatically create a matching `Type: Tunnel` row in `DNS → Records`. Sometimes it silently skips this — especially for wildcards, apex/root domains, or when conflicting records exist.
+
+**Diagnostic** (from your host):
+
+```bash
+# Query Cloudflare's authoritative nameserver directly — bypasses caching
+dig +short @sandy.ns.cloudflare.com whoami-public.yourdomain.com
+#   Expected: two Cloudflare anycast IPs (e.g., 104.21.x.x and 172.67.x.x)
+#   If empty: the wildcard / apex record is missing from Cloudflare's zone
+```
+
+If `dig` returns nothing from the authoritative nameserver, the record genuinely doesn't exist in Cloudflare's zone — this is not a propagation issue. Add the record manually:
+
+1. Go to `dash.cloudflare.com → <your-domain> → DNS → Records → Add record`
+2. Type: `CNAME`, Name: `*` (or `@` for root), Target: `<tunnel-uuid>.cfargotunnel.com`, Proxy status: **Proxied (orange cloud)**
+3. Get the tunnel UUID from `Networks → Tunnels → <your-tunnel> → Overview` tab
+
+Cloudflare's authoritative DNS is instant — within seconds of saving, `dig +short @sandy.ns.cloudflare.com` should return the anycast IPs.
+
+### 404 from Cloudflare edge (despite DNS working)
+
+If `curl https://your-hostname.yourdomain.com/` returns:
+
+```
+HTTP/2 404
+server: cloudflare
+cf-ray: ...
+```
+
+…and the headers show `server: cloudflare` (not `server: traefik` or your origin's server), the 404 is from Cloudflare's edge, not your cluster. This means **DNS resolves to Cloudflare, but Cloudflare has no Published Application Route to forward the request through**.
+
+**Diagnostic — confirm traefik would have served it**:
+
+```bash
+# Curl traefik directly with the unresolvable hostname as Host header
+curl -I -H 'Host: your-hostname.yourdomain.com' http://localhost/
+#   If you get 200 (or any non-404 from a route that matches), traefik is fine.
+#   The problem is at Cloudflare's published-route layer.
+```
+
+**Fix**: go to `Networks → Tunnels → <your-tunnel> → Hostname routes → Published application routes` and verify there's a row covering this hostname. If missing, add it (Step 3). If you previously added a route in the upper "Your hostname routes" section by mistake — that's a Private route and doesn't serve public traffic — delete it and re-add in the Published Application Routes section.
+
+### Stale DNS records from prior domain owners
+
+If your domain was previously used elsewhere (Squarespace, Wix, one.com, GitHub Pages, etc.), the DNS zone may contain leftover A/CNAME records that proxy traffic to the old origin. These show up as:
+
+- `A` rows at the apex pointing to non-Cloudflare IPs (e.g., Squarespace `198.185.x.x` or `198.49.x.x`)
+- `CNAME` rows for subdomains pointing to provider hostnames (e.g., `*.squarespace.com`, `ghs.google.com` for old Google Sites)
+- `NS` rows at the apex pointing to a previous registrar's nameservers (cosmetic leftover; the registrar-level NS is what actually matters)
+
+To use the domain with Cloudflare Tunnel, delete the old A/CNAME records that conflict with the tunnel routes. Leave MX records (email), TXT records (verification/SPF), and the registrar-level NS configuration alone.
 
 ### Port 7844 Blocked (Corporate Networks)
 
@@ -282,12 +362,19 @@ When you add published application routes, Cloudflare automatically creates:
 With the wildcard route (`*.urbalurba.no`), ALL subdomains automatically reach your cluster:
 
 ```
-whoami.urbalurba.no    → Cloudflare → cloudflared pod → Traefik → whoami service
-openwebui.urbalurba.no → Cloudflare → cloudflared pod → Traefik → openwebui service
-grafana.urbalurba.no   → Cloudflare → cloudflared pod → Traefik → grafana service
+whoami-public.urbalurba.no  → Cloudflare → cloudflared pod → Traefik → whoami service
+openwebui.urbalurba.no       → Cloudflare → cloudflared pod → Traefik → openwebui service
+grafana.urbalurba.no         → Cloudflare → cloudflared pod → Traefik → grafana service
 ```
 
-Traefik routes to the correct service using its HostRegexp IngressRoute rules (e.g., `HostRegexp('whoami\..+')`). No per-service tunnel configuration needed.
+Traefik routes to the correct service using its HostRegexp IngressRoute rules. Each service deployed via UIS defines its own HostRegexp pattern — `whoami` uses `HostRegexp(whoami-public.*)`, others use their own conventions. **The IngressRoute pattern is what determines the URL**, not the service name alone. Inspect with:
+
+```bash
+kubectl get ingressroutes -A
+kubectl get ingressroute <name> -n <namespace> -o yaml
+```
+
+A subdomain that doesn't match any specific IngressRoute falls through to Traefik's catch-all (typically `nginx-root-catch-all` serving the default nginx landing page), so an unconfigured subdomain still returns 200 — just from the catch-all, not the intended service. If you expect a specific service and see the nginx page instead, check the IngressRoute's HostRegexp pattern against your URL.
 
 ---
 

--- a/website/docs/networking/cloudflare-setup.md
+++ b/website/docs/networking/cloudflare-setup.md
@@ -196,7 +196,7 @@ This deploys 2 `cloudflared` pods (for high availability) that connect to Cloudf
 This runs 5 checks:
 1. **Secrets** — `CLOUDFLARE_TUNNEL_TOKEN` is configured and not a placeholder
 2. **Network** — DNS resolves and port 7844 is reachable
-3. **Pods** — 2/2 cloudflared pods are running
+3. **Pods** — the cloudflared pod is running
 4. **Logs** — Tunnel connection registered with Cloudflare edge
 5. **End-to-end** — HTTP request through the tunnel returns a response
 

--- a/website/docs/networking/cloudflare.md
+++ b/website/docs/networking/cloudflare.md
@@ -67,9 +67,9 @@ If the file already exists, the wizard offers three options: skip (keep existing
 Two stages:
 
 1. **`uis secrets generate` + `uis secrets apply`** — pushes the token from the local env file into the `urbalurba-secrets` Secret in the cluster. This is the same pipeline every other UIS secret uses.
-2. **`ansible-playbook 820-deploy-network-cloudflare-tunnel.yml`** — applies the static `820-cloudflare-tunnel-base.yaml` manifest (a Deployment with 2 replicas of `cloudflared`) and waits for both pods to reach `Running`. The playbook also runs a final HTTPS probe through your domain if `BASE_DOMAIN_CLOUDFLARE` is set.
+2. **`ansible-playbook 820-deploy-network-cloudflare-tunnel.yml`** — applies the static `820-cloudflare-tunnel-base.yaml` manifest (a Deployment with one `cloudflared` replica) and waits for the pod to reach `Running`. The playbook also runs a final HTTPS probe through your domain if `BASE_DOMAIN_CLOUDFLARE` is set.
 
-The pods register with Cloudflare's edge within ~15 seconds. After that, any service with a Traefik IngressRoute matching `*.your-domain.com` is reachable on the public internet.
+The pod registers with Cloudflare's edge within ~15 seconds. After that, any service with a Traefik IngressRoute matching `*.your-domain.com` is reachable on the public internet.
 
 ### 4. Verify
 
@@ -110,7 +110,7 @@ internet user
   ↓
 Cloudflare edge (terminates TLS, optionally adds WAF / DDoS rules)
   ↓
-cloudflared pod (outbound-only, 2 replicas)
+cloudflared pod (outbound-only)
   ↓
 Traefik IngressRoute (HostRegexp match)
   ↓

--- a/website/docs/networking/index.md
+++ b/website/docs/networking/index.md
@@ -15,7 +15,7 @@ UIS targets **multiple networking providers** from a single command interface. C
 ```
 $ uis network list
 PROVIDER     STATUS                                  HINT
-cloudflare   ✓ running                               2/2 cloudflared pods up
+cloudflare   ✓ running                               1/1 cloudflared pods up
 tailscale    · pending CLI port                      use legacy verbs: ./uis tailscale ...
 ```
 
@@ -23,7 +23,7 @@ The status column uses the same four-state vocabulary as `uis platform list`:
 
 | State | Meaning | Typical hint |
 |---|---|---|
-| `✓ running` | Provider is deployed and at least one pod is in the `Running` phase | provider-specific (e.g. `2/2 cloudflared pods up`) |
+| `✓ running` | Provider is deployed and at least one pod is in the `Running` phase | provider-specific (e.g. `1/1 cloudflared pods up`) |
 | `· configured, not running` | `init` has been run (env file exists), no provider deployment in the cluster | `run './uis network up <provider>' to deploy` |
 | `· not initialized` | UIS has no configuration for this provider yet | `run './uis network init <provider>' to set up` |
 | `✗ unreachable` | Deployment exists but no pods are Running | `check 'kubectl -n default logs -l app=<provider>'` |


### PR DESCRIPTION
## Summary

talk52 verified PR #169 + #170 end-to-end against a live `skryter.no` tunnel. Findings F4–F10 surfaced; this PR resolves the actionable ones and reverses one earlier decision.

- **Replicas back to 1**: revisited talk52 Obs D — on a single-node rancher-desktop cluster the two pods always land on the same node, so the prod-shape argument doesn't survive contact with the actual deploy target. `820-cloudflare-tunnel-base.yaml` is back to `replicas: 1`. If we later need HA on a multi-node platform (AKS), revisit via per-platform manifest override or a `--replicas` flag.
- **F4 (low) — playbook task-result strings**: 820-deploy, 821-remove, 822-verify still nudged users at the legacy `uis deploy cloudflare-tunnel` / `uis cloudflare verify` CLI removed in #169. Replaced with the `uis network ... cloudflare` verbs.
- **F5–F9 (docs) — Cloudflare dashboard friction**: the tester documented ~30 min of real-world setup friction (Beta UI Public/Private route confusion, DNS auto-create unreliability, DNS + Published Route both required, `whoami-public.*` IngressRoute mismatch). Their +103-line patch on `cloudflare-setup.md` is friction-tested with diagnostic `dig` / `curl` commands. Landing as-is.
- **F10 (suggestion) — `uis network export/import <provider>`**: backlog INVESTIGATE stub capturing design questions (scope, format, encryption, default location, conflict policy). Manual `cp` workaround is trivial; not urgent.
- **F8 (skipped)**: tester's Squarespace/one.com DNS cleanup is their domain, not UIS code.
- **`cloudflare-setup.md` vs `cloudflare.md` reconciliation (skipped)**: they overlap but serve different audiences for now (deep dive vs. concise walkthrough). Separate editorial pass if/when they drift further.

## Test plan

- [x] `npm run build` clean — no new broken links from this PR
- [x] grep confirms zero remaining `uis deploy cloudflare-tunnel` / `uis cloudflare verify` references in the three 82x playbooks
- [x] grep confirms zero remaining `replicas: 2` / `2/2 cloudflared` references in live (non-historical) files
- [ ] Tester (next round, optional): rerun `./uis network verify cloudflare` and confirm the result block's `Commands:` section now lists the new CLI; confirm `1/1` pod count

🤖 Generated with [Claude Code](https://claude.com/claude-code)