### PR TITLE
fix(tailscale): bump deploy connectivity-test retry budget (talk52 F4)

### DIFF
--- a/ansible/playbooks/802-deploy-network-tailscale-tunnel.yml
+++ b/ansible/playbooks/802-deploy-network-tailscale-tunnel.yml
@@ -334,6 +334,10 @@
         prompt: "Waiting for Tailscale Funnel and DNS to stabilize..."
 
     - name: "18 Test Tailscale tunnel connectivity"
+      # Fresh OWNER_ID first-deploys take ~90–120s for cert provisioning +
+      # DNS propagation (per talk52 F4). Warm-cache deploys short-circuit on
+      # the first attempt via the until condition, so the larger budget only
+      # matters when it's actually needed.
       ansible.builtin.uri:
         url: "https://{{ tailscale_owner_id }}.{{ tailscale_tailnet }}"
         method: GET
@@ -341,7 +345,7 @@
         validate_certs: false
         timeout: 30
       register: tunnel_test
-      retries: 12
+      retries: 24
       delay: 10
       until: tunnel_test.status == 200
       failed_when: false


### PR DESCRIPTION
## Summary

talk52 F4 follow-up to merged #173. The deploy playbook's task 18 hard-failed via task 19a on fresh `OWNER_ID` first-deploys even though the tunnel actually came up ~30s after the playbook gave up.

**Root cause** — Tailscale Funnel needs ~90–120s on a never-before-used device name for cert provisioning + DNS propagation. Prior retry config (`retries: 12, delay: 10` = 120s ceiling) landed right at the worst-case boundary.

**Fix** — bump `retries: 12 → 24` (~240s ceiling). Warm-cache deploys short-circuit on the first attempt via the `until` condition, so the bigger budget only matters when it's actually needed.

## Test plan

- [x] yaml parses
- [ ] Tester re-runs clean-slate restart with a fresh `OWNER_ID`; deploy playbook should now succeed end-to-end without the false "FAILED" banner

## Context

Surfaced in talk52 Message 9's clean-slate restart with `OWNER_ID=k8s-terchris`. Pre-existing playbook bug — not caused by the rename in #173 — but the rename's "use a new OWNER_ID per developer" guidance makes new users hit it more often, hence the same-day follow-up rather than backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)