### PR TITLE
Add MinIO object storage as a UIS service

### DIFF
--- a/ansible/playbooks/045-remove-minio.yml
+++ b/ansible/playbooks/045-remove-minio.yml
@@ -1,0 +1,209 @@
+---
+# file: ansible/playbooks/045-remove-minio.yml
+# Description:
+# Remove MinIO object storage from the Kubernetes cluster.
+#
+#   Default mode (no extra-var), set by `./uis undeploy minio`:
+#     - Uninstall the Helm release
+#     - Remove the Traefik IngressRoutes (console + S3 API)
+#     - Wait for pods to terminate
+#     KEEPS: the PVC (all buckets and objects) and urbalurba-secrets.
+#     A subsequent ./uis deploy minio re-attaches the same data.
+#
+#   Purge mode (-e _purge=true, set by `./uis undeploy minio --purge`):
+#     - Everything default mode does, plus:
+#     - Delete the MinIO PVC — PERMANENTLY DELETES ALL BUCKETS AND OBJECTS
+#     User-level confirmation is enforced by uis-cli.sh before this playbook runs.
+#
+# Prerequisites:
+# - Kubernetes cluster with MinIO deployed
+# - kubectl and Helm 3.x available
+#
+# Usage:
+# ansible-playbook playbooks/045-remove-minio.yml -e target_host="rancher-desktop"
+# ansible-playbook playbooks/045-remove-minio.yml -e _purge=true
+
+- name: Remove MinIO Object Storage from Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    _target: "{{ target_host | default('rancher-desktop') }}"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    minio_namespace: "default"
+    minio_release_name: "minio"
+    removal_timeout: 180       # 3 minutes timeout for helm uninstall
+    cleanup_wait_timeout: 120  # 2 minutes timeout for pod termination
+    purge_mode: "{{ _purge | default(false) | bool }}"
+
+  tasks:
+    - name: 1. Display removal information
+      ansible.builtin.debug:
+        msg:
+          - "======================================"
+          - "MinIO Object Storage Removal"
+          - "File: ansible/playbooks/045-remove-minio.yml"
+          - "======================================"
+          - "Target Host: {{ _target }}"
+          - "Namespace: {{ minio_namespace }}"
+          - "Release: {{ minio_release_name }}"
+          - "Mode: {{ 'PURGE - deletes the PVC and all stored objects' if purge_mode else 'default - keeps the PVC and all stored objects' }}"
+
+    - name: 2. Check if MinIO Helm release exists
+      ansible.builtin.shell: |
+        helm list -n {{ minio_namespace }} -q | grep -x {{ minio_release_name }} | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_release_check
+      changed_when: false
+      failed_when: false
+
+    - name: 3. Display MinIO release status
+      ansible.builtin.debug:
+        msg: >
+          MinIO Helm release: {{ 'found - will be removed'
+          if (minio_release_check.stdout | int) > 0
+          else 'not found - nothing to uninstall' }}
+
+    - name: 4. Get current MinIO resources before removal
+      ansible.builtin.shell: |
+        echo "=== PODS ==="
+        kubectl get pods -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null || echo "No MinIO pods found"
+        echo "=== SERVICES ==="
+        kubectl get svc -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null || echo "No MinIO services found"
+        echo "=== PVCs ==="
+        kubectl get pvc -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null || echo "No MinIO PVCs found"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_resources_before
+      changed_when: false
+      failed_when: false
+
+    - name: 5. Display resources before removal
+      ansible.builtin.debug:
+        msg: |
+          Current MinIO resources:
+          {{ minio_resources_before.stdout }}
+
+    - name: 6. Remove MinIO IngressRoutes
+      kubernetes.core.k8s:
+        state: absent
+        api_version: traefik.io/v1alpha1
+        kind: IngressRoute
+        name: "{{ item }}"
+        namespace: "{{ minio_namespace }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      loop:
+        - minio-console
+        - minio-api
+      failed_when: false
+
+    - name: 7. Remove MinIO Helm release
+      ansible.builtin.shell: |
+        helm uninstall {{ minio_release_name }} -n {{ minio_namespace }} --timeout {{ removal_timeout }}s
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_uninstall_result
+      when: (minio_release_check.stdout | int) > 0
+      changed_when: true
+      failed_when: false
+
+    - name: 8. Wait for MinIO pods to terminate
+      ansible.builtin.shell: |
+        timeout {{ cleanup_wait_timeout }} bash -c 'while kubectl get pods -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null | grep -q .; do echo "Waiting for pods to terminate..."; sleep 5; done'
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_pod_termination
+      changed_when: false
+      failed_when: false
+
+    - name: 9. Count remaining MinIO pods
+      ansible.builtin.shell: |
+        kubectl get pods -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_remaining_pods
+      changed_when: false
+      failed_when: false
+
+    - name: 10. Count remaining MinIO services
+      ansible.builtin.shell: |
+        kubectl get svc -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null | wc -l
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_remaining_services
+      changed_when: false
+      failed_when: false
+
+    # ============= PURGE ONLY: DESTROYS ALL STORED OBJECTS =============
+
+    - name: 11. PURGE - delete MinIO PVC (all buckets and objects)
+      ansible.builtin.shell: |
+        kubectl delete pvc -n {{ minio_namespace }} -l app=minio --ignore-not-found=true
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_pvc_delete
+      when: purge_mode
+      changed_when: true
+      failed_when: false
+
+    - name: 12. Check remaining PVCs
+      ansible.builtin.shell: |
+        kubectl get pvc -n {{ minio_namespace }} -l app=minio --no-headers 2>/dev/null
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_preserved_pvcs
+      changed_when: false
+      failed_when: false
+
+    - name: 13. Set removal status facts
+      ansible.builtin.set_fact:
+        helm_removed: "{{ (minio_release_check.stdout | int) == 0 or (minio_uninstall_result.rc is defined and minio_uninstall_result.rc == 0) }}"
+        pods_terminated: "{{ (minio_remaining_pods.stdout | int) == 0 }}"
+        services_removed: "{{ (minio_remaining_services.stdout | int) == 0 }}"
+        pvcs_preserved: "{{ minio_preserved_pvcs.stdout | trim | length > 0 }}"
+
+    - name: 14. Display final removal status
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          MinIO Object Storage Removal Status
+          ===============================================
+
+          Removal status:
+          - Helm release:  {{ 'Removed' if helm_removed else 'Still present' }}
+          - Pods:          {{ 'All terminated' if pods_terminated else 'Still running' }}
+          - Services:      {{ 'Removed' if services_removed else 'Still present' }}
+          - IngressRoutes: Removed (minio-console, minio-api)
+
+          Data:
+          {% if purge_mode %}
+          - PVC: DELETED - all buckets and objects are gone permanently
+          {% else %}
+          - PVC: {{ 'Preserved - buckets and objects survive' if pvcs_preserved else 'No PVC found' }}
+          - Secrets: urbalurba-secrets preserved (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD)
+          {% endif %}
+
+          {% if pvcs_preserved %}
+          Preserved PVCs:
+          {{ minio_preserved_pvcs.stdout }}
+          {% endif %}
+
+          Re-deployment:
+          - ./uis deploy minio
+          {% if not purge_mode %}
+          - Existing buckets and objects are re-attached from the preserved PVC
+          {% endif %}
+
+          {% if not purge_mode %}
+          Complete cleanup (DESTRUCTIVE):
+          - ./uis undeploy minio --purge
+          - WARNING: this permanently deletes all buckets and objects
+          {% endif %}
+
+          Verification commands:
+          - kubectl get all -n {{ minio_namespace }} -l app=minio
+          - kubectl get pvc -n {{ minio_namespace }} -l app=minio
+          - helm list -n {{ minio_namespace }}
+
+          {{ 'MINIO REMOVED' if helm_removed and pods_terminated and services_removed else 'CHECK REMOVAL STATUS' }}
+          ===============================================

--- a/ansible/playbooks/045-setup-minio.yml
+++ b/ansible/playbooks/045-setup-minio.yml
@@ -1,0 +1,302 @@
+---
+# file: ansible/playbooks/045-setup-minio.yml
+# Description:
+# Set up MinIO S3-compatible object storage on the Kubernetes cluster.
+# Applications use it for buckets of files: images, uploads, exports, backups.
+#
+# Part of: Database Services - Object Storage Component
+#
+# Prerequisites:
+# - Kubernetes cluster with a default StorageClass
+# - kubectl configured for target cluster
+# - Helm 3.x installed
+# - urbalurba-secrets applied to the default namespace
+#   (contains MINIO_ROOT_USER and MINIO_ROOT_PASSWORD)
+# - Required manifests: 045-minio-config.yaml, 046-minio-ingressroute.yaml
+#
+# Architecture:
+# - Official MinIO Helm chart (minio/minio) in standalone (single node) mode
+# - Root credentials are read from urbalurba-secrets and passed with --set,
+#   never stored in the manifest (see rules/secrets-management.md)
+# - S3 API on service "minio" port 9000, console on "minio-console" port 9001
+# - Traefik IngressRoutes: minio.<domain> = console, s3.<domain> = S3 API
+# - Persistent volume keeps buckets across pod restarts and re-deploys
+#
+# Usage:
+# ansible-playbook playbooks/045-setup-minio.yml -e target_host="rancher-desktop"
+
+- name: Set up MinIO Object Storage on Kubernetes
+  hosts: localhost
+  gather_facts: false
+  vars:
+    _target: "{{ target_host | default('rancher-desktop') }}"
+    manifests_folder: "/mnt/urbalurbadisk/manifests"
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    minio_namespace: "default"
+    component_name: "minio"
+    installation_timeout: 300   # 5 minutes timeout for helm install
+    pod_readiness_timeout: 180  # 3 minutes timeout for pod readiness
+
+    # Helm chart references
+    minio_release_name: "minio"
+    minio_chart: "minio/minio"
+    minio_repo_url: "https://charts.min.io/"
+
+    # Config files
+    minio_config_file: "{{ manifests_folder }}/045-minio-config.yaml"
+    minio_ingressroute_file: "{{ manifests_folder }}/046-minio-ingressroute.yaml"
+
+  tasks:
+    - name: 1. Display deployment information
+      ansible.builtin.debug:
+        msg:
+          - "======================================"
+          - "MinIO Object Storage Deployment"
+          - "File: ansible/playbooks/045-setup-minio.yml"
+          - "======================================"
+          - "Target Host: {{ _target }}"
+          - "Namespace: {{ minio_namespace }}"
+          - "Component: {{ component_name }}"
+          - "Chart: {{ minio_chart }}"
+          - "Credentials: MINIO_ROOT_USER / MINIO_ROOT_PASSWORD from urbalurba-secrets"
+
+    - name: 2. Check existing Helm repositories
+      ansible.builtin.command: helm repo list
+      register: helm_repo_list
+      changed_when: false
+
+    - name: 3. Add MinIO Helm repository if needed
+      kubernetes.core.helm_repository:
+        name: "minio"
+        repo_url: "{{ minio_repo_url }}"
+      when: "'charts.min.io' not in helm_repo_list.stdout"
+
+    - name: 4. Update Helm repositories
+      ansible.builtin.command: helm repo update
+      changed_when: false
+
+    - name: 5. Get MinIO root user from urbalurba-secrets
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ minio_namespace }} \
+        -o jsonpath='{.data.MINIO_ROOT_USER}' 2>/dev/null | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_root_user
+      changed_when: false
+      failed_when: false
+
+    - name: 6. Get MinIO root password from urbalurba-secrets
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ minio_namespace }} \
+        -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' 2>/dev/null | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_root_password
+      changed_when: false
+      failed_when: false
+      no_log: true
+
+    - name: 7. Fail early when credentials are missing
+      ansible.builtin.fail:
+        msg: |
+          MINIO_ROOT_USER / MINIO_ROOT_PASSWORD not found in urbalurba-secrets
+          (namespace {{ minio_namespace }}).
+
+          MinIO refuses to start without root credentials, so deployment stops here.
+
+          Fix:
+            ./uis secrets generate
+            ./uis secrets apply
+            ./uis deploy minio
+      when: >
+        minio_root_user.stdout | default('') | length == 0 or
+        minio_root_password.stdout | default('') | length == 0
+
+    - name: 8. Set MinIO credential facts
+      ansible.builtin.set_fact:
+        minio_root_user_fact: "{{ minio_root_user.stdout }}"
+        minio_root_password_fact: "{{ minio_root_password.stdout }}"
+      no_log: true
+
+    - name: 9. Display MinIO credential status (masked)
+      ansible.builtin.debug:
+        msg:
+          - "MinIO root user: {{ minio_root_user_fact }}"
+          - "MinIO root password: {{ minio_root_password_fact | regex_replace('.', '*') }}"
+
+    - name: 10. Create the MinIO data PVC (owned by UIS, not by Helm)
+      # Kept outside the Helm release on purpose: a chart-owned PVC is deleted by
+      # `helm uninstall`, which would make `./uis undeploy minio` destructive.
+      # storageClassName is omitted so the cluster's default provisioner is used.
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: "minio-data"
+            namespace: "{{ minio_namespace }}"
+            labels:
+              app: minio
+              app.kubernetes.io/name: minio
+              app.kubernetes.io/component: storage
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: "20Gi"
+        state: present
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 11. Deploy MinIO with Helm using centralized credentials
+      ansible.builtin.command: >
+        helm upgrade --install {{ minio_release_name }} {{ minio_chart }}
+        -f {{ minio_config_file }}
+        --set rootUser={{ minio_root_user_fact | quote }}
+        --set rootPassword={{ minio_root_password_fact | quote }}
+        --namespace {{ minio_namespace }}
+        --timeout {{ installation_timeout }}s
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_helm_result
+      changed_when: true
+      no_log: true
+
+    - name: 12. Display Helm deployment result
+      ansible.builtin.debug:
+        msg: "MinIO Helm release installed/upgraded. Waiting for readiness..."
+
+    - name: 13. Wait for MinIO pod to be running
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ minio_namespace }}"
+        label_selectors:
+          - "app=minio"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: minio_pods
+      retries: 20
+      delay: 15
+      until: >
+        minio_pods.resources | length > 0 and
+        minio_pods.resources[0].status.phase == "Running"
+
+    - name: 14. Wait for MinIO pod to be fully ready (1/1)
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ minio_namespace }}"
+        label_selectors:
+          - "app=minio"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: minio_pods_ready
+      retries: 30
+      delay: 10
+      until: >
+        minio_pods_ready.resources | length > 0 and
+        minio_pods_ready.resources[0].status.containerStatuses[0].ready == true
+
+    - name: 15. Test MinIO S3 API health from within the cluster
+      ansible.builtin.shell: |
+        kubectl run minio-curl-test-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ minio_namespace }} -- \
+        curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" http://{{ component_name }}:9000/minio/health/live
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_health_test
+      retries: 15
+      delay: 15
+      until: minio_health_test.rc == 0 and minio_health_test.stdout.find('HTTP_CODE:200') != -1
+      changed_when: false
+
+    - name: 16. Apply MinIO IngressRoutes (console + S3 API)
+      kubernetes.core.k8s:
+        state: present
+        src: "{{ minio_ingressroute_file }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: 17. Verify IngressRoutes are created
+      kubernetes.core.k8s_info:
+        api_version: traefik.io/v1alpha1
+        kind: IngressRoute
+        namespace: "{{ minio_namespace }}"
+        label_selectors:
+          - "app=minio"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: minio_ingress_check
+      retries: 5
+      delay: 2
+      until: minio_ingress_check.resources | length > 1
+
+    - name: 18. Get MinIO pods
+      ansible.builtin.command: kubectl get pods -n {{ minio_namespace }} -l app=minio
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_pods_out
+      changed_when: false
+
+    - name: 19. Get MinIO services
+      ansible.builtin.command: kubectl get svc -n {{ minio_namespace }} -l app=minio
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_svc_out
+      changed_when: false
+
+    - name: 20. Get MinIO PVC
+      ansible.builtin.command: kubectl get pvc -n {{ minio_namespace }} -l app=minio
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: minio_pvc_out
+      changed_when: false
+
+    - name: 21. Display final deployment status
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          MinIO Object Storage Deployment Status
+          ===============================================
+
+          SUCCESS - MinIO deployed and ready
+
+          Status:
+          - Object storage: {{ 'Running' if minio_pods_out.stdout.find('Running') != -1 else 'Not running' }}
+          - S3 API health:  {{ 'Responding (HTTP 200)' if minio_health_test.stdout.find('HTTP_CODE:200') != -1 else 'Not responding' }}
+          - Storage:        Persistent volume configured
+          - IngressRoutes:  {{ minio_ingress_check.resources | length }} created
+
+          Deployment details:
+          - Namespace:  {{ minio_namespace }}
+          - Chart:      {{ minio_chart }}
+          - S3 API:     http://minio.{{ minio_namespace }}.svc.cluster.local:9000 (cluster internal)
+          - Console:    http://minio-console.{{ minio_namespace }}.svc.cluster.local:9001 (cluster internal)
+
+          MinIO pods:
+          {{ minio_pods_out.stdout }}
+
+          MinIO services:
+          {{ minio_svc_out.stdout }}
+
+          Storage (PVC):
+          {{ minio_pvc_out.stdout }}
+
+          Access instructions:
+          - Console (browser):   http://minio.localhost
+          - S3 API (browser/app) http://s3.localhost
+          - S3 API from host:    ./uis expose minio   then use http://localhost:39900
+          - Credentials:         MINIO_ROOT_USER / MINIO_ROOT_PASSWORD in urbalurba-secrets
+              kubectl get secret urbalurba-secrets -n {{ minio_namespace }} \
+                -o jsonpath='{.data.MINIO_ROOT_USER}' | base64 -d
+              kubectl get secret urbalurba-secrets -n {{ minio_namespace }} \
+                -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d
+
+          Usage examples (from an application pod, any AWS S3 SDK):
+          - Endpoint:          http://minio.default.svc.cluster.local:9000
+          - Region:            us-east-1 (MinIO ignores the region, SDKs require one)
+          - Path-style access: required (MinIO does not do virtual-host buckets by default)
+
+          Troubleshooting:
+          - Check pods:   kubectl get pods -n {{ minio_namespace }} -l app=minio
+          - View logs:    kubectl logs -n {{ minio_namespace }} -l app=minio
+          - Check PVC:    kubectl get pvc -n {{ minio_namespace }} -l app=minio
+          - Check routes: kubectl get ingressroute -n {{ minio_namespace }} -l app=minio
+          - Verify E2E:   ./uis verify minio
+
+          MINIO READY - OBJECT STORAGE DEPLOYED
+          ===============================================

--- a/ansible/playbooks/045-test-minio.yml
+++ b/ansible/playbooks/045-test-minio.yml
@@ -1,0 +1,271 @@
+---
+# file: ansible/playbooks/045-test-minio.yml
+# Description:
+# End-to-end tests for the MinIO object storage deployment.
+# Validates health, S3 authentication, bucket round-trip, and Traefik routing.
+#
+# Tests (all CRITICAL):
+#   A. Liveness  - S3 API :9000 /minio/health/live must return 200
+#   B. Auth      - unsigned request to a bucket path must be rejected (403), not open
+#   C. Console   - console service :9001 must serve the web UI
+#   D. Round-trip - mc creates a bucket, uploads an object, reads it back, cleans up
+#   E. Routing   - s3.<domain> and minio.<domain> must resolve through Traefik
+#
+# Usage:
+# ansible-playbook ansible/playbooks/045-test-minio.yml
+
+- name: End-to-End MinIO Tests
+  hosts: localhost
+  gather_facts: false
+  vars:
+    merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
+    minio_namespace: "default"
+    minio_service: "minio.default.svc.cluster.local"
+    minio_console_service: "minio-console.default.svc.cluster.local"
+    test_bucket: "uis-verify-bucket"
+
+  tasks:
+    - name: "0. Display test suite initiation"
+      ansible.builtin.debug:
+        msg: |
+          End-to-End MinIO Tests
+          ===============================================
+          Running 5 test groups (all CRITICAL)
+
+    - name: "0.1. Get Traefik ClusterIP for in-cluster hostname routing"
+      ansible.builtin.command: kubectl get svc traefik -n kube-system -o jsonpath={.spec.clusterIP}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: traefik_ip_result
+      changed_when: false
+
+    - name: "0.2. Store Traefik IP"
+      ansible.builtin.set_fact:
+        traefik_ip: "{{ traefik_ip_result.stdout }}"
+
+    - name: "0.3. Get MinIO root user from urbalurba-secrets"
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ minio_namespace }} \
+        -o jsonpath='{.data.MINIO_ROOT_USER}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: root_user_result
+      changed_when: false
+
+    - name: "0.4. Get MinIO root password from urbalurba-secrets"
+      ansible.builtin.shell: |
+        kubectl get secret urbalurba-secrets -n {{ minio_namespace }} \
+        -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: root_password_result
+      changed_when: false
+      no_log: true
+
+    - name: "0.5. Store credentials"
+      ansible.builtin.set_fact:
+        minio_user: "{{ root_user_result.stdout }}"
+        minio_password: "{{ root_password_result.stdout }}"
+      no_log: true
+
+    # ===== Test A: Liveness (CRITICAL) =====
+    - name: "A1. Check MinIO liveness endpoint (port 9000)"
+      ansible.builtin.shell: |
+        kubectl run minio-test-live-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ minio_namespace }} -- \
+          curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" http://{{ minio_service }}:9000/minio/health/live
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: live_test
+      retries: 5
+      delay: 10
+      until: "'HTTP_CODE:200' in live_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "A2. Verify liveness returns 200"
+      ansible.builtin.assert:
+        that:
+          - "'HTTP_CODE:200' in live_test.stdout"
+        fail_msg: |
+          CRITICAL: MinIO liveness check failed!
+          Expected HTTP 200 from :9000/minio/health/live.
+          Got: {{ live_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check pod status: kubectl get pods -n {{ minio_namespace }} -l app=minio
+          - Check pod logs:   kubectl logs -n {{ minio_namespace }} -l app=minio --tail=50
+        success_msg: "Test A PASSED: MinIO liveness OK"
+
+    - name: "A3. Display liveness test success"
+      ansible.builtin.debug:
+        msg: "Test A: Liveness - PASSED (CRITICAL)"
+
+    # ===== Test B: Unauthenticated access rejected (CRITICAL) =====
+    - name: "B1. Request a bucket listing without credentials"
+      ansible.builtin.shell: |
+        kubectl run minio-test-auth-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ minio_namespace }} -- \
+          curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" http://{{ minio_service }}:9000/
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: auth_test
+      retries: 3
+      delay: 5
+      until: auth_test.rc == 0
+      failed_when: false
+      changed_when: false
+
+    - name: "B2. Verify unsigned requests are rejected (403)"
+      ansible.builtin.assert:
+        that:
+          - "'HTTP_CODE:403' in auth_test.stdout"
+        fail_msg: |
+          CRITICAL: MinIO did not reject an unsigned S3 request!
+          Expected HTTP 403 (AccessDenied) from :9000/ without credentials.
+          Got: {{ auth_test.stdout[:500] | default('No output') }}
+
+          An open MinIO means anonymous clients can list and read buckets.
+          Check that rootUser/rootPassword were applied:
+            helm get values minio -n {{ minio_namespace }}
+        success_msg: "Test B PASSED: unauthenticated S3 access is rejected"
+
+    - name: "B3. Display auth test success"
+      ansible.builtin.debug:
+        msg: "Test B: Unauthenticated access rejected - PASSED (CRITICAL)"
+
+    # ===== Test C: Console reachable (CRITICAL) =====
+    - name: "C1. Request the MinIO console (port 9001)"
+      ansible.builtin.shell: |
+        kubectl run minio-test-console-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ minio_namespace }} -- \
+          curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" http://{{ minio_console_service }}:9001/
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: console_test
+      retries: 5
+      delay: 10
+      until: "'HTTP_CODE:200' in console_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "C2. Verify console returns 200"
+      ansible.builtin.assert:
+        that:
+          - "'HTTP_CODE:200' in console_test.stdout"
+        fail_msg: |
+          CRITICAL: MinIO console is not responding!
+          Expected HTTP 200 from :9001/.
+          Got: {{ console_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Check the console service: kubectl get svc minio-console -n {{ minio_namespace }}
+        success_msg: "Test C PASSED: MinIO console responding"
+
+    - name: "C3. Display console test success"
+      ansible.builtin.debug:
+        msg: "Test C: Console reachable - PASSED (CRITICAL)"
+
+    # ===== Test D: Bucket round-trip with mc (CRITICAL) =====
+    - name: "D1. Create bucket, write an object, read it back, clean up"
+      ansible.builtin.shell: |
+        kubectl run minio-test-mc-{{ 99999 | random }} --image=quay.io/minio/mc --rm -i --restart=Never -n {{ minio_namespace }} \
+          --env=MC_USER={{ minio_user | quote }} \
+          --env=MC_PASS={{ minio_password | quote }} \
+          --command -- sh -c '
+            set -e
+            mc alias set uistest http://{{ minio_service }}:9000 "$MC_USER" "$MC_PASS" > /dev/null
+            mc mb --ignore-existing uistest/{{ test_bucket }} > /dev/null
+            echo "urbalurba-minio-roundtrip" > /tmp/probe.txt
+            mc cp /tmp/probe.txt uistest/{{ test_bucket }}/probe.txt > /dev/null
+            mc cat uistest/{{ test_bucket }}/probe.txt
+            mc rm uistest/{{ test_bucket }}/probe.txt > /dev/null
+            mc rb uistest/{{ test_bucket }} > /dev/null
+          '
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: roundtrip_test
+      retries: 3
+      delay: 10
+      until: "'urbalurba-minio-roundtrip' in roundtrip_test.stdout"
+      failed_when: false
+      changed_when: false
+      no_log: true
+
+    - name: "D2. Verify the object round-tripped"
+      ansible.builtin.assert:
+        that:
+          - "'urbalurba-minio-roundtrip' in roundtrip_test.stdout"
+        fail_msg: |
+          CRITICAL: MinIO bucket round-trip failed!
+          Expected to create a bucket, upload an object and read it back.
+          Output (truncated): {{ roundtrip_test.stdout[:500] | default('No output') }}
+
+          Troubleshooting:
+          - Credentials come from urbalurba-secrets (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD)
+          - Check storage:  kubectl get pvc -n {{ minio_namespace }} -l app=minio
+          - Check logs:     kubectl logs -n {{ minio_namespace }} -l app=minio --tail=50
+        success_msg: "Test D PASSED: bucket create/write/read/delete round-trip OK"
+
+    - name: "D3. Display round-trip test success"
+      ansible.builtin.debug:
+        msg: "Test D: S3 bucket round-trip - PASSED (CRITICAL)"
+
+    # ===== Test E: Traefik routing (CRITICAL) =====
+    - name: "E1. Reach the S3 API through Traefik (Host: s3.localhost)"
+      ansible.builtin.shell: |
+        kubectl run minio-test-route-api-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ minio_namespace }} -- \
+          curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" -H "Host: s3.localhost" http://{{ traefik_ip }}/minio/health/live
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: route_api_test
+      retries: 5
+      delay: 10
+      until: "'HTTP_CODE:200' in route_api_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "E2. Reach the console through Traefik (Host: minio.localhost)"
+      ansible.builtin.shell: |
+        kubectl run minio-test-route-ui-{{ 99999 | random }} --image=curlimages/curl --rm -i --restart=Never -n {{ minio_namespace }} -- \
+          curl -s -o /dev/null -w "HTTP_CODE:%{http_code}" -H "Host: minio.localhost" http://{{ traefik_ip }}/
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: route_ui_test
+      retries: 5
+      delay: 10
+      until: "'HTTP_CODE:200' in route_ui_test.stdout"
+      failed_when: false
+      changed_when: false
+
+    - name: "E3. Verify both IngressRoutes resolve"
+      ansible.builtin.assert:
+        that:
+          - "'HTTP_CODE:200' in route_api_test.stdout"
+          - "'HTTP_CODE:200' in route_ui_test.stdout"
+        fail_msg: |
+          CRITICAL: MinIO Traefik routing failed!
+          s3.localhost   -> {{ route_api_test.stdout | default('No output') }}
+          minio.localhost -> {{ route_ui_test.stdout | default('No output') }}
+
+          Troubleshooting:
+          - Check routes: kubectl get ingressroute -n {{ minio_namespace }} -l app=minio
+          - Re-apply:     kubectl apply -f /mnt/urbalurbadisk/manifests/046-minio-ingressroute.yaml
+        success_msg: "Test E PASSED: both MinIO IngressRoutes resolve through Traefik"
+
+    - name: "E4. Display routing test success"
+      ansible.builtin.debug:
+        msg: "Test E: Traefik routing - PASSED (CRITICAL)"
+
+    # ===== Summary =====
+    - name: "SUMMARY - Display all test results"
+      ansible.builtin.debug:
+        msg: |
+          ===============================================
+          MinIO E2E Test Results
+          ===============================================
+          A. Liveness (:9000/minio/health/live):     PASS
+          B. Unauthenticated S3 access rejected:     PASS
+          C. Console reachable (:9001):              PASS
+          D. Bucket create/write/read/delete:        PASS
+          E. Traefik routing (s3.* and minio.*):     PASS
+
+          ALL TESTS PASSED - MinIO is healthy
+          ===============================================

--- a/ansible/playbooks/05-install-helm-repos.yml
+++ b/ansible/playbooks/05-install-helm-repos.yml
@@ -17,6 +17,7 @@
         - { name: 'runix', url: 'https://helm.runix.net' }
         - { name: 'graviteeio', url: 'https://helm.gravitee.io' }
         - { name: 'rhdh-chart', url: 'https://redhat-developer.github.io/rhdh-chart' }
+        - { name: 'minio', url: 'https://charts.min.io/' }
       register: helm_repo_result
 
     - name: 01. Print playbook description

--- a/manifests/045-minio-config.yaml
+++ b/manifests/045-minio-config.yaml
@@ -1,0 +1,134 @@
+# File: 045-minio-config.yaml
+#
+# Description:
+# Helm values for the official MinIO chart (minio/minio from https://charts.min.io/).
+# Deploys a single-node ("standalone") S3-compatible object storage server suitable
+# for a laptop-sized development cluster.
+#
+# Requirements:
+# - Helm repo: minio -> https://charts.min.io/ (added by 045-setup-minio.yml)
+# - urbalurba-secrets in the default namespace with MINIO_ROOT_USER / MINIO_ROOT_PASSWORD
+#
+# Credentials:
+# - rootUser/rootPassword are deliberately NOT set here. The setup playbook reads them
+#   from urbalurba-secrets and passes them with --set, so no credential ever lives in git.
+#   See docs/contributors/rules/secrets-management.md ("No Helm Chart Defaults for Security Values").
+#
+# Usage:
+# installing:   helm install minio minio/minio -f 045-minio-config.yaml -n default \
+#                 --set rootUser=... --set rootPassword=...
+# upgrading:    helm upgrade minio minio/minio -f 045-minio-config.yaml -n default ...
+# uninstalling: helm uninstall minio -n default
+#
+# Debugging commands:
+# check pod status: kubectl get pods -n default -l app=minio
+# view logs:        kubectl logs -n default -l app=minio
+# port-forward S3:  kubectl port-forward svc/minio 9000:9000 -n default
+# port-forward UI:  kubectl port-forward svc/minio-console 9001:9001 -n default
+# health check:     curl http://localhost:9000/minio/health/live
+#
+# Notes:
+# - Two ClusterIP services are created: "minio" (S3 API, 9000) and "minio-console" (UI, 9001).
+# - Ingress is handled by 046-minio-ingressroute.yaml (Traefik IngressRoute), not by the
+#   chart's own ingress objects — hence ingress/consoleIngress are disabled below.
+# - MINIO_BROWSER_REDIRECT_URL is intentionally not set: the console must work on
+#   minio.localhost, on Tailscale and on Cloudflare domains from the same deployment.
+# - Buckets are NOT pre-created here. Applications create their own buckets through the
+#   S3 API, which keeps this file application-agnostic.
+
+# Single node, single drive - the right shape for a dev cluster.
+# (Chart default is "distributed" with 16 replicas.)
+mode: standalone
+replicas: 1
+drivesPerNode: 1
+pools: 1
+
+image:
+  pullPolicy: IfNotPresent
+  # Empty tag uses the chart's appVersion
+
+# Persistent storage for buckets and objects.
+#
+# The PVC is created by the setup playbook, NOT by Helm, and referenced here as an
+# existingClaim. This is the same pattern Qdrant uses, and it is what makes
+# `./uis undeploy minio` non-destructive: a chart-owned PVC is deleted by
+# `helm uninstall`, an externally-owned one survives and is re-attached on the next
+# deploy. `./uis undeploy minio --purge` deletes it explicitly.
+#
+# The playbook creates the claim without a storageClassName, so the cluster's default
+# provisioner is used (local-path on Rancher Desktop, managed-csi on AKS, etc).
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  existingClaim: "minio-data"
+  size: 20Gi
+
+# Resource requests and limits sized for a laptop.
+# (Chart default requests 16Gi of memory, which will not schedule.)
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 100m
+  limits:
+    memory: 2Gi
+    cpu: 1000m
+
+# S3 API service
+service:
+  type: ClusterIP
+  port: "9000"
+
+# Web console service
+consoleService:
+  type: ClusterIP
+  port: "9001"
+
+# Routing is done with Traefik IngressRoute CRDs (046-minio-ingressroute.yaml)
+ingress:
+  enabled: false
+
+consoleIngress:
+  enabled: false
+
+# Run as non-root with a writable data volume
+securityContext:
+  enabled: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
+
+# Post-install jobs (bucket/user/policy creation) - kept empty on purpose,
+# but the job pods still need laptop-sized resource requests.
+buckets: []
+users: []
+policies: []
+svcaccts: []
+
+makeBucketJob:
+  resources:
+    requests:
+      memory: 128Mi
+
+makeUserJob:
+  resources:
+    requests:
+      memory: 128Mi
+
+makePolicyJob:
+  resources:
+    requests:
+      memory: 128Mi
+
+postJob:
+  podAnnotations:
+    app.kubernetes.io/part-of: "storage-stack"
+
+podAnnotations:
+  app.kubernetes.io/part-of: "storage-stack"
+
+# Prometheus metrics are exposed on the API port at /minio/v2/metrics/cluster.
+# Set enabled: true after deploying the observability stack.
+metrics:
+  serviceMonitor:
+    enabled: false

--- a/manifests/046-minio-ingressroute.yaml
+++ b/manifests/046-minio-ingressroute.yaml
@@ -1,0 +1,81 @@
+---
+# File: manifests/046-minio-ingressroute.yaml
+#
+# Description:
+# Traefik IngressRoutes for MinIO. Two routes are needed because MinIO serves the
+# web console and the S3 API on two different ports:
+#
+#   minio.<domain>  -> minio-console:9001  (browser UI for humans)
+#   s3.<domain>     -> minio:9000          (S3 API for applications and SDKs)
+#
+# HostRegexp Routing:
+# Both routes use HostRegexp so the same manifest works on every domain the cluster
+# is reachable on, without edits:
+# - minio.localhost / s3.localhost              (local development)
+# - minio.<tailnet>.ts.net / s3.<tailnet>.ts.net (Tailscale)
+# - minio.example.com / s3.example.com           (Cloudflare tunnel)
+#
+# Usage:
+# kubectl apply -f 046-minio-ingressroute.yaml
+#
+# Dependencies:
+# - 045-minio-config.yaml (MinIO Helm deployment)
+# - services "minio" and "minio-console" must exist in the default namespace
+#
+# Testing:
+# Console:  curl -I http://minio.localhost
+# S3 API:   curl http://s3.localhost/minio/health/live   (expects HTTP 200)
+#
+# Security Considerations:
+# - The console gives full administrative access to every bucket. It is public here
+#   (dev-cluster convention, same as the RabbitMQ management UI); add the
+#   authentik-forward-auth middleware if the cluster is exposed to the internet.
+# - The S3 API route is public at the network level but every request is still
+#   signed with AWS SigV4 credentials, so unauthenticated callers get 403.
+#
+# Cluster Standards Compliance:
+# - traefik.io/v1alpha1 API version (current working version in Traefik 3.3.6)
+# - HostRegexp pattern for unified routing (recommended approach)
+# - Descriptive labels matching cluster conventions
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio-console
+  namespace: default
+  labels:
+    app: minio
+    component: console-ui
+    type: public
+    routing: unified
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`minio\..+`)
+      kind: Rule
+      services:
+        - name: minio-console
+          port: 9001
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio-api
+  namespace: default
+  labels:
+    app: minio
+    component: s3-api
+    type: public
+    routing: unified
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: HostRegexp(`s3\..+`)
+      kind: Rule
+      services:
+        - name: minio
+          port: 9000

--- a/provision-host/provision-host-04-helmrepo.sh
+++ b/provision-host/provision-host-04-helmrepo.sh
@@ -52,6 +52,7 @@ install_helm_and_repos() {
         helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add runix https://helm.runix.net
         helm repo add graviteeio https://helm.gravitee.io
+        helm repo add minio https://charts.min.io/
         helm repo update
         
         echo "Helm $(helm version --short) installed successfully"

--- a/provision-host/uis/lib/expose.sh
+++ b/provision-host/uis/lib/expose.sh
@@ -22,6 +22,9 @@ EXPOSE_CONFIG=(
     ["elasticsearch"]="elasticsearch-master default 9200"
     ["qdrant"]="qdrant default 6333"
     ["authentik"]="authentik-server authentik 9000"
+    # MinIO S3 API. The console is reached through Traefik (http://minio.localhost),
+    # so only the API port is port-forwarded.
+    ["minio"]="minio default 9000"
 )
 
 # Base path — inside container it's /mnt/urbalurbadisk, outside it's the repo root

--- a/provision-host/uis/lib/integration-testing.sh
+++ b/provision-host/uis/lib/integration-testing.sh
@@ -82,6 +82,7 @@ VERIFY_SERVICES="
 argocd:argocd verify
 backstage:backstage verify
 enonic:enonic verify
+minio:minio verify
 nextcloud:nextcloud verify
 openmetadata:openmetadata verify
 "

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -142,6 +142,9 @@ ArgoCD:
 Enonic XP:
   enonic verify                  Run E2E health checks on Enonic XP
 
+MinIO:
+  minio verify                   Run E2E health checks on MinIO object storage
+
 OpenMetadata:
   openmetadata verify            Run E2E health checks on OpenMetadata
 
@@ -2005,6 +2008,7 @@ cmd_verify() {
         echo "  argocd          Run E2E health checks on ArgoCD server"
         echo "  backstage       Run E2E health checks on Backstage (RHDH)"
         echo "  enonic          Run E2E health checks on Enonic XP"
+        echo "  minio           Run E2E health checks on MinIO object storage"
         echo "  nextcloud       Run E2E health checks on Nextcloud + OnlyOffice"
         echo "  openmetadata    Run E2E health checks on OpenMetadata"
         exit "$EXIT_GENERAL_ERROR"
@@ -2026,6 +2030,9 @@ cmd_verify() {
         enonic)
             cmd_enonic_verify
             ;;
+        minio)
+            cmd_minio_verify
+            ;;
         nextcloud)
             cmd_nextcloud_verify
             ;;
@@ -2041,6 +2048,7 @@ cmd_verify() {
             echo "  argocd          Run E2E health checks on ArgoCD server"
             echo "  backstage       Run E2E health checks on Backstage (RHDH)"
             echo "  enonic          Run E2E health checks on Enonic XP"
+            echo "  minio           Run E2E health checks on MinIO object storage"
             echo "  nextcloud       Run E2E health checks on Nextcloud + OnlyOffice"
             echo "  openmetadata    Run E2E health checks on OpenMetadata"
             exit "$EXIT_GENERAL_ERROR"
@@ -2334,6 +2342,15 @@ cmd_backstage_verify() {
 cmd_openmetadata_verify() {
     print_section "Verifying OpenMetadata Deployment"
     ansible-playbook "$ANSIBLE_DIR/340-test-openmetadata.yml"
+}
+
+# ============================================================
+# MinIO Commands
+# ============================================================
+
+cmd_minio_verify() {
+    print_section "Verifying MinIO Deployment"
+    ansible-playbook "$ANSIBLE_DIR/045-test-minio.yml"
 }
 
 # ============================================================
@@ -2661,6 +2678,22 @@ main() {
                     echo ""
                     echo "Commands:"
                     echo "  enonic verify    Run E2E health checks on Enonic XP"
+                    exit "$EXIT_GENERAL_ERROR"
+                    ;;
+            esac
+            ;;
+        minio)
+            local subcmd="${1:-}"
+            shift 2>/dev/null || true
+            case "$subcmd" in
+                verify)
+                    cmd_minio_verify
+                    ;;
+                *)
+                    log_error "Unknown minio command: $subcmd"
+                    echo ""
+                    echo "Commands:"
+                    echo "  minio verify    Run E2E health checks on MinIO object storage"
                     exit "$EXIT_GENERAL_ERROR"
                     ;;
             esac

--- a/provision-host/uis/services/databases/service-minio.sh
+++ b/provision-host/uis/services/databases/service-minio.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# service-minio.sh - MinIO service metadata
+#
+# MinIO is an S3-compatible object storage server. It gives applications a
+# bucket/object API (images, uploads, backups, data-lake files) without a
+# cloud dependency, and a web console for browsing buckets.
+
+# === Service Metadata (Required) ===
+SCRIPT_ID="minio"
+SCRIPT_NAME="MinIO"
+SCRIPT_DESCRIPTION="S3-compatible object storage"
+SCRIPT_CATEGORY="DATABASES"
+
+# === UIS-Specific (Optional) ===
+SCRIPT_PLAYBOOK="045-setup-minio.yml"
+SCRIPT_MANIFEST=""
+SCRIPT_CHECK_COMMAND="kubectl get pods -n default -l app=minio --no-headers 2>/dev/null | grep -q Running"
+SCRIPT_REMOVE_PLAYBOOK="045-remove-minio.yml"
+SCRIPT_REQUIRES=""
+SCRIPT_PRIORITY="34"
+
+# === Deployment Details (Optional) ===
+SCRIPT_HELM_CHART="minio/minio"
+SCRIPT_NAMESPACE="default"
+
+# === Extended Metadata (Optional) ===
+SCRIPT_KIND="Resource"          # Component | Resource
+SCRIPT_TYPE="object-storage"    # service | tool | library | database | cache | message-broker
+SCRIPT_OWNER="platform-team"    # platform-team | app-team
+
+# === Website Metadata (Optional) ===
+SCRIPT_ABSTRACT="S3-compatible object storage for files, images, and backups"
+SCRIPT_LOGO="minio-logo.svg"
+SCRIPT_WEBSITE="https://min.io"
+SCRIPT_TAGS="object-storage,s3,buckets,files,images,blob-storage"
+SCRIPT_SUMMARY="MinIO is a high-performance, S3-compatible object storage server. Applications talk to it with any AWS S3 SDK, so code written against MinIO in UIS runs unchanged against AWS S3, Azure Blob (via S3 gateway), or a production MinIO cluster. Deployed in standalone mode with a persistent volume, an S3 API on port 9000, and a web console on port 9001."
+SCRIPT_DOCS="/docs/services/databases/minio"
+
+# === Template Integration (Optional) ===
+# The S3 API port is what applications need on the host machine
+# (./uis expose minio -> localhost:39900). The console is reached
+# through Traefik at http://minio.localhost instead.
+SCRIPT_EXPOSE_PORT="39900"

--- a/provision-host/uis/templates/secrets-templates/00-common-values.env.template
+++ b/provision-host/uis/templates/secrets-templates/00-common-values.env.template
@@ -161,6 +161,17 @@ JUPYTERHUB_AUTH_PASSWORD=${DEFAULT_ADMIN_PASSWORD}
 QDRANT_API_KEY=LocalDevQdrantKey123
 
 # ================================================================
+# 🔧 OPTIONAL - MINIO OBJECT STORAGE
+# ================================================================
+# S3-compatible object storage. The root credentials below are the
+# "account owner" of the MinIO instance - applications use them to
+# create buckets and read/write objects.
+# MinIO requires: user >= 3 chars, password >= 8 chars.
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=${DEFAULT_DATABASE_PASSWORD}
+MINIO_HOST=minio.default.svc.cluster.local
+
+# ================================================================
 # 🔧 OPTIONAL - OPENMETADATA
 # ================================================================
 # OpenMetadata bootstraps with admin@open-metadata.org / admin.

--- a/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
+++ b/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
@@ -115,6 +115,19 @@ stringData:
   QDRANT_API_KEY: "${QDRANT_API_KEY}"
 
   # ================================================================
+  # MINIO OBJECT STORAGE
+  # ================================================================
+  # S3-compatible object storage. MINIO_ROOT_USER / MINIO_ROOT_PASSWORD are
+  # read by 045-setup-minio.yml and passed to the Helm chart; applications use
+  # the same pair as their S3 access key / secret key.
+  MINIO_ROOT_USER: "${MINIO_ROOT_USER}"
+  MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD}"
+  MINIO_HOST: "${MINIO_HOST}"
+  MINIO_PORT: "9000"
+  MINIO_CONSOLE_PORT: "9001"
+  MINIO_ENDPOINT: "http://${MINIO_HOST}:9000"
+
+  # ================================================================
   # GRAFANA ADMIN CREDENTIALS
   # ================================================================
   # For checking logging

--- a/provision-host/uis/templates/uis.extend/enabled-services.conf.default
+++ b/provision-host/uis/templates/uis.extend/enabled-services.conf.default
@@ -19,6 +19,7 @@ nginx
 # === Databases ===
 # postgresql
 # redis
+# minio
 
 # === Applications ===
 # nextcloud

--- a/website/docs/contributors/architecture/manifests.md
+++ b/website/docs/contributors/architecture/manifests.md
@@ -60,6 +60,8 @@ Files are numbered by category. The number in the manifest filename matches the 
 | `042-database-postgresql-config.yaml` | PostgreSQL Helm values |
 | `043-database-mysql-config.yaml` | MySQL Helm values |
 | `044-qdrant-config.yaml` | Qdrant vector database Helm values |
+| `045-minio-config.yaml` | MinIO object storage Helm values |
+| `046-minio-ingressroute.yaml` | MinIO console + S3 API Traefik routes |
 | `050-redis-config.yaml` | Redis Helm values |
 | `060-elasticsearch-config.yaml` | Elasticsearch Helm values |
 

--- a/website/docs/getting-started/services.md
+++ b/website/docs/getting-started/services.md
@@ -15,6 +15,7 @@ Complete list of services available in UIS compared to their cloud equivalents.
 | **Cache & Session Store** | Azure Cache for Redis | Redis | `./uis deploy redis` |
 | **Search Engine** | Azure AI Search | Elasticsearch | `./uis deploy elasticsearch` |
 | **Vector Database** | Azure AI Search | Qdrant | `./uis deploy qdrant` |
+| **Object Storage** | Azure Blob Storage, AWS S3 | MinIO | `./uis deploy minio` |
 | **Authentication & SSO** | Azure AD, AWS IAM | Authentik | `./uis deploy authentik` |
 | **AI Chat Interface** | Azure OpenAI Service | OpenWebUI | `./uis deploy openwebui` |
 | **LLM Proxy & Router** | Azure OpenAI, AWS Bedrock | LiteLLM | `./uis deploy litellm` |
@@ -68,6 +69,7 @@ Deploy as a package: `./uis stack install observability`
 - **MongoDB** — Document database
 - **Redis** — Cache and session store
 - **Elasticsearch** — Full-text search engine
+- **MinIO** — S3-compatible object storage
 
 ### Management
 - **ArgoCD** — GitOps continuous delivery

--- a/website/docs/reference/documentation-index.md
+++ b/website/docs/reference/documentation-index.md
@@ -96,6 +96,7 @@ Welcome to the complete documentation for **Urbalurba Infrastructure** — a zer
 | [Redis](../services/databases/redis.md) | In-memory cache and message broker |
 | [Elasticsearch](../services/databases/elasticsearch.md) | Search and analytics engine |
 | [Qdrant](../services/databases/qdrant.md) | Vector database |
+| [MinIO](../services/databases/minio.md) | S3-compatible object storage |
 
 ### Services — Management
 

--- a/website/docs/reference/service-dependencies.md
+++ b/website/docs/reference/service-dependencies.md
@@ -62,6 +62,7 @@ These can be deployed in any order:
 | mongodb | Databases | `./uis deploy mongodb` |
 | qdrant | Databases | `./uis deploy qdrant` |
 | elasticsearch | Databases | `./uis deploy elasticsearch` |
+| minio | Databases | `./uis deploy minio` |
 | prometheus | Observability | `./uis deploy prometheus` |
 | loki | Observability | `./uis deploy loki` |
 | tempo | Observability | `./uis deploy tempo` |

--- a/website/docs/services/databases/index.md
+++ b/website/docs/services/databases/index.md
@@ -1,7 +1,7 @@
 ---
 title: Databases
 sidebar_label: Databases
-description: PostgreSQL, MySQL, MongoDB, Redis, Elasticsearch, and Qdrant
+description: PostgreSQL, MySQL, MongoDB, Redis, Elasticsearch, Qdrant, and MinIO
 ---
 
 # Databases
@@ -18,6 +18,7 @@ UIS provides multiple database options for different data models and use cases. 
 | [MongoDB](./mongodb.md) | Document (NoSQL) | — | `./uis deploy mongodb` |
 | [Qdrant](./qdrant.md) | Vector search | — | `./uis deploy qdrant` |
 | [Elasticsearch](./elasticsearch.md) | Search & analytics | — | `./uis deploy elasticsearch` |
+| [MinIO](./minio.md) | Object storage (S3) | — | `./uis deploy minio` |
 
 ## Quick Start
 

--- a/website/docs/services/databases/minio.md
+++ b/website/docs/services/databases/minio.md
@@ -1,0 +1,199 @@
+---
+title: MinIO
+sidebar_label: MinIO
+---
+
+# MinIO
+
+S3-compatible object storage
+
+| | |
+|---|---|
+| **Category** | Databases |
+| **Deploy** | `./uis deploy minio` |
+| **Undeploy** | `./uis undeploy minio` |
+| **Depends on** | None |
+| **Required by** | None |
+| **Helm chart** | `minio/minio` (unpinned) |
+| **Default namespace** | `default` |
+
+## What It Does
+
+MinIO is a high-performance, S3-compatible object storage server. Applications talk to it with any AWS S3 SDK, so code written against MinIO in UIS runs unchanged against AWS S3 or a production MinIO cluster later. It is deployed in standalone (single-node) mode with a persistent volume.
+
+Key capabilities:
+
+- **S3 API** on port `9000` — buckets, objects, presigned URLs, multipart uploads
+- **Web console** on port `9001` — browse buckets, inspect objects, manage access keys
+- **Persistent storage** — a PVC keeps every bucket across pod restarts and re-deploys
+- **Root credentials from `urbalurba-secrets`** — nothing is hard-coded in the manifests
+- **Same SDK everywhere** — `boto3`, `@aws-sdk/client-s3`, `minio-js`, `mc` all work unchanged
+
+Typical uses: user uploads, generated image variants, exports and reports, build artifacts, database dumps.
+
+## Deploy
+
+```bash
+./uis deploy minio
+```
+
+No dependencies.
+
+Access after deploy:
+
+| What | URL |
+|------|-----|
+| Console (browser) | `http://minio.localhost` |
+| S3 API (browser / apps outside the cluster) | `http://s3.localhost` |
+| S3 API (from inside the cluster) | `http://minio.default.svc.cluster.local:9000` |
+| S3 API (from the host machine) | `./uis expose minio` → `http://localhost:39900` |
+
+Log in to the console with `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`.
+
+## Verify
+
+```bash
+# Full E2E test suite (liveness, auth, console, bucket round-trip, routing)
+./uis verify minio
+
+# Manual check
+kubectl get pods -n default -l app=minio
+
+# Health endpoint (from inside the cluster)
+kubectl run curl-test --image=curlimages/curl --rm -i --restart=Never -n default -- \
+  curl -s -o /dev/null -w "%{http_code}\n" http://minio:9000/minio/health/live
+```
+
+## Configuration
+
+MinIO configuration is in `manifests/045-minio-config.yaml`. Key settings:
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Mode | `standalone` | Single node, single drive — right shape for a dev cluster |
+| S3 API port | `9000` | Service `minio` |
+| Console port | `9001` | Service `minio-console` |
+| Data storage | `20Gi` PVC `minio-data` | Created by the playbook, not by Helm, so `undeploy` keeps the data |
+| Memory | 512Mi request / 2Gi limit | Chart default requests 16Gi and will not schedule |
+| Buckets | none pre-created | Applications create their own buckets over the S3 API |
+
+### Secrets
+
+| Variable | File | Purpose |
+|----------|------|---------|
+| `MINIO_ROOT_USER` | `.uis.secrets/secrets-config/00-common-values.env.template` | S3 access key / console login |
+| `MINIO_ROOT_PASSWORD` | `.uis.secrets/secrets-config/00-common-values.env.template` | S3 secret key / console password |
+| `MINIO_HOST`, `MINIO_PORT`, `MINIO_ENDPOINT` | same file | Cluster-internal endpoint for applications |
+
+All of them land in the `urbalurba-secrets` Secret in the `default` namespace. The setup playbook reads the root credentials from there and passes them to Helm, so no credential is ever stored in a manifest.
+
+Read them back with:
+
+```bash
+kubectl get secret urbalurba-secrets -n default -o jsonpath='{.data.MINIO_ROOT_USER}' | base64 -d
+kubectl get secret urbalurba-secrets -n default -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d
+```
+
+To change them: edit `00-common-values.env.template`, then `./uis secrets generate`, `./uis secrets apply`, and re-deploy MinIO.
+
+### Connecting an application
+
+Applications running in the cluster mount `urbalurba-secrets` and use the S3 endpoint directly:
+
+```yaml
+env:
+  - name: S3_ENDPOINT
+    valueFrom:
+      secretKeyRef: { name: urbalurba-secrets, key: MINIO_ENDPOINT }
+  - name: S3_ACCESS_KEY
+    valueFrom:
+      secretKeyRef: { name: urbalurba-secrets, key: MINIO_ROOT_USER }
+  - name: S3_SECRET_KEY
+    valueFrom:
+      secretKeyRef: { name: urbalurba-secrets, key: MINIO_ROOT_PASSWORD }
+```
+
+Two things every S3 SDK needs when pointing at MinIO:
+
+- **Path-style addressing must be enabled** (`forcePathStyle: true` / `s3ForcePathStyle`). MinIO does not do virtual-host-style bucket subdomains by default.
+- **A region must be set** even though MinIO ignores it — `us-east-1` is the usual choice.
+
+Example (Node.js, AWS SDK v3):
+
+```js
+const s3 = new S3Client({
+  endpoint: process.env.S3_ENDPOINT,          // http://minio.default.svc.cluster.local:9000
+  region: 'us-east-1',
+  forcePathStyle: true,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_KEY,
+  },
+});
+```
+
+For development from the host machine (or a devcontainer), port-forward the S3 API:
+
+```bash
+./uis expose minio           # binds localhost:39900 -> svc/minio:9000
+./uis expose minio --stop
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `manifests/045-minio-config.yaml` | Helm values (mode, storage, resources, services) |
+| `manifests/046-minio-ingressroute.yaml` | Traefik routes: `minio.*` → console, `s3.*` → S3 API |
+| `ansible/playbooks/045-setup-minio.yml` | Deployment playbook (reads credentials, waits, health-checks) |
+| `ansible/playbooks/045-remove-minio.yml` | Removal playbook (keeps data unless `--purge`) |
+| `ansible/playbooks/045-test-minio.yml` | E2E verification playbook (`./uis verify minio`) |
+
+## Undeploy
+
+```bash
+# Removes the deployment, keeps all buckets and objects on the PVC
+./uis undeploy minio
+
+# Removes everything including the PVC — all objects are gone permanently
+./uis undeploy minio --purge
+```
+
+## Troubleshooting
+
+**Pod won't start / stays Pending:**
+
+```bash
+kubectl describe pod -n default -l app=minio
+kubectl get pvc -n default -l app=minio
+```
+
+A Pending PVC usually means the cluster has no default StorageClass. The claim is named `minio-data` and lives outside the Helm release.
+
+**Deploy fails with "MINIO_ROOT_USER / MINIO_ROOT_PASSWORD not found":**
+
+The secret has not been applied to the cluster yet:
+
+```bash
+./uis secrets generate
+./uis secrets apply
+./uis deploy minio
+```
+
+**S3 requests return 403 SignatureDoesNotMatch:**
+
+The access key / secret key pair does not match what MinIO was started with. This happens after rotating secrets without re-deploying. Fix with `./uis secrets apply` followed by `./uis undeploy minio` and `./uis deploy minio` (data on the PVC is preserved).
+
+**Bucket exists but the app gets 404 on the bucket URL:**
+
+Path-style addressing is not enabled in the SDK — see [Connecting an application](#connecting-an-application).
+
+**Console loads but shows a blank page on an external domain:**
+
+The console is served from the route root. Use a dedicated subdomain (`minio.<domain>`), not a path prefix.
+
+## Learn More
+
+- [Official MinIO documentation](https://min.io/docs/minio/kubernetes/upstream/)
+- [MinIO Helm chart](https://github.com/minio/minio/tree/master/helm/minio)
+- [MinIO client (`mc`) reference](https://min.io/docs/minio/linux/reference/minio-mc.html)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -140,6 +140,7 @@ const sidebars: SidebarsConfig = {
             'services/databases/qdrant',
             'services/databases/redis',
             'services/databases/elasticsearch',
+            'services/databases/minio',
           ],
         },
         {

--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -148,6 +148,27 @@
 ,
   {
     "@type": "SoftwareApplication",
+    "id": "minio",
+    "name": "MinIO",
+    "description": "S3-compatible object storage",
+    "category": "DATABASES",
+    "tags": ["object-storage", "s3", "buckets", "files", "images", "blob-storage"],
+    "abstract": "S3-compatible object storage for files, images, and backups",
+    "logo": "minio-logo.svg",
+    "website": "https://min.io"
+    ,"summary": "MinIO is a high-performance, S3-compatible object storage server. Applications talk to it with any AWS S3 SDK, so code written against MinIO in UIS runs unchanged against AWS S3, Azure Blob (via S3 gateway), or a production MinIO cluster. Deployed in standalone mode with a persistent volume, an S3 API on port 9000, and a web console on port 9001."
+    ,"docs": "/docs/services/databases/minio"
+    ,"playbook": "045-setup-minio.yml"
+    ,"priority": 34
+    ,"checkCommand": "kubectl get pods -n default -l app=minio --no-headers 2>/dev/null | grep -q Running"
+    ,"removePlaybook": "045-remove-minio.yml"
+    ,"helmChart": "minio/minio"
+    ,"namespace": "default"
+    ,"exposePort": 39900
+  }
+,
+  {
+    "@type": "SoftwareApplication",
     "id": "mongodb",
     "name": "MongoDB",
     "description": "Document-oriented NoSQL database",

--- a/website/static/img/LOGO-SOURCES.md
+++ b/website/static/img/LOGO-SOURCES.md
@@ -27,7 +27,7 @@ Service logos sourced from official project websites and icon repositories. SVG 
 - **CNCF Artwork**: prometheus, argocd, otel-collector
 - **Simple Icons**: grafana, postgresql, mysql, mongodb, redis, rabbitmq, elasticsearch, nginx, spark, jupyterhub, cloudflare, tailscale, traefik, ollama
 - **Official GitHub**: authentik, litellm, qdrant, loki (PNG), openwebui (PNG), pgadmin (PNG), unity-catalog (PNG)
-- **Created (Heroicons style)**: gravitee, redisinsight, tempo, tika
+- **Created (Heroicons style)**: gravitee, redisinsight, tempo, tika, minio
 
 ### Core Infrastructure
 | Logo ID | Service | Source | License |
@@ -42,6 +42,7 @@ Service logos sourced from official project websites and icon repositories. SVG 
 | `mysql-logo` | MySQL | [mysql.com](https://www.mysql.com/) | Oracle |
 | `mongodb-logo` | MongoDB | [mongodb.com](https://www.mongodb.com/) | MongoDB |
 | `qdrant-logo` | Qdrant | [qdrant.tech](https://qdrant.tech/) | Apache 2.0 |
+| `minio-logo` | MinIO | Created (Heroicons style, MinIO red #C72E29) | Heroicons MIT |
 
 ### Message Queues & Caching
 | Logo ID | Service | Source | License |

--- a/website/static/img/services/minio-logo.svg
+++ b/website/static/img/services/minio-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#C72E29" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 6.5c0-1.38 4.03-2.5 9-2.5s9 1.12 9 2.5-4.03 2.5-9 2.5-9-1.12-9-2.5z"/>
+  <path d="M3 6.5v11c0 1.38 4.03 2.5 9 2.5s9-1.12 9-2.5v-11"/>
+  <path d="M3 12c0 1.38 4.03 2.5 9 2.5s9-1.12 9-2.5"/>
+</svg>


### PR DESCRIPTION
S3-compatible object storage, added via the documented process in `website/docs/contributors/guides/adding-a-service.md` (all 11 steps).

Requested for the **urbalurba-platform image pipeline**, which needs somewhere to write company logo variants. Self-hosted keeps it consistent with cost-leadership, and S3 compatibility keeps the exit open to R2/S3 later.

### Added
- `service-minio.sh` — databases category, priority 34
- `045-setup-minio.yml` / `045-remove-minio.yml` / `045-test-minio.yml`
- `manifests/045-minio-config.yaml` (Helm values) + `046-minio-ingressroute.yaml`
- registered in `expose.sh`, `uis-cli.sh`, `integration-testing.sh`, `enabled-services.conf`, helm repo installers, secrets templates, sidebars, website service data
- generated docs page + logo

### 🐛 Data-loss bug found and fixed during testing
A **chart-owned PVC is deleted by `helm uninstall`**, so `undeploy` destroyed the data. The playbook now owns the PVC (mirroring the Qdrant pattern); only `--purge` removes it. Verified by writing an object → undeploy → redeploy → reading it back.

Also: the chart's default `console/console123` admin is **disabled** (`users: []`); credentials come from `urbalurba-secrets`.

### Tested against the running test cluster
| | |
|---|---|
| `uis deploy minio` | ok=19, failed=0 |
| `uis verify minio` | 5/5 |
| `uis test-all --only minio` | **3/3** (deploy, verify, undeploy) |
| persistence | object survived undeploy → redeploy |
| purge | leaves nothing behind |
| from host | `s3.localhost` health **200**, console **200**, unsigned S3 **403** |
| website build | clean |

### Decisions worth a look
- **Category `DATABASES`, not `STORAGE`** — `STORAGE` (000-009) is doc-only, has no `services/storage/` dir, and the docs generator skips it.
- **Port 39900** for the S3 API — the natural `39000` is taken by Authentik. Console is ingress-only.
- **Hostnames** `minio.*` (console) and `s3.*` (API) — `s3.*` is a fairly generic HostRegexp.
- Chart `minio/minio` unpinned, per repo convention.

### Known gap (repo-wide)
`00-common-values.env.template` is user-owned and not auto-synced, so **existing installs must add the `MINIO_*` lines themselves** — the playbook fails with an explicit message if they're absent. Tracked in `INVESTIGATE-secrets-template-defaults-clarity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNFJDhFJ7j34bJQDHrNAia