### PR TITLE
fix(uis-cli): forward args from cmd_network_{init,up,down,verify} to scripts

### DIFF
--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -1401,6 +1401,7 @@ _list_available_network_providers_with_script() {
 # No banner — `init` writes a local env file; doesn't touch the cluster.
 cmd_network_init() {
     local provider="${1:-}"
+    shift || true
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
@@ -1418,7 +1419,7 @@ cmd_network_init() {
     fi
 
     export UIS_REPO_ROOT="$repo_root"
-    exec "$script"
+    exec "$script" "$@"
 }
 
 # cmd_network_up — provision the provider into the active cluster.
@@ -1428,6 +1429,7 @@ cmd_network_init() {
 cmd_network_up() {
     _uis_cluster_banner
     local provider="${1:-}"
+    shift || true
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
@@ -1445,7 +1447,7 @@ cmd_network_up() {
     fi
 
     export UIS_REPO_ROOT="$repo_root"
-    exec "$script"
+    exec "$script" "$@"
 }
 
 # cmd_network_down — remove the provider's cluster footprint.
@@ -1453,6 +1455,7 @@ cmd_network_up() {
 cmd_network_down() {
     _uis_cluster_banner
     local provider="${1:-}"
+    shift || true
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
@@ -1470,7 +1473,7 @@ cmd_network_down() {
     fi
 
     export UIS_REPO_ROOT="$repo_root"
-    exec "$script"
+    exec "$script" "$@"
 }
 
 # cmd_network_status — show provider state, tunnel/route state, pod health.
@@ -1503,6 +1506,7 @@ cmd_network_status() {
 cmd_network_verify() {
     _uis_cluster_banner
     local provider="${1:-}"
+    shift || true
     local repo_root
     repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
@@ -1520,7 +1524,7 @@ cmd_network_verify() {
     fi
 
     export UIS_REPO_ROOT="$repo_root"
-    exec "$script"
+    exec "$script" "$@"
 }
 
 # cmd_network_expose — per-service Funnel exposure. Tailscale-specific; the


### PR DESCRIPTION
## Summary
- The four `cmd_network_*` dispatcher functions in `provision-host/uis/manage/uis-cli.sh` consumed `$1` as `provider` but never `shift`ed and never forwarded `"$@"` to the underlying `networking/<provider>/scripts/<verb>.sh`. Flags after the provider name were silently dropped.
- `./uis network up tailscale --with-cluster-funnel` ran in operator-only mode because `up.sh` never saw the flag.
- Patch matches the pattern `cmd_network_expose` / `cmd_network_unexpose` already use: `shift || true` after `local provider="${1:-}"`, then `exec "$script" "$@"`.

## How surfaced
talk54 R4 verification against `dog-pence.ts.net`. Tester patched the in-container CLI transiently with `sed` to unblock the round; this PR makes the fix permanent.

## Scope
- Fixes `cmd_network_init` (line 1402), `cmd_network_up` (line 1429), `cmd_network_down` (line 1455), `cmd_network_verify` (line 1506).
- `cmd_network_status` already forwards `"$@"` (just doesn't shift; status.sh ignores non-`--summary` args).
- The same shape exists in `cmd_platform_*` but none of those scripts accept flags today (latent, separate concern, deliberately not bundled).

## Test plan
- [x] `bash provision-host/uis/tests/run-tests.sh` — all 7 test scripts pass
- [ ] After `:latest` rebuild: tester re-runs talk54 R1-R10 against `dog-pence.ts.net`; specifically R4 (`./uis network up tailscale --with-cluster-funnel`) should register the cluster Funnel device without an in-container patch