### PR TITLE
docs(networking): add provider decision matrix + fix Tailscale setup leftovers

### DIFF
--- a/website/docs/networking/index.md
+++ b/website/docs/networking/index.md
@@ -8,6 +8,26 @@ sidebar_position: 1
 
 UIS targets **multiple networking providers** from a single command interface. Cloudflare tunnels expose services on a domain you own. Tailscale Funnel + Tailscale internal ingress give you tunnel-style or VPN-style access without a public domain. All of them speak the same `uis network ...` vocabulary, so swapping the path your services take to the internet is a CLI flag away.
 
+## Which one should I use?
+
+You probably want **one** of these — most users don't need both. Pick by what you're trying to do:
+
+| If you want to… | Use | Why |
+|---|---|---|
+| Quickly show a service on your laptop to a colleague | **Tailscale Funnel** | No domain needed (get a free `<thing>.ts.net` URL), no Cloudflare account, works from any network including corporate Wi-Fi |
+| Run a service for real (own DNS, WAF, DDoS protection, predictable URL) | **Cloudflare tunnel** | You already own the domain, Cloudflare handles certs and edge security, wildcard subdomain routing works |
+| Both — different services on different paths | Both | They coexist. The same backend pod can answer on `whoami.localhost`, `whoami.<your-name>.ts.net`, and `whoami.your-domain.com` simultaneously |
+
+The decision typically comes down to **three constraints**:
+
+1. **Do you own a domain Cloudflare can host DNS for?** No → Tailscale is your option. Yes → either works.
+2. **Does your network allow outbound TCP/7844?** Some corporate networks block it. Cloudflare needs it. Tailscale uses UDP/443 + DERP relay, which goes through almost anything.
+3. **How many services do you want to expose?** Cloudflare gives you wildcard subdomain routing for free — one tunnel handles `*.your-domain.com`. Tailscale Funnel has no wildcard DNS, so you `uis tailscale expose <service>` for each one you want public.
+
+**On security:** both paths terminate TLS at the provider's edge and reach into the cluster over an outbound-only connection — no inbound ports, no public IP on your side. Cloudflare adds a free WAF and DDoS protection in front. Tailscale Funnel sits behind Tailscale's own infrastructure with no built-in WAF. Authentik forward-auth in front of Traefik still works for Cloudflare paths; **it does not work for Tailscale Funnel**, because the Tailscale operator's per-service proxy routes directly to the backend service and bypasses Traefik entirely. If you want auth on a Tailscale-exposed service, the service has to enforce it itself.
+
+
+
 ## See what you have
 
 `uis network list` shows every provider UIS knows about and its current state:
@@ -66,4 +86,4 @@ You don't change the ingress to switch providers — you add or remove the netwo
 - **[Cloudflare tunnel](./cloudflare.md)** — set up `cloudflared` in-cluster, point a domain at it. Token-based, no inbound ports.
 - **[Cloudflare setup (deep dive)](./cloudflare-setup.md)** — historical setup guide. Covers DNS, dashboard config, multiple environments.
 - **[Tailscale Funnel setup](./tailscale-setup.md)** — public `*.ts.net` exposure with Tailscale Funnel.
-- **[Tailscale network isolation](./tailscale-network-isolation.md)** — ACL patterns for restricting who reaches what.
+- **[Tailscale network isolation](./tailscale-network-isolation.md)** — design proposal for host-network-isolation hardening (not implemented; design reference only).

--- a/website/docs/networking/tailscale-network-isolation.md
+++ b/website/docs/networking/tailscale-network-isolation.md
@@ -1,7 +1,12 @@
 # Tailscale Funnel Security Setup for Rancher Desktop
 
-TODO: This is not implemented - it is a potential solution that isolates the cluster when connected to the internet using tailscale funnel or cloudfrale tunnel.
+:::warning Design proposal — not deployed
 
+This page describes a network-isolation design that has **not been implemented** in UIS. Nothing on this page is wired up to the CLI or the default rancher-desktop configuration. It exists as a design reference for a future investigation, not as a setup guide.
+
+If you want to expose services through Tailscale Funnel today, see [Tailscale Funnel setup](./tailscale-setup.md) — that's the active, working path. Come back to this page only if you want to read about the proposed host-network-isolation hardening on top.
+
+:::
 
 ## Overview
 

--- a/website/docs/networking/tailscale-setup.md
+++ b/website/docs/networking/tailscale-setup.md
@@ -76,7 +76,7 @@ Before starting, ensure you have:
 ### Step 1: Create Tailscale Account
 
 1. Visit [tailscale.com](https://tailscale.com) and sign up
-2. Your tailnet will be created (e.g., `yourusername.github`) → **Note this as `TAILSCALE_TAILNET`**
+2. Tailscale gives you a tailnet identifier (e.g., `yourusername.github`). The value UIS needs is your **MagicDNS domain** — the `<words>.ts.net` form, captured in Step 5 below. Don't note the org-handle form for `TAILSCALE_TAILNET`.
 
 ### Step 2: Configure Access Control Tags (Prepare for auth key)
 
@@ -158,19 +158,22 @@ Before starting, ensure you have:
 
 ### Step 6: Configure Tailscale Secrets
 
-Edit the secrets source file with your Tailscale values from Steps 1-5:
+Edit the secrets source file with your Tailscale values from Steps 1-5. The file lives in your local `.uis.secrets/secrets-config/` folder; edit it with whichever editor you prefer (from the host or inside the provision-host container — `./uis secrets edit` opens it in `vi`, or just edit the file directly on the host since it's bind-mounted):
+
 ```bash
-nano .uis.secrets/config/00-common-values.env
+# From the host:
+vi .uis.secrets/secrets-config/00-common-values.env.template
+# Or from inside the provision-host container:
+./uis secrets edit
 ```
 
 Update these variables:
 ```bash
-TAILSCALE_VM_AUTH_KEY=tskey-auth-YOUR-AUTH-KEY           # From Step 3: Auth Key
-TAILSCALE_TAILNET=your-tailnet-name                 # From Step 1: Your tailnet name
-TAILSCALE_TAILNET=your-magic-dns-domain              # From Step 5: MagicDNS domain
-TAILSCALE_OWNER_ID=k8s                      # Becomes: k8s.[your-domain].ts.net (cluster ingress only)
-TAILSCALE_CLIENTID=YOUR-OAUTH-CLIENT-ID             # From Step 4: OAuth Client ID
-TAILSCALE_CLIENTSECRET=tskey-client-YOUR-SECRET      # From Step 4: OAuth Client Secret
+TAILSCALE_TAILNET=your-magic-dns-domain     # From Step 5: MagicDNS domain (e.g. dog-pence.ts.net)
+TAILSCALE_OWNER_ID=k8s-yourname             # Your identity on the tailnet; cluster Funnel device + operator prefix
+TAILSCALE_CLIENTID=YOUR-OAUTH-CLIENT-ID     # From Step 4: OAuth Client ID
+TAILSCALE_CLIENTSECRET=tskey-client-YOUR-SECRET   # From Step 4: OAuth Client Secret
+TAILSCALE_VM_AUTH_KEY=tskey-auth-YOUR-AUTH-KEY    # From Step 3: only needed for VM/cloud-init provisioning
 ```
 
 Then regenerate the Kubernetes secrets:
@@ -310,7 +313,7 @@ This error means your OAuth client doesn't have permission for `tag:k8s-operator
 3. In **Devices → Core** scope, ensure `tag:k8s-operator` is added
 4. In **Keys → Auth Keys** scope, ensure `tag:k8s-operator` is added
 5. Generate a new client secret (required after scope changes)
-6. Update `TAILSCALE_CLIENTSECRET` in `.uis.secrets/config/00-common-values.env`
+6. Update `TAILSCALE_CLIENTSECRET` in `.uis.secrets/secrets-config/00-common-values.env.template`
 7. Regenerate secrets: `./uis secrets generate`
 8. Redeploy: `./uis deploy tailscale-tunnel`
 
@@ -334,7 +337,7 @@ If you get authentication errors, create new keys at [Tailscale Admin Console](h
 
 **Update secrets file:**
 ```bash
-# Edit .uis.secrets/config/00-common-values.env
+# Edit .uis.secrets/secrets-config/00-common-values.env.template
 TAILSCALE_VM_AUTH_KEY=tskey-auth-YOUR-NEW-AUTH-KEY
 TAILSCALE_CLIENTID=YOUR-NEW-CLIENT-ID
 TAILSCALE_CLIENTSECRET=tskey-client-YOUR-NEW-CLIENT-SECRET
@@ -363,7 +366,7 @@ This means **Let's Encrypt ACME rate limiting** is blocking TLS certificate issu
 
 **Solutions:**
 1. **Wait** for the rate limit to reset (the error message includes the retry-after timestamp)
-2. **Use a different hostname** — change `TAILSCALE_OWNER_ID` in `.uis.secrets/config/00-common-values.env` (e.g., `k8s-2` instead of `k8s`), then `./uis secrets generate` and redeploy
+2. **Use a different hostname** — change `TAILSCALE_OWNER_ID` in `.uis.secrets/secrets-config/00-common-values.env.template` (e.g., `k8s-2` instead of `k8s`), then `./uis secrets generate` and redeploy
 3. **Avoid repeated deploy/undeploy cycles** with the same hostname during testing
 
 ### Script Execution Issues


### PR DESCRIPTION
## Summary

Three user-facing networking-doc fixes that don't depend on PLAN-002's CLI port:

**`index.md`** — add a "Which one should I use?" section. Three-row use-case table (show-a-colleague vs production vs both) plus three decision constraints (own a domain? outbound 7844 reachable? wildcard routing matters?). Surfaces the Tailscale-Funnel-bypasses-Traefik fact that Authentik forward-auth doesn't apply on Tailscale URLs.

**`tailscale-setup.md`** — clean up the leftovers from PR #173's mechanical Phase-2 rewires:
- Step 6 had a duplicate `TAILSCALE_TAILNET` line (collision from the `DOMAIN → TAILNET` replace_all) and pointed at the wrong path (`.uis.secrets/config/` instead of `.uis.secrets/secrets-config/`), wrong filename (missing `.template`), and an editor that isn't in the image (`nano` vs `vi` after talk52 F2).
- Step 1 told users to capture their org-handle as `TAILSCALE_TAILNET`; the variable actually wants the MagicDNS form captured in Step 5.
- Three other troubleshooting-section path references corrected.
- Bumped the `OWNER_ID` example from `k8s` to `k8s-yourname` to nudge away from the collision-prone bare default (talk52 Obs A).

**`tailscale-network-isolation.md`** — the "TODO: This is not implemented" line at the top is too easy to miss. Promoted to a proper `:::warning` admonition explaining it's a design reference, not a setup guide.

## Test plan

- [x] `cd website && npm run build` — Docusaurus build clean (only pre-existing broken anchors unrelated to this branch)
- [ ] Spot-check the rendered pages on the docs site after merge

## Scope context

This is **option A** of the networking-docs analysis. Options B (write `tailscale.md` novice short guide) and C (PLAN-002 + PLAN-003) follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)