### PR TITLE
Rescue uncommitted investigations and the production docs section

### DIFF
--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-cli-stack-profiles.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-cli-stack-profiles.md
@@ -1,0 +1,880 @@
+# Investigate: a stack installs the same way on a laptop and a server
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Give UIS a way to express *how much* of a stack to install and *how
+big* to size it, so one stack definition serves both a developer's Rancher
+Desktop and a production cluster. Today `uis stack install observability`
+installs five components at fixed sizes regardless of the machine — and the one
+flag intended to slim it down cannot work.
+
+**Related**: [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md)
+— answers its **Q3** (what Grafana should require) and **Q4** (retention and
+sizing, whose premise it also corrects). Its **Q2** (opt-in vs default) is
+*not* answered here: Part 7 Q5 shows the RAM figure that decision rests on is
+not yet established.
+
+**Finding IDs**: findings here are prefixed `CLI-`; the companion document uses
+`OBS-`. Both documents number findings from 1, so an unprefixed "F3" is
+ambiguous — always use the prefix.
+
+**Depends on**: `PLAN-cli-stack-002-profiles` cannot be implemented before the
+parent's `PLAN-system-observability-001-log-collection`, which creates the Alloy
+service the profiles reference. See CLI-F9.
+
+**Created**: 2026-08-05 — findings traced against `main` @ `ca59e7c`
+
+---
+
+## Background
+
+UIS has two deployment situations that pull in opposite directions:
+
+| | Developer | Production |
+|---|---|---|
+| Platform | Rancher Desktop (Lima VM) | k3s / AKS on real hardware |
+| RAM available | often 8–12 GB total | tens of GB |
+| What they need | all signals, almost no history | full retention, alerting, tracing |
+
+The observability stack is where this bites hardest — it is the largest stack
+UIS ships (5 components, 40 GiB of claims) — but the gap is in the **stack
+mechanism**, not in observability. Any future stack will hit it.
+
+This investigation is scoped to the CLI surface. The Alloy migration and the
+telemetry gaps live in the parent investigation.
+
+---
+
+## Part 1: Findings (traced from source, with file:line)
+
+### CLI-F1 — `--skip-optional` already exists, and it cannot succeed (severity: high, bug)
+
+The mechanism is half-built. `uis stack install <stack> [--skip-optional]` is
+implemented, and the stack schema in `stacks.sh` already carries an
+`optional_services` field:
+
+```
+observability|…|services=prometheus,tempo,loki,otel-collector,grafana|optional=otel-collector|…
+```
+
+But two files disagree about whether `otel-collector` is optional:
+
+| File | Declares |
+|---|---|
+| `provision-host/uis/lib/stacks.sh` | `optional_services = "otel-collector"` |
+| `provision-host/uis/services/observability/service-grafana.sh` | `SCRIPT_REQUIRES="prometheus loki tempo otel-collector"` |
+
+And dependencies are enforced by hard failure, not by auto-install:
+
+```bash
+# provision-host/uis/lib/service-deployment.sh:292
+check_dependencies() {
+    for dep in $requires; do
+        if ! check_service_deployed "$dep"; then
+            die_dependency "Required service '$dep' is not deployed"
+        fi
+```
+
+So the execution path is:
+
+```
+uis stack install observability --skip-optional
+  → uis-cli.sh:823   skips otel-collector
+  → deploys prometheus, tempo, loki          ✅
+  → deploy_single_service grafana            (grafana is last in the stack order)
+  → service-deployment.sh:120 check_dependencies "prometheus loki tempo otel-collector"
+  → otel-collector not deployed
+  → die_dependency                           ❌ stack install fails
+```
+
+**The only existing mechanism for a smaller install is broken by a
+contradiction in the service metadata.** The same applies to a bare
+`uis deploy grafana`, which demands all four services today.
+
+*Repro (not yet run against a cluster — traced from source; worth confirming
+before implementing):*
+
+```bash
+uis stack install observability --skip-optional
+# expected: fails at grafana with "Required service 'otel-collector' is not deployed"
+```
+
+### CLI-F2 — Grafana's dependency declaration is the real blocker (severity: high)
+
+`SCRIPT_REQUIRES="prometheus loki tempo otel-collector"` makes every slim
+scenario impossible, not just `--skip-optional`. A metrics-only install —
+the single most useful configuration for a developer laptop — cannot be
+expressed at all while Grafana hard-requires a log store and a trace store it
+does not need in order to run.
+
+This is the parent investigation's Q3. It is not a design question; it is a bug
+with a small diff.
+
+### CLI-F3 — Sizing is fixed, and unrelated to retention (severity: medium)
+
+The parent investigation's Q4 states the PVCs have "no documented retention
+policy". **That is not correct** — retention is configured in all three stores:
+
+| Component | Retention | PVC | Assessment |
+|---|---|---:|---|
+| prometheus-server | `retention: 15d` | 8Gi | the only sensible ratio |
+| alertmanager | — | 2Gi | silences/state; ~100Mi would do |
+| tempo | `retention: 24h` | 10Gi | oversized for the window |
+| loki | `retention_period: 24h` + compactor `retention_enabled: true` | 10Gi | oversized for the window |
+| grafana | — | 10Gi | SQLite + dashboards, typically < 100Mi |
+| | | **40Gi** | matches the measured figure |
+
+The actual defect is different: **PVC sizes were chosen independently of the
+retention windows.** 24 hours of logs or traces from a small cluster is tens to
+low hundreds of MB, against 10Gi claims.
+
+And the real risk neither document has flagged: **all retention is time-based;
+there is no size cap anywhere.**
+
+```bash
+grep -riE 'retentionSize|retention_size' manifests/03*.yaml   # → no matches
+```
+
+Time-based retention does not protect a disk. If scrape volume grows,
+Prometheus fills 8Gi long before 15d elapses, and a full TSDB is an ugly
+failure mode. `server.retentionSize` set just below the claim is the missing
+backstop.
+
+### CLI-F4 — Three of five components declare no resources at all (severity: medium)
+
+```bash
+grep -c 'resources:' manifests/031-tempo-config.yaml \
+                     manifests/032-loki-config.yaml \
+                     manifests/034-grafana-config.yaml
+# → 0, 0, 0
+```
+
+Prometheus and the OTel Collector set requests/limits; Loki, Tempo and Grafana
+do not, so they run on chart defaults. **A sizing feature cannot be built on
+top of this** — there is nothing to scale. Declaring resources is a
+prerequisite, not a nice-to-have.
+
+Credit where due: the Loki values are otherwise well-tuned —
+`deploymentMode: SingleBinary` with `chunksCache` and `resultsCache` explicitly
+disabled, which avoids that chart's multi-GB memcached default.
+
+### CLI-F5 — Two Grafana values files; one is dead
+
+`ansible/playbooks/034-setup-grafana.yml:16` uses
+`manifests/034-grafana-config.yaml` (10Gi). `manifests/030-grafana-config.yaml`
+(5Gi) is referenced by nothing but its own header comments. It should be
+deleted before someone tunes the wrong file.
+
+### CLI-F6 — Components enabled by default that a small install does not need
+
+| Component | Where | Note |
+|---|---|---|
+| `pushgateway` | `030-prometheus-config.yaml:78` `enabled: true` | nothing pushes to it; it occupies a scrape target |
+| `gateway` | not set in `032-loki-config.yaml` | chart default enables it — an nginx proxy unnecessary for in-cluster SingleBinary access |
+| `lokiCanary` | not set in `032-loki-config.yaml` | chart default enables it; continuously writes synthetic logs |
+
+The canary is worth calling out: it is part of why the parent investigation
+found Loki containing only test data. A small profile should disable all three.
+
+### CLI-F7 — The platform layer exists, and is the wrong place to put sizing
+
+UIS already models *where* a cluster runs: `uis platform list` / `uis platform
+use`, backed by `platforms/rancher-desktop` and `platforms/azure-aks`
+(`provision-host/uis/lib/platform-switching.sh`).
+
+It is tempting to hang install size off platform — "rancher-desktop means
+small". That hard-codes the wrong relationship. See Part 2.
+
+### CLI-F8 — The tests cannot detect any of this (severity: high)
+
+This is why the gap went unnoticed. `u10-verify-observability-tasks.yml` runs 15
+checks, and **every one of them is either "is the API up" or "can I read back
+data I just wrote"**:
+
+| Steps | What they do |
+|---|---|
+| VERIFY 1–4, 11–13 | health / API availability / datasource presence |
+| VERIFY 5–7 | push a trace to the collector → wait → query Tempo for *that trace* |
+| VERIFY 8–10 | push a log to the collector → wait → query Loki for *that log* |
+
+Not one check asks whether telemetry from a **real workload** arrives. The log
+test pushes over OTLP directly, so it passes with **no log-shipping agent
+installed at all** — which is exactly the parent's OBS-F2. The suite is
+structurally incapable of catching the failure it exists to prevent.
+
+Worse, it never runs. `u10-verify-observability-tasks.yml` has **no caller** —
+independently found in
+[INVESTIGATE-system-verification-playbooks-usage](./INVESTIGATE-system-verification-playbooks-usage.md)
+("no active caller found"). For contrast, `u02-verify-postgres.yml` *is* wired
+in, from `650-setup-backstage.yml`, so the pattern works; this file is
+specifically orphaned.
+
+There is also no hook to wire it to. Service metadata has `SCRIPT_PLAYBOOK`,
+`SCRIPT_REMOVE_PLAYBOOK` and `SCRIPT_CHECK_COMMAND`, but **no `SCRIPT_TEST`**:
+
+```bash
+grep -rhoE '^SCRIPT_[A-Z_]+=' provision-host/uis/services/ | sort -u   # no SCRIPT_TEST
+```
+
+That absence is why `NNN-test-<service>.yml` files and `u10-*` float unattached.
+
+One consequence for the work proposed here: **VERIFY 13 hard-asserts that
+Grafana has both a `tempo` and a `loki` datasource.** The Grafana dependency fix
+(CLI-F2) will break that assertion. The test currently encodes the bug.
+
+### CLI-F9 — The profiles reference a service that does not exist yet (severity: high)
+
+```bash
+ls provision-host/uis/services/*/service-alloy.sh   # → no such file
+```
+
+Every profile in Part 3 lists `alloy`, but **Alloy is not a UIS service**. It is
+created by the parent's `PLAN-system-observability-001-log-collection`.
+
+`PLAN-cli-stack-002-profiles` is therefore **not startable on its own** — anyone
+picking it up first is blocked immediately. Either sequence the parent's PLAN-001
+ahead of it, or have the profiles name `otel-collector` until Alloy lands and
+switch afterwards. This is a hard cross-investigation dependency, not a
+preference.
+
+### CLI-F10 — A PersistentVolumeClaim cannot be shrunk (severity: high)
+
+Kubernetes supports volume **expansion** only. There is no in-place shrink.
+
+Consequently `--size small` applies cleanly to a **fresh** install and **cannot
+be applied to the existing 40 GiB deployment**. Moving an existing install to a
+smaller size means deleting and recreating the PVCs, which destroys the
+historical metrics, logs and traces they hold.
+
+This is the gap most likely to cause damage in practice, because the natural
+reading of "add a `--size` flag" is that it can be applied to what you already
+have. It cannot. Any sizing work must therefore state:
+
+- which sizes are **install-time only** versus safely changeable later
+- that going *up* a size is possible (expansion) while going *down* is not
+- what the documented procedure is for deliberately resizing down, including the
+  data loss it entails
+
+Growing is not automatic either: it requires the StorageClass to have
+`allowVolumeExpansion: true`, which should be verified on both Rancher Desktop's
+`local-path` and whatever production uses before promising it.
+
+### CLI-F11 — Production is not an install; it is a migration (severity: high)
+
+Everything in Part 3 is written as `stack install` — a fresh cluster choosing a
+profile and a size. **The production case is not that.** The parent
+investigation's appendix records `asgard` as already running 13 UIS services
+*including the full observability stack*, with Prometheus scraping 18 targets.
+
+So the production command is not:
+
+```bash
+uis stack install observability --profile full --size medium   # asgard already has this stack
+```
+
+There is no defined answer today for what that does to a cluster where the stack
+exists — re-run the Helm upgrades, fail, refuse, or partially apply. That
+undefined behaviour is the gap, and production is the only place it occurs.
+
+What the migration path can and cannot do follows from CLI-F10:
+
+| Move on an existing install | Possible? | How |
+|---|---|---|
+| `small` → `medium` → `large` | yes | volume expansion, if `allowVolumeExpansion: true` |
+| profile widened (`metrics` → `full`) | yes | additive; deploy the new components |
+| profile narrowed (`full` → `metrics`) | yes, destructive | removing a component destroys its store |
+| any size **downward** | **no** | delete + recreate PVCs; retained data is lost |
+
+The good news for production specifically: **the direction production wants is
+the allowed one.** asgard growing from today's fixed sizes up to a defined
+`medium` is expansion, which is safe. Only shrinking is a one-way door.
+
+Any sizing work must therefore ship an explicit answer for existing installs, not
+only for clean clusters — most likely "growing is safe and supported; shrinking
+requires deliberate recreation and accepts data loss", with the CLI refusing a
+downward `--size` unless confirmed.
+
+### CLI-F12 — The Grafana playbook enforces the dependency a second time (severity: high)
+
+CLI-F2 identified `SCRIPT_REQUIRES` as "the real blocker" and called the fix a
+small diff. **Tracing `034-setup-grafana.yml` shows that is only half of it.**
+Reducing `SCRIPT_REQUIRES` on its own changes nothing observable: the deploy stops
+failing at `check_dependencies` and starts failing at playbook task 20 instead,
+with a worse message.
+
+Task 20 (`FAIL deployment if core tests did not pass`) aborts the play unless the
+Loki datasource, the Tempo datasource, an OTLP log round-trip *and* an OTLP trace
+round-trip all succeed. Three things follow:
+
+1. **`otel-collector` is a hidden dependency** beyond the four declared ones —
+   tasks 14, 17, 24 and 25 push through
+   `otel-collector-opentelemetry-collector`, which no metadata mentions.
+2. **Datasource proxy IDs are positional** — every check uses
+   `/api/datasources/proxy/1|2|3/…`, assuming Prometheus=1, Loki=2, Tempo=3. Under
+   conditional datasources those positions shift, so a metrics-only install would
+   proxy the *wrong datasource* rather than error. The repo has zero UID-based
+   proxy calls today (`grep -c 'proxy/uid'` → 0). This is the one change here that
+   fails silently instead of loudly.
+3. **The shipped dashboards assume all three signals** —
+   `035-grafana-test-dashboards.yaml` references the `loki` and `tempo`
+   datasource UIDs twice each, `036-grafana-sovdev-metrics.yaml` references `loki`
+   four times, and task 23 blocks until ≥4 dashboard ConfigMaps exist.
+
+**Additionally, the Loki datasource URL collides with CLI-F6.** It points at
+`loki-gateway.monitoring.svc.cluster.local:80`, while CLI-F6 recommends disabling
+Loki's chart-default `gateway` in the small profile. Doing both breaks the
+datasource; the URL must move to the Loki service directly when that lands.
+
+This does not change the conclusion that the Grafana fix should be done first —
+it is still the smallest *unblocking* change and still independently valuable. It
+changes the size estimate: five files, not one line. See
+[PLAN-service-grafana-optional-datasources](./PLAN-service-grafana-optional-datasources.md).
+
+---
+
+## Part 2: Platform, profile and size are three different things
+
+The framing "we have two deploy situations" suggests one axis. There are three,
+and collapsing them is the trap:
+
+| Axis | Question it answers | Modelled today? |
+|---|---|---|
+| **Platform** | *Where* does the cluster run? | ✅ `uis platform use` |
+| **Profile** | *Which* components get installed? | ❌ only a binary `--skip-optional` |
+| **Size** | *How big* are they sized? | ❌ hardcoded in manifests |
+
+Profile and size do not follow from platform:
+
+- a **small production** k3s on a cheap VPS wants the lean install
+- a **32 GB developer workstation** may want the full stack, traces included,
+  precisely in order to develop against it
+
+The evidence in this repo shows both ends: the parent investigation's findings
+come from production k3s `asgard` with room to spare, while a Rancher Desktop VM
+is commonly 8–12 GB.
+
+The **storage** figure is solid and sufficient to make the case on its own: 40
+GiB of claims (CLI-F3, summed from the manifests) against a laptop is
+substantial regardless of RAM. The frequently-quoted "~4 GB RAM" is *not* used as
+evidence here — see Part 7 Q5 for why it is not yet established.
+
+**Size follows from the machine, not from dev-vs-prod.** So: add profile and
+size as their own axes, and let the active platform supply *defaults* for them.
+
+---
+
+## Part 3: Proposed command surface
+
+```bash
+# which components
+uis stack install observability --profile metrics    # prometheus + alloy + grafana
+uis stack install observability --profile logs       # + loki
+uis stack install observability --profile full       # + tempo
+
+# how big — orthogonal
+uis stack install observability --profile logs --size small
+```
+
+### Defaults — and the two cases they get wrong
+
+The obvious rule is "`rancher-desktop` → `metrics`/`small`, everything else →
+`full`/`medium`". **The `metrics` half of that is wrong**, for the reason below;
+the recommended rule is `rancher-desktop` → **`full`/`small`**.
+
+#### Why the developer default must be `full`, not `metrics`
+
+"The developer" is two different people who want opposite things:
+
+| | What they want | Observability is… |
+|---|---|---|
+| **A.** Building an app *against* the platform | Postgres, Redis, the cluster up | overhead — every GB matters |
+| **B.** Instrumenting an app's telemetry | to see their traces and logs actually arrive | the entire point |
+
+A `metrics` default serves A and **silently breaks B**. B is not hypothetical: it
+is the parent investigation's PLAN-005, whose acceptance criterion is *"a
+scaffolded app emits a trace locally and in production with no code change."* A
+metrics-only local default means that trace goes nowhere — which is precisely the
+failure in the parent's OBS-F3, where an application team defaulted to Grafana
+Cloud because no local path was documented, while a self-hosted stack was running
+the whole time.
+
+The two-axis design in Part 2 handles this without contradiction, which is
+evidence the split is the right one. A developer wants *all signals* with *almost
+no history*:
+
+```bash
+uis stack install observability --profile full --size small
+```
+
+Profile = which signals. Size = how much history. That combination is coherent,
+not a compromise.
+
+Judge the default by which error is worse:
+
+| Default | If the guess is wrong | Cost |
+|---|---|---|
+| `full` | dev only needed the cluster running | ~500 MB wasted; `--profile metrics` fixes it in one flag |
+| `metrics` | dev is instrumenting an app | traces vanish with no error; they debug the wrong thing or conclude UIS cannot do it |
+
+The second is far worse, and it is the one that loses users to a cloud APM
+vendor. `metrics` remains available for person A and for genuinely small nodes.
+
+#### How defaults are keyed
+
+Two honest options:
+
+1. **Platform-keyed defaults, with the limitation documented.** Simple and right
+   most of the time; wrong for a small production cluster, where the operator
+   must pass `--size small` explicitly. Note this is the exact case Part 2 gives
+   as the reason *not* to bind size to platform — keying defaults off platform is
+   a documented approximation, not a claim the axes collapse. Recommended as a
+   starting point, because it is predictable and never silently *shrinks* a
+   production install.
+2. **Capacity-keyed defaults.** Read allocatable memory from the target nodes and
+   pick a size from thresholds. Correct for the VPS case, but the default becomes
+   a function of cluster state — the same command produces different installs on
+   different days, which is harder to reason about and to support.
+
+The failure modes are asymmetric, which decides it: option 1 errs toward
+installing *more* than a small production cluster wants (visible, fixable with a
+flag), while a mis-sized capacity heuristic could quietly under-provision
+production monitoring. **Recommend option 1, and print the resolved
+profile/size before installing** so the choice is never invisible.
+
+Whichever is chosen, the defaults must be documented as machine-shaped, not
+environment-shaped — see Part 7 Q4.
+
+### Schema change
+
+Add a `profiles` field to `_STACK_DATA` in `stacks.sh`:
+
+```
+profiles = metrics:prometheus,alloy,grafana;logs:prometheus,alloy,loki,grafana;full:prometheus,alloy,loki,tempo,grafana
+```
+
+This is **additive, not a replacement.** An earlier draft proposed superseding
+`optional_services` outright; that breaks the other stacks. `analytics` declares
+`unity-catalog` as optional today and `--skip-optional` works there, but profiles
+are defined here only for `observability` — so "resolve `--skip-optional` to the
+next profile down" is undefined for every stack that has no profiles.
+
+The rule instead:
+
+- a stack **may** declare `profiles`; if it does not, nothing changes for it
+- `optional_services` and `--skip-optional` keep working exactly as today
+- `--profile` and `--skip-optional` are **mutually exclusive**; passing both is
+  an error rather than a silently-resolved precedence
+- only once a stack declares profiles is `--skip-optional` deprecated *for that
+  stack*
+
+This keeps `analytics` and `ai-local` untouched by this work.
+
+Note that with Alloy replacing the OTel Collector (parent investigation,
+PLAN-001), the `optional_services` contradiction in CLI-F1 disappears on its own —
+the disputed component ceases to exist. Fixing CLI-F2 is still required.
+
+### Where size lives
+
+Helm values overlays, applied after the base values:
+
+```
+helm upgrade --install prometheus … -f 030-prometheus-config.yaml \
+                                    -f 030-prometheus-config.small.yaml
+```
+
+Each size sets the **triple** `{PVC, retention window, retentionSize cap}`
+together. Setting one without the others is exactly what produced the
+24h-retention-on-a-10Gi-claim mismatch in CLI-F3.
+
+Indicative targets — today's fixed 40Gi is roughly `medium`-shaped in storage but
+`small`-shaped in retention, which is the CLI-F3 mismatch in one line:
+
+| Claim | Now | `small` | `medium` | `large` |
+|---|---:|---:|---:|---:|
+| prometheus | 8Gi | 4Gi | 20Gi | 60Gi |
+| alertmanager | 2Gi | 1Gi | 1Gi | 2Gi |
+| loki | 10Gi | 2Gi | 20Gi | 60Gi |
+| tempo | 10Gi | 2Gi | 10Gi | 30Gi |
+| grafana | 10Gi | 1Gi | 2Gi | 5Gi |
+| **total** | **40Gi** | **~10Gi** | **~53Gi** | **~157Gi** |
+
+| Retention | `small` | `medium` | `large` |
+|---|---|---|---|
+| metrics | 7d + `retentionSize: 3GB` | **30d** + `retentionSize: 16GB` | **90d** + `retentionSize: 50GB` |
+| logs | 24h | **7d** | **30d** |
+| traces | 24h | **3d** | **7d** |
+
+**`medium` and `large` are not a scaled-up `small`; the retention windows differ
+in kind.** 24 hours of logs is adequate for a laptop, where you are looking at
+what you just did. It is not adequate for production, where you frequently learn
+about a problem days after it started — a 24h window means the evidence is
+already gone when the investigation begins. That is why `medium` moves logs to 7d
+and traces to 3d rather than simply widening the claims.
+
+Two constraints on these numbers:
+
+- They are **indicative and unmeasured.** Ingest volume per GB is workload-shaped;
+  `PLAN-cli-stack-003-sizing` should measure a real day of asgard ingest before
+  fixing them. The relationship between the rows (`{PVC, retention window,
+  retentionSize cap}` set together) is the part that matters and is not
+  negotiable.
+- **Undershooting is recoverable; overshooting is not** — see CLI-F10. Going up a
+  size is volume expansion; going down requires recreating the PVC and losing its
+  data. So when uncertain between two sizes for production, pick the smaller one
+  and grow into the larger.
+
+There is prior art worth copying rather than inventing: Grafana's own
+`k8s-monitoring` chart ships **small / medium / large / xlarge** presets.
+
+---
+
+## Part 4: Test strategy
+
+Every change below alters what gets installed. Without tests that can tell the
+difference, "the stack still deploys" will again be mistaken for "the stack
+still works" (CLI-F8).
+
+### The rule: a test must observe a signal no test wrote
+
+The existing suite pushes synthetic telemetry and reads it back. That proves the
+*store* works and says nothing about the *pipeline*. Every new test here asserts
+on data produced by a workload that is not part of the test harness.
+
+### T1 — Unattended log arrival (proves OBS-F2 is closed)
+
+Deploy a workload that only writes to stdout — `whoami` already exists for this
+(`025-setup-whoami-testpod.yml`) — then query Loki for logs carrying **that
+pod's** labels, pushing nothing.
+
+Anti-cheat assertion, straight from the parent investigation's repro:
+
+```bash
+curl -s "$LOKI/loki/api/v1/label/job/values"
+# FAIL if the only value is the validation job — that is today's broken state
+```
+
+### T2 — Alerts exist, and actually fire (proves OBS-F1 is closed)
+
+Static check is necessary but weak:
+
+```bash
+curl -s "$PROM/api/v1/rules" | jq '.data.groups | length'   # FAIL if 0
+```
+
+The real test is dynamic: scale a deployment to zero, then assert an alert
+reaches `firing` within the rule's window. "Monitoring installed" and "monitored"
+differ exactly here.
+
+### T3 — Profile matrix (guards the Grafana dependency fix)
+
+For each profile, assert the component set is *exactly* what the profile
+declares — no more, no less — and that Grafana is healthy with datasources
+matching the profile:
+
+| Profile | Must exist | Must NOT exist | Grafana datasources |
+|---|---|---|---|
+| `metrics` | prometheus, alloy, grafana | loki, tempo | prometheus only |
+| `logs` | + loki | tempo | + loki |
+| `full` | + tempo | — | + tempo |
+
+The "must NOT exist" column is the important half — it is what catches a profile
+silently installing more than it claims. **VERIFY 13 must become profile-aware
+as part of this**, or it fails the moment the dependency fix lands.
+
+### T4 — Sizing assertions (guards `--size`)
+
+Cheap, static, and catches drift:
+
+- sum of PVC capacity in the namespace ≤ the profile's documented budget
+- every component declares both requests and limits (fails today — CLI-F4)
+- Prometheus `retentionSize` is set and is below its claim (fails today — CLI-F3)
+
+### T5 — Alloy equivalence (run during the collector swap)
+
+Before/after comparison rather than a fixed expectation: capture the scrape
+target list and a successful trace ingestion with the OTel Collector, then assert
+both still hold with Alloy. Proves the swap is non-regressive rather than merely
+green.
+
+### When these run
+
+**During each change** — every plan below ships with a test that **fails before
+the change and passes after**. The expected-fail is stated in the plan, so a test
+that passes beforehand is treated as a broken test, not as good news.
+
+**After** — the suite runs per profile, so the matrix in T3 is exercised on every
+profile rather than only the one a developer happened to install.
+
+### Where each test can actually run
+
+The tests are not uniform in cost or safety, and treating them as one suite would
+put a destructive check into a routine command:
+
+| Test | Cost | Safe on a live cluster? | Where |
+|---|---|---|---|
+| T3 profile matrix | seconds | yes — read-only | every `stack test` run |
+| T4 sizing assertions | seconds | yes — read-only | every `stack test` run |
+| T1 log arrival | ~1 min (ingest lag) | yes — deploys one pod | every `stack test` run |
+| T5 Alloy equivalence | minutes | yes | during the collector swap only |
+| **T2 alerts fire** | minutes | **no — scales a workload to zero** | throwaway/dev cluster, or explicit opt-in flag |
+
+T2 is the only genuinely disruptive one. It must not run by default against a
+production cluster; gate it behind something like `uis stack test observability
+--include-disruptive`, and use a workload deployed by the test itself as the
+scale-to-zero target rather than a real service.
+
+Note also that T1 depends on log ingest latency, and T5 on Tempo's block flush —
+the same class of timing that makes today's Grafana E2E flaky (OBS-F6). Both must
+poll to a deadline rather than sleep-and-hope, or they will teach the same lesson
+that produced CLI-F8.
+
+### Where they live — and the hook that is missing
+
+This intersects
+[INVESTIGATE-system-verification-playbooks-usage](./INVESTIGATE-system-verification-playbooks-usage.md),
+whose Q5 asks whether verification belongs in setup playbooks, dedicated test
+playbooks, or reusable utility includes. This investigation's answer, for
+stack-level tests:
+
+1. Keep reusable task includes in `utility/` (the `u10-*` shape) — but **wire
+   them in**, which is the fix for CLI-F8.
+2. Add a **`SCRIPT_TEST`** field to service metadata, alongside the existing
+   `SCRIPT_PLAYBOOK` / `SCRIPT_REMOVE_PLAYBOOK`. Its absence is the structural
+   reason test playbooks float unattached.
+3. Add `uis stack test <stack> [--profile <p>]` so the matrix is runnable as one
+   command rather than by hand.
+
+Point 2 is small and independently useful: it gives every existing
+`NNN-test-<service>.yml` a defined place to be called from.
+
+---
+
+## Part 5: Proposed plans (ordered)
+
+```
+PLAN-cli-stack-001-test-harness.md             ← test hook + `uis stack test`; nothing below is verifiable without it
+PLAN-service-grafana-optional-datasources.md   ← standalone bug fix, unblocks every profile
+PLAN-cli-stack-002-profiles.md                 ← the --profile axis + schema
+PLAN-cli-stack-003-sizing.md                   ← the --size axis + values overlays
+PLAN-cli-stack-004-platform-defaults.md        ← defaults from the active platform
+```
+
+T1 (log arrival) and T2 (alerts fire) are **not** listed here — they belong with
+the parent investigation's `PLAN-system-observability-001-log-collection` and
+`-002-alert-baseline`, because a test asserting logs arrive can only pass once
+something ships logs. The harness below provides the mechanism they plug into.
+
+### PLAN-cli-stack-001-test-harness (do first)
+
+Add the `SCRIPT_TEST` metadata field, wire the orphaned
+`u10-verify-observability-tasks.yml` to an actual caller, and add
+`uis stack test <stack>`. Split the existing 15 checks into *component* checks
+(keep) and mark the push-and-read-back pairs as what they are, so nobody mistakes
+them for pipeline coverage again.
+
+Also fix the flaky Grafana E2E race (OBS-F6) while in here: it retries 3 times
+against Tempo's block flush and aborts the play on a healthy stack. A test that
+fails on timing teaches people to ignore failures, which is how CLI-F8 survived.
+
+*Acceptance:* `uis stack test observability` runs the verification suite and
+reports per-check results. **Expected-fail before:** the suite is unreachable by
+any command today.
+
+### PLAN-service-grafana-optional-datasources (do next — biggest unblock)
+
+**Drafted:** [PLAN-service-grafana-optional-datasources](./PLAN-service-grafana-optional-datasources.md)
+
+Reduce `SCRIPT_REQUIRES` to `"prometheus"`, provision the Loki and Tempo
+datasources conditionally on whether those services are deployed, **and remove the
+second enforcement of the same dependency inside `034-setup-grafana.yml`** —
+which is five files, not the one-line diff CLI-F2 implied. See CLI-F12.
+
+Independently valuable: it fixes today's broken `--skip-optional` (CLI-F1) and makes
+`uis deploy grafana` usable on its own, whether or not the rest of this
+investigation proceeds.
+
+*Acceptance:* `uis deploy prometheus && uis deploy grafana` succeeds on a clean
+cluster, and Grafana starts with a working Prometheus datasource and no
+dangling Loki/Tempo datasources.
+
+### PLAN-cli-stack-002-profiles
+
+**Blocked by** the parent's `PLAN-system-observability-001-log-collection` —
+the profiles name `alloy`, which is not a UIS service yet (CLI-F9). Either
+sequence that plan first, or ship the profiles naming `otel-collector` and swap
+the name when Alloy lands.
+
+Add the `profiles` field to the stack schema and `--profile` to `stack install`,
+with validation that lists valid profiles on error. Make `--profile` and
+`--skip-optional` mutually exclusive. Leave `optional_services` in place for
+stacks that declare no profiles, so `analytics` and `ai-local` are unaffected.
+
+*Acceptance:* `uis stack install observability --profile metrics` installs
+exactly the profile's components on a clean cluster and reports healthy, and
+T3's must-NOT-exist assertions pass for all three profiles. **Expected-fail
+before:** no `--profile` flag exists, and `--skip-optional` — the nearest
+equivalent — dies at Grafana (CLI-F1).
+
+### PLAN-cli-stack-003-sizing
+
+Declare `resources:` for Loki, Tempo and Grafana (CLI-F4 — prerequisite), add
+per-size values overlays, add `--size`, and delete the dead
+`030-grafana-config.yaml` (CLI-F5). Disable `pushgateway`, Loki `gateway` and
+`lokiCanary` in the small overlay (CLI-F6).
+
+Define all three sizes, not just `small` — production is the case that needs
+`medium`, and its retention windows differ in kind from `small`, not only in
+magnitude.
+
+Must also document the CLI-F10 constraint (sizes apply at install time, going up
+is possible via volume expansion, going down is not) **and ship the existing-install
+path from CLI-F11** — `asgard` already runs this stack, so "what happens when the
+stack is already there" is the production case, not an edge case.
+
+*Acceptance:* claims stay within the budget **for the profile installed** — the
+threshold is per `(profile, size)` pair, not per size, since a `metrics` install
+has three claims and a `full` install has five:
+
+| Profile at `--size small` | Claims | Budget |
+|---|---|---:|
+| `metrics` | prometheus, alertmanager, grafana | ≤ 6Gi |
+| `logs` | + loki | ≤ 8Gi |
+| `full` | + tempo | ≤ 10Gi |
+
+Plus: every component declares requests and limits, and Prometheus has a
+`retentionSize` below its claim. **Expected-fail before:** three components
+declare no resources (CLI-F4) and no `retentionSize` exists anywhere (CLI-F3).
+
+### PLAN-cli-stack-004-platform-defaults
+
+Resolve unspecified `--profile` / `--size` from the active platform, and print
+the resolved values before installing so the behaviour is never a surprise.
+
+*Acceptance:* on `rancher-desktop`, a bare `uis stack install observability`
+installs the **`full` profile at `small` size** and says so — all signals, almost
+no history, so that an instrumented app's traces arrive locally (parent PLAN-005).
+
+---
+
+### Scope limit: none of this makes production observability *useful*
+
+Worth stating plainly, because the plan list above can read as a path to a
+production-ready stack. It is not one.
+
+`uis stack install observability --profile full --size medium` on asgard yields a
+cluster that still **will not tell you** the database host is out of disk, or that
+backups stopped a week ago. The parent investigation's two highest-severity
+production findings are:
+
+| Parent finding | What is missing | Delivered by a profile or size? |
+|---|---|---|
+| **OBS-F1** | no alert rules exist at all | **no** |
+| **OBS-F4** | only Kubernetes is scraped — nothing outside the cluster | **no** |
+
+Neither is expressible as a `--profile` value or a `--size`, because neither is
+about *which components* or *how big*. They are the parent's `PLAN-002`
+(baseline alerts) and `PLAN-004` (external targets).
+
+**Profiles and sizes make the stack fit the machine. They do not make it useful.**
+Fitting is the developer's problem; usefulness is production's. The sequencing
+should say so rather than implying this CLI work moves production forward — for
+asgard, the parent's PLAN-002 and PLAN-004 are worth more than everything in
+Part 5.
+
+---
+
+## Part 6: Rollback
+
+Observability is the system you would normally use to diagnose a bad change. If
+one of these changes breaks it, that diagnostic capability is what breaks — so
+each plan needs a stated way back before it starts.
+
+| Change | Reversible? | How back |
+|---|---|---|
+| Grafana `SCRIPT_REQUIRES` reduced | yes, trivially | revert one metadata line and redeploy Grafana |
+| `--profile` added | yes | flag is additive; omitting it preserves today's behaviour |
+| Collector → Alloy | yes, with care | keep the OTel Collector manifests until Alloy is verified; both can receive OTLP during the overlap |
+| `--size` **down** | **no** | PVCs cannot shrink (CLI-F10) — recreating them destroys retained data |
+| `--size` **up** | yes | volume expansion, if the StorageClass allows it |
+
+Two consequences worth designing around:
+
+1. **Sequence the Alloy swap as add-then-remove, not replace.** Deploy Alloy
+   alongside the existing collector, confirm T5 equivalence, and only then remove
+   the collector. A straight swap has a window with no working telemetry path and
+   no easy way back.
+2. **The one-way door is `--size` downward.** It is the only change here that
+   destroys data, and it should require explicit confirmation rather than being
+   reachable by a flag typo.
+
+There is no need for a `uis stack rollback` verb: every reversible item above is
+either a flag omission or a normal redeploy.
+
+---
+
+## Part 7: Open questions for the maintainer
+
+1. **Should `--size` be per-stack or global?** A `uis config set size small`
+   applying to every stack is less typing, but observability is the only stack
+   large enough to care today. Suggest per-invocation now, global later if a
+   second stack needs it.
+2. **Are `metrics` / `logs` / `full` the right profile names?** They are
+   observability-shaped. A stack like `analytics` would want different names,
+   which is fine if profiles are per-stack — but it means no cross-stack
+   vocabulary like `--profile minimal`.
+3. **Should a profile be recorded after install?** There is no `uis stack
+   upgrade` today — the subcommands are `list`, `info`, `install`, `remove` — so
+   this is about future need, not a current break. The cases that would want it:
+   re-running `stack install` to add a component, `uis status` reporting what was
+   intended versus what is running, and any later upgrade verb. `.uis.extend/` is
+   the natural home. Cheap to add now, awkward to backfill once installs exist in
+   the wild.
+4. **Are the proposed retention windows right?** Part 3 now defines all three
+   sizes, with `medium`/`large` differing from `small` in retention *kind*
+   (30d/7d/3d rather than 7d/24h/24h). The numbers are indicative and unmeasured —
+   measuring a day of asgard ingest would replace them with real ones. Sizes
+   should still be documented as machine-shaped ("fits a 12 GB laptop"), not
+   environment-shaped ("dev"), to avoid re-introducing the platform/size
+   conflation in the naming.
+5. **Does the parent's ~4 GB RAM figure hold?** It drives the opt-in decision
+   (parent Q2), but the parent's appendix reports *node* usage of 4.7 GiB across
+   13 services plus observability — it does not isolate the stack. Worth
+   measuring the observability namespace's actual working set before sizing
+   decisions rest on it.
+
+---
+
+## Appendix: how the findings were produced
+
+Traced against `main` @ `ca59e7c` by source inspection, not by running a
+cluster. Every claim above is reproducible with:
+
+```bash
+# CLI-F1 — the contradiction
+grep -n 'observability|' provision-host/uis/lib/stacks.sh
+grep -n 'SCRIPT_REQUIRES' provision-host/uis/services/observability/service-grafana.sh
+sed -n '292,305p' provision-host/uis/lib/service-deployment.sh
+
+# CLI-F3 — claims, retention, and the missing size cap
+grep -nE 'size:|retention' manifests/03[0-4]-*.yaml
+grep -riE 'retentionSize|retention_size' manifests/03*.yaml
+
+# CLI-F4 — components with no resources declared
+grep -c 'resources:' manifests/031-tempo-config.yaml \
+                     manifests/032-loki-config.yaml \
+                     manifests/034-grafana-config.yaml
+
+# CLI-F5 — the dead values file
+grep -rn '030-grafana-config' --include='*.yml' --include='*.sh' .
+
+# CLI-F6 — defaults left unset in the Loki values
+grep -cE '^(gateway|lokiCanary):' manifests/032-loki-config.yaml
+```
+
+The one thing **not** verified against a live cluster is CLI-F1's failure mode. The
+code path is unambiguous, but running `uis stack install observability
+--skip-optional` once would turn a traced conclusion into a measured one.

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-system-backup-and-scheduling.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-system-backup-and-scheduling.md
@@ -1,0 +1,231 @@
+# Investigate: Backup and scheduling — UIS deploys stateful services it cannot back up
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Give UIS (a) a backup capability for the stateful services it deploys,
+and (b) the scheduling primitive that backup — and everything else periodic —
+depends on. Today UIS has neither. A reference implementation (pgBackRest with
+verified point-in-time recovery) was built on a production deployment; its
+findings and the scheduling trade-offs are recorded here.
+
+**Related**: [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md),
+[INVESTIGATE-system-registry-cache](./INVESTIGATE-system-registry-cache.md)
+**Created**: 2026-08-05 — built and verified on Proxmox host `odin` / k3s `asgard`
+
+---
+
+## Background
+
+UIS deploys **postgresql, mysql, mongodb, redis, elasticsearch, minio** — six
+services that hold state. Searching the repo:
+
+```bash
+grep -rliE 'pg_dump|pgbackrest|wal_level|archive_mode' .   # → nothing
+grep -rlE 'kind: CronJob|schedule:' manifests/ ansible/    # → nothing
+```
+
+**There is no backup capability and no scheduling primitive anywhere in UIS.**
+
+This is arguably the most consequential gap in the platform. A developer can
+`uis deploy postgresql`, put real data in it, and have no supported way to back
+it up — and nothing warns them. `PLANS.md` even uses
+`PLAN-service-postgresql-backup-cronjob.md` as its example filename, so the need
+was recognised; it was never written.
+
+---
+
+## Part 1: Scheduling — decide this first, backup depends on it
+
+Three schedulers are plausible in a UIS deployment. They are **not
+interchangeable**, and the difference matters most for backups.
+
+| Option | Strengths | Fatal for backups because… |
+|---|---|---|
+| **Kubernetes `CronJob`** | native, declarative, ships with the manifest | doesn't run when the cluster is down — exactly when you need a backup to have existed |
+| **Temporal** (already in the catalogue) | durable, retries, history, visibility | **Temporal stores its own state in PostgreSQL** — scheduling Postgres backups in it is circular |
+| **systemd timers on the host/CT** | independent of cluster *and* database; survives both | invisible to UIS: no `uis` command shows them, no central status, easy to forget |
+
+### ⚠️ This is not the only scheduling question in the backlog
+
+Three distinct layers, easily conflated:
+
+| Layer | Examples | Owner |
+|---|---|---|
+| **Infrastructure jobs** | database backup, guest backup, offsite copy, cache warming | **this document** |
+| **Data pipelines** | ingest → transform → catalogue, with DAGs, freshness and lineage | [INVESTIGATE-service-dagster](./INVESTIGATE-service-dagster.md) |
+| **Durable workflows** | long-running business logic, retries, distributed workers | **Temporal** — already in the catalogue and deployed |
+
+They are complementary, but note: the Dagster investigation (2026-04-21)
+**predates Temporal being deployed** and does not consider it. Both are
+orchestrators with durable state in PostgreSQL, both retry, both ship a UI —
+running both is defensible (Dagster is asset/data-oriented, Temporal is durable
+execution of arbitrary code) but should be a deliberate decision rather than an
+accident, especially on a small node. **Worth resolving before implementing
+either.**
+
+Whatever is decided there, it does not change this document: neither Dagster nor
+Temporal can own infrastructure jobs, for the reason below.
+
+### The rule this produces
+
+> **A backup job must not depend on the thing it backs up.**
+
+Which implies a two-tier model, and UIS should say so explicitly:
+
+- **Infrastructure jobs** — database backup, host/guest backup, offsite copy,
+  cache warming. Must run when the cluster is down. Belong at the **host layer**.
+- **Application jobs** — report generation, data pipelines, cleanup. Belong
+  **in-cluster** (`CronJob`) or in **Temporal** when durability/retries/visibility
+  matter.
+
+### What is missing regardless of which is chosen
+
+There is no way to **declare, discover or observe** a scheduled job:
+
+```
+uis jobs list           # what periodic work exists, where it runs, when it last ran
+uis jobs status <job>   # last result, duration, next run
+uis jobs run <job>      # run now (the thing you want when testing a backup)
+```
+
+Today an operator must know that `systemctl list-timers` on four different hosts
+is the source of truth. That is exactly the kind of knowledge UIS exists to
+remove.
+
+**Ties into observability:** a scheduled job that silently stops is invisible
+without alerting. "Last successful backup older than N hours" is the highest-value
+alert a self-hosted platform can have — see
+[INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md) PLAN-004.
+
+---
+
+## Part 2: Backup — findings from the reference implementation
+
+Built for the production PostgreSQL (which runs **outside** the cluster, per
+[INVESTIGATE-system-remote-deployment-targets] topology).
+
+### F1 — Logical dumps alone are a 24-hour data-loss window
+
+`pg_dump` nightly is a good floor, but it means losing up to a day. Continuous
+WAL archiving reduces the worst case to the archive interval. With
+`archive_timeout=300` the measured RPO is **≤5 minutes** — a 288× improvement for
+a few MB/day of compressed WAL.
+
+Both are worth having: WAL/PITR for recency, logical dumps for selective restore
+and for surviving repo corruption.
+
+### F2 — pgBackRest is the right tool, and a "stanza" is just its config unit
+
+`pgbackrest` 2.59 (in PGDG for bookworm) gives full/differential/incremental
+backups, WAL archiving, PITR, retention, encryption and verification.
+
+A **stanza** is one configuration unit: a PostgreSQL cluster plus where its
+backups go. Cluster-level, not per-database — one stanza covered
+`urbalurba_db`, `authentik` and `temporal` together. A second server would be a
+second stanza. Worth defining in the docs; it is the one unfamiliar term.
+
+### F3 — ⚠️ pgBackRest requires TLS for `s3` repos; MinIO-over-HTTP fails
+
+Pointing the repo at the in-house MinIO produced:
+
+```
+ERROR: [101]: TLS error [1:167772427] wrong version number
+```
+
+`repo1-s3-verify-tls=n` disables *verification*, not TLS itself. Options are to
+enable TLS on MinIO (which breaks existing plain-HTTP consumers) or use a
+`posix` repo. **This will bite anyone who assumes "we have MinIO, use it as the
+backup repo".** If UIS wants S3-repo backups pointing at its own MinIO, MinIO
+needs TLS as a prerequisite — worth deciding deliberately.
+
+### F4 — Repo encryption creates a new critical secret
+
+`repo1-cipher-pass` encrypts the whole archive. **Lose it and every backup,
+including offsite copies, is unreadable.** Any UIS backup feature must integrate
+with the secrets layer rather than leaving the passphrase in a config file — see
+[INVESTIGATE-system-observability]'s sibling secrets work.
+
+### F5 — Restores must be tested, and the test finds real bugs
+
+Restore-testing all four layers on this deployment found a **timezone bug**: the
+database container ran `Etc/UTC` while the host ran `Europe/Oslo`, so the dump
+job ran *three hours after* the off-box backup that was supposed to capture it.
+Every offsite snapshot contained the **previous day's** dump — a ~48 h worst case
+instead of 24 h. Nothing reported an error; both jobs "succeeded" every night.
+
+Two lessons for any UIS backup feature:
+1. **Cross-host schedule ordering is meaningless unless the hosts agree on a
+   timezone.** Provisioning should set a consistent timezone, or schedules should
+   be expressed in UTC.
+2. Avoid scheduling in **02:00–03:00 local** — the European DST transition, where
+   a timer can be skipped entirely at spring-forward or run twice in autumn.
+
+### F6 — Restore gotcha worth documenting
+
+On Debian, `postgresql.conf` lives in `/etc`, **not** in the data directory — so
+a restored data directory won't start without one. A PITR test needs a minimal
+`postgresql.conf` + `pg_hba.conf` supplied by hand. Similarly, restoring a
+*privileged* LXC from `vzdump` requires `--unprivileged 0`, else `tar` fails with
+a uid-mapping error.
+
+---
+
+## Part 3: Proposed plans (ordered)
+
+```
+PLAN-system-scheduling-001-jobs-primitive.md        ← decide + expose scheduled jobs
+PLAN-service-postgresql-002-backup.md               ← pgBackRest, PITR, restore test
+PLAN-system-backup-003-other-stateful-services.md   ← mysql/mongo/redis/elastic/minio
+PLAN-system-backup-004-freshness-alerting.md        ← with the observability work
+```
+
+### PLAN-001 — Scheduling primitive
+
+Adopt the two-tier model (Part 1), and add `uis jobs list|status|run`. Even if the
+first implementation only *reports* systemd timers and k8s CronJobs it finds, the
+discoverability alone is a large win.
+
+*Acceptance:* `uis jobs list` shows every periodic job UIS created, where it runs,
+when it last ran and whether it succeeded.
+
+### PLAN-002 — PostgreSQL backup
+
+Ship pgBackRest with the postgresql service: stanza creation, `archive_command`
+wiring, retention, encryption via the secrets layer, and a documented restore +
+PITR procedure. Must work for both in-cluster and external PostgreSQL.
+
+*Acceptance:* a fresh `uis deploy postgresql` is backed up automatically; a
+documented PITR restore recovers a row written minutes before the target time.
+
+### PLAN-003 — The other stateful services
+
+MySQL (`xtrabackup`/dumps), MongoDB (`mongodump`), Redis (RDB/AOF — decide whether
+it counts as durable), Elasticsearch (snapshot API → S3), MinIO (`mc mirror` or
+versioning + replication).
+
+### PLAN-004 — Backup freshness alerting
+
+Export last-success timestamps as metrics and alert when stale. Without this,
+backups fail silently — as F5 demonstrates.
+
+---
+
+## Part 4: Open questions
+
+1. **Where does the scheduler live** for a UIS install with no cluster yet, or a
+   cluster that is down? Probably the host layer — the same "platform components
+   beside the cluster" class as the external database, object store, secret store
+   and registry cache. That class keeps recurring and may deserve first-class
+   modelling.
+2. **Should backups be on by default** for stateful services, or opt-in? Argument
+   for default-on: the failure mode of forgetting is unrecoverable.
+3. **Where do backups go by default?** Local disk is not a backup. MinIO is
+   convenient but shares a failure domain and needs TLS (F3). Offsite needs
+   credentials UIS doesn't currently manage.
+4. **Retention defaults** — and who is responsible for not filling the disk.
+5. **Does UIS want to own restore too?** `uis restore <service> --to <time>` is the
+   command an operator actually wants at 3am, and it is where the value is.

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-system-observability.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-system-observability.md
@@ -1,0 +1,273 @@
+# Investigate: Observability — the stack deploys, but the signals don't arrive
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Make a UIS deployment actually observable. The observability stack
+installs and reports healthy, but no telemetry reaches it — there are no alert
+rules, no log collection, and nothing outside Kubernetes is monitored. This
+investigation documents the gaps with reproducible evidence and proposes five
+ordered plans.
+
+**Related**: [INVESTIGATE-system-remote-deployment-targets](./INVESTIGATE-system-remote-deployment-targets.md),
+[INVESTIGATE-cli-stack-profiles](./INVESTIGATE-cli-stack-profiles.md) — the
+install-shape and testing companion to this document; it answers Q3 and Q4 below
+and corrects Q4's original premise
+
+**Finding IDs**: findings here are prefixed `OBS-` so cross-references between
+the two documents are unambiguous (the companion uses `CLI-`).
+**Created**: 2026-08-05 — findings measured on a production k3s cluster (see Appendix)
+
+---
+
+## Background
+
+`uis stack install observability` deploys Prometheus, Loki, Tempo, the OTel
+Collector and Grafana. On a real production cluster (k3s `asgard`, Proxmox host
+`odin`) all five deploy and report healthy, and each service's own E2E test
+passes.
+
+**But the platform is not observable.** The components are installed; the
+telemetry pipelines that would make them useful are not connected. This
+investigation documents what is missing, with reproducible evidence, and
+proposes an ordered set of plans.
+
+The distinction matters because the current state is the dangerous kind: a
+monitoring stack that *looks* deployed, consumes ~4 GB RAM and ~40 GB of
+storage, and would not tell you if the platform broke.
+
+---
+
+## Part 1: Findings (measured, with repro)
+
+### OBS-F1 — There are no alert rules. Monitoring cannot alert. (severity: high)
+
+```bash
+curl -s "$PROM/api/v1/rules"
+{"status":"success","data":{"groups":[]}}
+```
+
+Alertmanager is deployed (`prometheus-alertmanager-0` Running) and has storage
+provisioned, but **zero rules are loaded**. No condition on any service will ever
+notify anyone. This is the single biggest gap: everything else in the stack is
+for *investigating* a problem you already know about; alerts are how you find out.
+
+### OBS-F2 — Nothing ships logs to Loki. It contains only its own test data. (severity: high)
+
+```bash
+curl -s "$LOKI/loki/api/v1/label/job/values"
+{"status":"success","data":["loki-validation"]}
+```
+
+`loki-validation` is the log the deployment's own E2E test pushed. There is **no
+log-shipping agent** in the cluster:
+
+```bash
+kubectl get pods -A | grep -iE 'promtail|alloy|fluent|vector'   # → nothing
+```
+
+So container logs are never collected. Loki, its gateway, its canary and a 10 GB
+PVC are running to store test data. `kubectl logs` remains the only way to read
+logs, which does not survive pod restarts and cannot be searched across services.
+
+### OBS-F3 — Tempo receives no traces from anything real. (severity: medium)
+
+Same shape as OBS-F2: Tempo is deployed and queryable, but only the E2E validation
+trace has ever reached it. Nothing documents how an application should send
+traces, and no UIS service is instrumented.
+
+Relevant data point: an application team using this platform was shipping OTLP
+traces/metrics/logs to **Grafana Cloud** because there was no documented local
+path — a self-hosted stack was running the whole time.
+
+### OBS-F4 — Only Kubernetes is monitored. (severity: high for production)
+
+Prometheus scrape jobs, in full:
+
+```
+ 1 x kubernetes-api-servers      1 x kubernetes-nodes
+ 1 x kubernetes-nodes-cadvisor   5 x kubernetes-pods
+ 8 x kubernetes-service-endpoints
+ 1 x prometheus                  1 x prometheus-pushgateway
+```
+
+Every target is inside the cluster. In a production UIS deployment, critical
+components are deliberately **outside** it:
+
+| Component | Why outside | Monitored? |
+|---|---|---|
+| PostgreSQL | survives cluster failure; bootstrap/recovery | ❌ |
+| Object storage (MinIO/S3) | reachable by workers outside the cluster | ❌ |
+| Secret store | must not depend on the cluster it serves | ❌ |
+| Hypervisor / host | runs everything | ❌ |
+| Storage pool (ZFS/LVM), disk health | where the data lives | ❌ |
+| Backups (dumps, snapshots, offsite) | the last line of defence | ❌ |
+
+A cluster-only view will happily report "all green" while the database host is
+out of disk, the SSD is failing, or backups have silently not run for a week.
+**For a production install, the components outside Kubernetes are the ones whose
+failure is unrecoverable.**
+
+### OBS-F5 — No service dashboards ship with services
+
+Each service knows what "healthy" means for itself, but that knowledge isn't
+expressed anywhere. An operator gets Grafana with generic Kubernetes views and
+must build service views by hand.
+
+### OBS-F6 — The Grafana E2E test fails deployment on a timing race
+
+`034-setup-grafana.yml` pushes a trace then queries it back within 3 retries.
+Tempo does not make traces searchable until it flushes a block, so the play
+aborts with `GRAFANA DATASOURCE VALIDATION FAILED` **while the stack is healthy**
+— and because it aborts, the `enable` step never runs, leaving Grafana running,
+reported `✅ Deployed` by `uis list`, but **absent from `uis list-enabled`**.
+
+(Also tracked as a standalone defect; repeated here because it shapes any work on
+the observability playbooks.)
+
+---
+
+## Part 2: What "better observability" should mean for UIS
+
+UIS's promise is a platform you use *without* knowing Kubernetes. Applied to
+observability, that implies three properties the current stack doesn't have:
+
+1. **Signals arrive by default.** Deploying the stack should collect logs and
+   metrics from everything UIS deployed, with no further wiring. Today the
+   operator must know to add an agent that isn't in the catalogue.
+2. **The platform tells you when it is unhealthy**, without the operator writing
+   PromQL first. A baseline rule set shipped with UIS is the difference between
+   "monitoring installed" and "monitored".
+3. **It covers the whole deployment, not just the cluster** — including the
+   external database, object store, secret store and host that a production
+   topology depends on.
+
+A useful framing: UIS already treats *services* as the unit of composition
+(`uis deploy <service>`). Observability should follow the same shape — a service
+brings its own scrape config, dashboard and alert rules, so `uis deploy postgresql`
+also makes Postgres observable.
+
+---
+
+## Part 3: Proposed plans (ordered)
+
+```
+PLAN-system-observability-001-log-collection.md     ← Loki is decorative without this
+PLAN-system-observability-002-alert-baseline.md     ← makes it "monitored"
+PLAN-system-observability-003-service-dashboards.md ← per-service, ships with the service
+PLAN-system-observability-004-external-targets.md   ← the production-topology gap
+PLAN-system-observability-005-app-telemetry.md      ← the dev→prod story for apps
+```
+
+### PLAN-001 — Log collection (highest value, unblocks OBS-F2)
+
+Add a log-shipping agent to the observability stack so container logs reach Loki
+automatically.
+
+**Decided: Grafana Alloy.** This was an open question when first written; it no
+longer is. **Promtail reached end-of-life on 2 March 2026** — support has ended
+and all development moved to Alloy, so it is not a candidate. Alloy is a
+vendor-neutral distribution of the OTel Collector and handles logs, metrics and
+traces, so it also subsumes the standalone collector, taking the stack from 5
+components to 4.
+
+Two practical notes:
+
+- This is **not** a Promtail migration — UIS has no Promtail to convert
+  (that is OBS-F2). It is a greenfield install. The existing collector config
+  *can* be converted: `alloy convert --source-format=otelcol`.
+- Alloy's DaemonSet defaults (100m/128Mi requests, 500m/512Mi limits) match what
+  the OTel Collector is already allocated, so log collection arrives at roughly
+  no additional cost.
+- Alloy emits different metrics than Promtail or the collector; any dashboard or
+  alert built on collector metrics needs updating.
+
+*Acceptance:* after `uis stack install observability`, `logcli`/Grafana can query
+logs from every namespace; `job` label values include real services, not just
+`loki-validation`.
+
+### PLAN-002 — Baseline alert rules + routing
+
+Ship a default rule group covering: node/pod not ready, pod crash-looping, PVC
+above ~85%, node disk/memory pressure, target down, certificate expiry. Plus
+Alertmanager routing so alerts have somewhere to go.
+
+*Open question:* what receiver is the sensible default for a self-hosted install
+(email needs SMTP; ntfy/Gotify are self-hostable; Slack/Discord need a webhook)?
+Suggest: rules shipped enabled, receiver configured via `.uis.extend`, with a
+loud warning while unconfigured.
+
+*Acceptance:* stopping a deployment produces a firing alert visible in
+Alertmanager and Grafana within ~2 minutes.
+
+### PLAN-003 — Per-service dashboards and scrape config
+
+Give each service definition optional `dashboard` and `alerts` artifacts, applied
+when both that service and Grafana/Prometheus are deployed. Start with the
+services most likely to break: postgresql, redis, minio, temporal, traefik.
+
+*Acceptance:* `uis deploy postgresql` on a cluster with the observability stack
+yields a Postgres dashboard in Grafana with no manual steps.
+
+### PLAN-004 — Targets outside Kubernetes (OBS-F4)
+
+Support scraping components UIS did not deploy into the cluster:
+- an `.uis.extend` list of external scrape targets, rendered into Prometheus config
+- guidance/manifests for the standard exporters (`postgres_exporter`,
+  `node_exporter`, MinIO's built-in `/minio/v2/metrics`, `zfs`/SMART where relevant)
+- **backup freshness as a first-class signal** — "last successful backup older
+  than N hours" is arguably the single most valuable alert a self-hosted platform
+  can have, and nothing currently produces it
+
+*Acceptance:* on a deployment with an external database, Grafana shows database
+and host health, and an alert fires when the last backup exceeds its threshold.
+
+### PLAN-005 — Application telemetry (the dev→prod story)
+
+Document and template how an application emits traces/metrics/logs to the
+in-cluster OTel Collector, with the same endpoint working in local development
+(Rancher Desktop) and production. This is the piece that keeps teams from
+defaulting to a cloud APM vendor, and it aligns with the existing
+`uis configure` pattern: the platform hands the app its connection details.
+
+*Acceptance:* a scaffolded app emits a trace locally and in production with no
+code change, only configuration.
+
+---
+
+## Part 4: Open questions for the maintainer
+
+1. ~~**Alloy vs Promtail + OTel Collector.**~~ **Settled — Alloy.** Promtail
+   reached end-of-life on 2 March 2026, so this is no longer a trade-off. See
+   PLAN-001 above.
+2. **Should observability be opt-in or part of a default production profile?**
+   It costs ~4 GB RAM and ~40 GB storage measured here — significant on small
+   nodes, cheap on a real server.
+3. **How much should Grafana require?** Today it hard-depends on Prometheus *and*
+   Loki *and* Tempo. Making Loki/Tempo optional would let small installs run
+   metrics-only. (Tracked separately.)
+4. **Retention and sizing defaults.** *(Corrected 2026-08-05 — the original
+   wording, "no documented retention policy", was wrong.)* Retention **is**
+   configured: Prometheus `15d`, Tempo `24h`, Loki `retention_period: 24h` with
+   the compactor enabled. The actual defect is that the 8–10 GB claims were
+   sized independently of those windows — 24h of logs or traces is orders of
+   magnitude smaller than a 10 GB claim — and that **all retention is
+   time-based, with no size cap** (`retentionSize` appears nowhere), so a disk
+   can still fill before the window elapses. Analysed in
+   [INVESTIGATE-cli-stack-profiles](./INVESTIGATE-cli-stack-profiles.md) CLI-F3.
+5. **Does observability belong in the `system` area or its own?** This
+   investigation assumes `system`; if observability grows service-level artifacts
+   (PLAN-003), a dedicated area may be warranted.
+
+---
+
+## Appendix: environment the findings come from
+
+Production k3s cluster `asgard` (v1.36.2) on Proxmox host `odin`; 13 UIS services
+deployed including postgresql (external), minio (external), temporal, redis,
+authentik, and the full observability stack. Prometheus scraping 18 targets,
+Grafana healthy, Loki and Tempo queryable. Node usage after the full stack:
+4.7 GiB / 10 GB RAM, ~23% of 4 vCPU.

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-system-registry-cache.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-system-registry-cache.md
@@ -1,0 +1,237 @@
+# Investigate: Registry cache — a UIS cluster cannot currently restart without the internet
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Give UIS a pull-through registry cache so a cluster can restart,
+reschedule and self-heal with no internet access — and so repeated deploys stop
+re-downloading the same layers and stop being subject to Docker Hub rate limits.
+UIS has no registry mirror concept today; a working reference implementation was
+built and outage-tested on a production Proxmox deployment, and the findings
+(including two non-obvious traps) are recorded here.
+
+**Related**: [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md),
+[INVESTIGATE-system-remote-deployment-targets](./INVESTIGATE-system-remote-deployment-targets.md)
+**Created**: 2026-08-05 — built and verified on k3s cluster `asgard` / Proxmox host `odin`
+
+---
+
+## Background
+
+A UIS deployment pulls images from `registry.k8s.io`, `docker.io`, `ghcr.io` and
+`quay.io`. On the production cluster surveyed, **41 distinct images** across those
+four upstreams.
+
+There is no mirror or cache anywhere in UIS:
+
+```bash
+grep -rl 'registries.yaml\|registry-mirror\|pull-through' .   # → no matches
+```
+
+### The failure mode this creates
+
+If upstream registries are unreachable — an outage, an ISP problem, a rate limit,
+or simply an air-gapped site — then:
+
+- **already-running pods keep running** (their layers are on the node), so nothing
+  looks wrong at first;
+- **any restart, reschedule, node reboot or scale-up fails to pull**, and the
+  affected service stays down until connectivity returns.
+
+That is the worst shape of failure: invisible until the moment you need recovery,
+and it hits hardest exactly when other things are already broken.
+
+### Three reasons this matters beyond outages
+
+1. **Docker Hub rate limits.** Anonymous pulls are throttled per IP. A cluster
+   redeploying a stack, or several developers on one office IP, can hit the limit
+   and see confusing `toomanyrequests` failures mid-deploy.
+2. **Bandwidth and time.** Redeploying the observability stack alone re-pulls
+   ~2 GB. A cache makes repeated installs and rebuilds dramatically faster.
+3. **Developer laptops benefit too.** Rancher Desktop supports registry mirrors,
+   so one cache on the network speeds up every `uis deploy` for everyone — not
+   just production.
+
+---
+
+## Part 1: Findings from the reference implementation
+
+### F1 — The cache must live OUTSIDE the cluster (architectural, not preference)
+
+A registry running *inside* the cluster cannot serve the images required to start
+that cluster. After a cold boot, the cache's own pod needs an image, which needs
+the cache. Same bootstrap circularity as an in-cluster secret store.
+
+**Implication for UIS:** a registry cache is **not a service** in the
+`uis deploy <service>` sense. It belongs to the **host/platform layer** — alongside
+the things UIS provisions *around* a cluster. This may need a new concept, or it
+fits naturally under host/target management.
+
+*(In-cluster P2P alternatives such as `spegel` share already-pulled layers between
+nodes and are useful, but they cannot solve the cold-start case and are irrelevant
+on a single-node cluster.)*
+
+### F2 — `registry:2` proxies exactly one upstream, so N upstreams need N instances
+
+`REGISTRY_PROXY_REMOTEURL` is singular. The reference build runs four containers:
+
+| Port | Upstream |
+|---|---|
+| 5000 | `https://registry-1.docker.io` |
+| 5001 | `https://registry.k8s.io` |
+| 5002 | `https://ghcr.io` |
+| 5003 | `https://quay.io` |
+
+Workable but clunky. **Alternatives worth evaluating before implementing:** `zot`
+(CNCF, supports multiple upstream sync targets in one instance), `Harbor` (heavy,
+but full-featured with GC and auth), or `docker/distribution` behind a router.
+
+### F3 — k3s wiring is simple and well-defined
+
+`/etc/rancher/k3s/registries.yaml`:
+
+```yaml
+mirrors:
+  docker.io:
+    endpoint: ["http://<cache-host>:5000"]
+  registry.k8s.io:
+    endpoint: ["http://<cache-host>:5001"]
+  ghcr.io:
+    endpoint: ["http://<cache-host>:5002"]
+  quay.io:
+    endpoint: ["http://<cache-host>:5003"]
+```
+
+k3s generates `/var/lib/rancher/k3s/agent/etc/containerd/certs.d/<registry>/hosts.toml`
+from this on restart. Verified: pulls route through the cache and the upstream
+remains the fallback. (Rancher Desktop accepts the same file, and other distros
+have equivalents — so the concept is portable across UIS's cluster types.)
+
+### F4 — ⚠️ `crictl pull` does NOT warm the cache (the trap)
+
+**This cost real time and produced a false positive.** `crictl pull` is a no-op
+when the image is already present on the node — it never contacts the mirror.
+A warming loop over all 41 images reported:
+
+```
+pulled ok=41  failed=0
+```
+
+…while the cache actually contained **4 repositories**. Confirmed by querying the
+registry rather than trusting exit codes:
+
+```bash
+curl -s http://<cache>:5000/v2/_catalog
+{"repositories":["library/busybox","library/postgres","library/redis"]}
+```
+
+**The reliable method is to request each image *from the mirror endpoint*,** which
+forces it to fetch and store:
+
+```bash
+skopeo copy --src-tls-verify=false \
+  docker://<cache-host>:5000/library/redis:7.4 dir:/tmp/warm && rm -rf /tmp/warm
+```
+
+After doing it properly: **42 repositories, ~2 GB**.
+
+**Any `uis registry warm` implementation must verify via `/v2/_catalog`, not via
+the pull command's exit status.**
+
+### F5 — Official Docker Hub images need `library/` inserted
+
+`docker.io/redis:7.4` maps to `<cache>:5000/library/redis:7.4`, not
+`<cache>:5000/redis:7.4`. This was the single failure in the warming run. Any
+image→mirror path translation needs to handle: bare name (`nginx`), `org/repo`,
+and fully-qualified `docker.io/...`, `ghcr.io/...` etc.
+
+### F6 — Outage behaviour, verified
+
+With internet egress blocked (nft drop to everything outside the LAN) on **both**
+the cache host and the cluster node, an image was deleted from the node and
+pulled again successfully from cache. This is the test any implementation should
+ship as its acceptance criteria — it is the only way to know the cache is real.
+
+### F7 — Sizing and lifecycle
+
+~2 GB for 42 repositories of a 13-service platform. Cache storage should live on
+snapshotted/backed-up storage if cheap, but it is **reconstructible** — so it is
+a candidate for exclusion from offsite backup.
+
+No garbage collection is configured in the reference build. `registry:2` needs
+`REGISTRY_STORAGE_DELETE_ENABLED=true` plus a periodic `registry garbage-collect`
+run, or the cache grows without bound as tags churn.
+
+---
+
+## Part 2: Proposed plans (ordered)
+
+```
+PLAN-system-registry-cache-001-provision.md      ← the cache host/role itself
+PLAN-system-registry-cache-002-cluster-wiring.md ← generate registries.yaml on provision
+PLAN-system-registry-cache-003-warm-verify.md    ← `uis registry warm` + outage test
+```
+
+### PLAN-001 — Provision the cache
+
+Decide the engine (see F2) and where it runs. Because of F1 it cannot be a
+cluster service; candidates are a small VM/container on the same host, or a role
+added to the host templates from
+`INVESTIGATE-system-remote-deployment-targets`.
+
+*Acceptance:* a documented, reproducible cache reachable from the cluster,
+surviving host reboot.
+
+### PLAN-002 — Wire clusters to it automatically
+
+Render `registries.yaml` (or the distro equivalent) during cluster provisioning,
+from a cache endpoint configured in `.uis.extend`. Must degrade gracefully: no
+cache configured ⇒ current behaviour, unchanged.
+
+*Acceptance:* a freshly provisioned cluster pulls through the cache with no
+manual file editing; `certs.d/*/hosts.toml` is present.
+
+### PLAN-003 — `uis registry warm` and verification
+
+A command that enumerates images in use (or in the enabled service set) and warms
+them **via the mirror endpoints** (F4), handling path translation (F5), then
+reports what is actually cached from `/v2/_catalog`. Plus a documented outage test
+(F6) and a GC policy (F7).
+
+*Acceptance:* `uis registry warm` reports cached repository counts that match the
+enabled services; the outage test passes.
+
+---
+
+## Part 3: Open questions
+
+1. **Engine:** four `registry:2` instances, or one multi-upstream tool (`zot`)?
+   Fewer moving parts is worth a lot for a self-hosted platform.
+2. **Where does a non-cluster component live in the UIS model?** This is the
+   interesting design question — UIS's unit of composition is an in-cluster
+   service, and this cannot be one. Same shape as an external database, external
+   object store, or the secret store: a growing class of "platform components
+   beside the cluster" that may deserve first-class support.
+3. **Private registries.** `ghcr.io` pulls of private images need credentials in
+   the cache. Out of scope for a first pass, but worth designing for.
+4. **TLS.** Plain HTTP is acceptable on a trusted segment (and simplest), but
+   `containerd` needs explicit configuration for insecure endpoints on some
+   distros. TLS with an internal CA is the cleaner end state.
+5. **One cache for many clusters?** A single cache serving production, dev
+   laptops and CI multiplies the benefit — but makes it a shared dependency, so
+   it should fail open (upstream fallback) rather than closed.
+6. **Retention/GC defaults** so the cache cannot fill the disk it shares.
+
+---
+
+## Appendix: reference implementation as built
+
+Proxmox LXC (2 cores, 1 GB RAM, 60 GB cache volume on ZFS with 1 M recordsize +
+zstd), Docker running four `registry:2` pull-through caches with
+`--restart=always`, cluster wired via `registries.yaml`. Warmed with `skopeo` to
+42 repositories / ~2 GB. Outage-tested by blocking egress on both the cache and
+the cluster node. Cache volume is snapshotted and included in guest backups,
+though it is fully reconstructible.

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-grafana-optional-datasources.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-grafana-optional-datasources.md
@@ -1,0 +1,278 @@
+# Plan: Grafana runs with only the datasources that exist
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Make Grafana deployable with Prometheus alone, provisioning Loki and
+Tempo datasources only when those services are actually deployed — so a
+metrics-only observability install is expressible at all.
+
+**Last Updated**: 2026-08-06
+
+---
+
+## Dependencies
+
+**Investigation**: [INVESTIGATE-cli-stack-profiles](./INVESTIGATE-cli-stack-profiles.md)
+(CLI-F1, CLI-F2) — also answers [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md)'s **Q3**.
+
+**Prerequisites**: none. This plan is deliberately standalone.
+
+**Blocks**: `PLAN-cli-stack-002-profiles` — no `--profile` value below `full` can
+install successfully until this ships. Also unblocks today's broken
+`uis stack install observability --skip-optional` (CLI-F1).
+
+**Priority**: High
+
+---
+
+## Problem Summary
+
+`uis deploy grafana` and `uis stack install observability --skip-optional` both
+fail unless the entire observability stack is present. The investigation
+attributed this to one metadata line. **Tracing the actual code shows two
+independent blockers, and the second is the larger one.**
+
+### Blocker 1 — service metadata (known, CLI-F2)
+
+`provision-host/uis/services/observability/service-grafana.sh:19`
+
+```bash
+SCRIPT_REQUIRES="prometheus loki tempo otel-collector"
+```
+
+`check_dependencies()` (`provision-host/uis/lib/service-deployment.sh:292`) hard-fails
+on any missing entry, so deployment dies before the playbook runs.
+
+### Blocker 2 — the playbook enforces the same thing again (new)
+
+**Reducing `SCRIPT_REQUIRES` alone changes nothing.** `034-setup-grafana.yml`
+task 20 (`FAIL deployment if core tests did not pass`) aborts the play unless
+*all* of these pass:
+
+| Task | Asserts | Needs |
+|---|---|---|
+| 10 | Prometheus datasource reachable | prometheus |
+| 11 | Loki datasource reachable | **loki** |
+| 12 | Tempo datasource reachable | **tempo** |
+| 13 | Prometheus returns data | prometheus |
+| 14–16 | push logs via OTLP → query back through Grafana | **loki + otel-collector** |
+| 17–19 | push traces via OTLP → query back through Grafana | **tempo + otel-collector** |
+
+So a metrics-only Grafana would fail later, in the playbook, with a worse message
+than the dependency check gives today. Three further consequences:
+
+1. **Datasource proxy IDs are positional.** Every check calls
+   `/api/datasources/proxy/1|2|3/…`, which assumes Prometheus=1, Loki=2, Tempo=3.
+   Once datasources are conditional those positions shift, and a metrics-only
+   install would silently proxy the wrong datasource rather than error. The repo
+   uses positional IDs in every call today and UID-based paths in none
+   (`grep -c 'proxy/uid'` → 0).
+2. **`otel-collector` is a hidden fourth dependency** — tasks 14, 17, 24 and 25
+   push through `otel-collector-opentelemetry-collector`, independent of anything
+   `SCRIPT_REQUIRES` declares.
+3. **The shipped dashboards assume all three.** `035-grafana-test-dashboards.yaml`
+   references `loki` (×2) and `tempo` (×2) datasource UIDs;
+   `036-grafana-sovdev-metrics.yaml` references `loki` (×4). Task 23 blocks until
+   ≥4 dashboard ConfigMaps exist. On a metrics-only install these panels render
+   datasource errors.
+
+The playbook's E2E tasks are also the OBS-F6 flaky race (retry-3 against Tempo's
+block flush) — this plan makes them conditional, it does not fix their timing.
+
+---
+
+## Phase 1: Baseline — reproduce both failures
+
+Turns CLI-F1's traced conclusion into a measured one. **Nothing is changed in
+this phase**; its output is the expected-fail record for every phase below.
+
+### Tasks
+
+- [ ] On a clean cluster, deploy Prometheus only: `uis deploy prometheus`
+- [ ] Attempt `uis deploy grafana` — record the exact `die_dependency` message
+- [ ] Temporarily set `SCRIPT_REQUIRES="prometheus"` (do not commit) and retry —
+      record where the playbook aborts and what task 20 prints
+- [ ] Attempt `uis stack install observability --skip-optional` on a clean
+      cluster — record the failure point (CLI-F1's unverified repro)
+- [ ] Revert the temporary edit
+
+### Validation
+
+Three recorded failures, each with its message. If any of them *passes*, stop:
+the finding is wrong and this plan needs rewriting before any code changes.
+
+---
+
+## Phase 2: Refactors that are invisible on a full stack
+
+Both changes below are prerequisites for conditionality but alter no behaviour
+while all five services are deployed — so they can be validated against the
+existing install before anything becomes conditional.
+
+### Tasks
+
+- [ ] Add detection facts to `034-setup-grafana.yml`: `k8s_info` probes for the
+      Loki, Tempo and OTel Collector services, registered as
+      `loki_present` / `tempo_present` / `otel_present`. Probe the **Service**, not
+      the Pod — a datasource needs a resolvable endpoint, not a running pod.
+- [ ] Replace every positional datasource proxy path with a UID-based one:
+      `/api/datasources/proxy/1/…` → `/api/datasources/proxy/uid/prometheus/…`,
+      likewise `uid/loki` and `uid/tempo` (tasks 10, 11, 12, 13, 16, 19). The UIDs
+      are already declared in `034-grafana-config.yaml`.
+- [ ] Print the three detected facts in task 1's banner, so the deploy log says
+      which datasources it is about to provision.
+
+### Validation
+
+- [ ] `uis deploy grafana` on a **full** stack still passes end to end, with every
+      datasource check reporting PASS as before
+- [ ] The banner reports all three services present
+
+---
+
+## Phase 3: Conditional datasources + metadata fix
+
+### Tasks
+
+- [ ] Convert `manifests/034-grafana-config.yaml` to a Jinja template
+      (`034-grafana-config.yaml.j2`) and render it to a temp path before the Helm
+      task, wrapping the Loki and Tempo datasource entries in
+      `{% if loki_present %}` / `{% if tempo_present %}`.
+      *Alternative if templating a manifest is unwelcome:* keep the static file as
+      the base and pass a computed `datasources` map via the Helm task's inline
+      `values:`, which takes precedence over `values_files:`. Templating is
+      preferred — it keeps the values file readable as one document.
+- [ ] Reduce `SCRIPT_REQUIRES` to `"prometheus"` in `service-grafana.sh`
+- [ ] Update the values file's header comment block, which currently states
+      Loki and Tempo as prerequisites (lines 18–22)
+
+### Validation
+
+- [ ] With Prometheus only: Grafana starts, `GET /api/datasources` returns exactly
+      one entry, `uid=prometheus`
+- [ ] **No dangling datasources** — this is the failure mode that looks like
+      success: a provisioned-but-unreachable Loki datasource makes Grafana appear
+      configured while every query times out
+- [ ] With the full stack: all three datasources present, unchanged from Phase 2
+
+---
+
+## Phase 4: Conditional validation gate
+
+### Tasks
+
+- [ ] Add `when: loki_present` to tasks 11, 14, 15, 16; `when: tempo_present` to
+      tasks 12, 17, 18, 19
+- [ ] Gate the OTLP-push tasks (14, 17) on `otel_present` as well as the store
+      being present — pushing through a collector that is not deployed cannot work
+- [ ] Rewrite task 20's `when:` and message so each store is asserted **only if it
+      was expected**. Prometheus stays unconditionally required; Grafana without a
+      metrics datasource is not a meaningful install.
+- [ ] Same treatment for the task 29 summary — report `not installed` rather than
+      `FAIL ❌` for an absent store, so the log does not read as a broken deploy
+
+### Validation
+
+- [ ] Prometheus-only: playbook completes, summary shows Loki/Tempo as
+      `not installed`, exit 0
+- [ ] Prometheus + Loki: Loki checks run and pass, Tempo reported not installed
+- [ ] Full stack: identical output to Phase 2's baseline
+- [ ] **Negative test:** deploy Loki, then delete its Service and redeploy Grafana
+      — the run must fail, not skip. `when:` conditions must reflect what is
+      *present*, never suppress a genuine failure.
+
+---
+
+## Phase 5: Dashboards match the datasources
+
+### Tasks
+
+- [ ] Split `035-grafana-test-dashboards.yaml` by signal, so the Logs and Traces
+      test dashboards deploy only with their datasource
+- [ ] Decide `036-grafana-sovdev-metrics.yaml`'s fate — it mixes 8 Prometheus
+      panels with 4 Loki panels in one dashboard. Either split it or accept
+      degraded panels on a metrics-only install; **splitting is preferred**, since
+      broken panels in a shipped dashboard are how users conclude the platform is
+      broken.
+- [ ] Make task 23's `>= 4` ConfigMap assertion a function of which dashboards
+      were actually deployed
+- [ ] Gate the test-data generators (tasks 24, 25) on `otel_present`
+
+### Validation
+
+- [ ] Metrics-only: every deployed dashboard renders with no datasource errors
+- [ ] Full stack: all four dashboards deploy as before
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uis deploy prometheus && uis deploy grafana` succeeds on a clean cluster
+- [ ] Grafana starts with a working Prometheus datasource and **no dangling
+      Loki/Tempo datasources**
+- [ ] `uis stack install observability --skip-optional` succeeds (closes CLI-F1)
+- [ ] `uis stack install observability` (full) produces a deployment
+      indistinguishable from today's
+- [ ] Every datasource proxy call is UID-based; `grep -c 'proxy/[0-9]'` in
+      `ansible/playbooks/` returns 0
+- [ ] The three intermediate combinations are exercised: `prometheus`,
+      `prometheus+loki`, `prometheus+loki+tempo`
+
+**Expected-fail before** (from Phase 1): `uis deploy grafana` dies at
+`check_dependencies`; with metadata relaxed it dies at playbook task 20.
+
+---
+
+## Implementation Notes
+
+### Do the phases in order — Phase 2 is the safety net
+
+Phases 2 and 3 look mergeable and are not. The positional→UID proxy change is the
+one edit that **silently misbehaves** rather than failing loudly: with
+conditional datasources and positional IDs, `/proxy/2` on a metrics-only install
+addresses whatever happens to be second. Landing it while the full stack is still
+deployed means it can be verified against known-good output first.
+
+### Two problems this plan deliberately does not fix
+
+**1. VERIFY 13 in `u10-verify-observability-tasks.yml` hard-asserts that Grafana
+has both a `tempo` and a `loki` datasource.** This plan makes that assertion
+wrong. It is not fixed here because the file **has no caller** (CLI-F8) — it
+cannot fail today. Making it profile-aware belongs to
+`PLAN-cli-stack-001-test-harness`, which is what wires it in. Note the ordering
+trap: whoever ships the harness inherits an assertion this plan already
+invalidated.
+
+**2. The Loki datasource URL collides with CLI-F6.** It points at
+`loki-gateway.monitoring.svc.cluster.local:80`, while CLI-F6 recommends disabling
+Loki's `gateway` in the small profile — an nginx proxy that in-cluster
+SingleBinary access does not need. **Doing both breaks the Loki datasource.**
+Whoever implements the small profile must repoint this URL at the Loki service
+directly and verify the port; that work belongs to
+`PLAN-cli-stack-003-sizing`, but it is recorded here because this is the file
+that has to change.
+
+### Scope
+
+This makes Grafana *installable* in reduced configurations. It does not add
+`--profile`, does not resize anything, and does not make production observability
+more useful — see the scope limit in Part 5 of the investigation.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `provision-host/uis/services/observability/service-grafana.sh` | `SCRIPT_REQUIRES` → `"prometheus"` |
+| `ansible/playbooks/034-setup-grafana.yml` | detection facts; UID-based proxy paths; `when:` on tasks 11–12, 14–19, 24–25; rewrite task 20 gate and task 29 summary; render templated values |
+| `manifests/034-grafana-config.yaml` | → `.j2`; conditional Loki/Tempo datasource entries; correct the prerequisites comment |
+| `manifests/035-grafana-test-dashboards.yaml` | split by signal |
+| `manifests/036-grafana-sovdev-metrics.yaml` | split Prometheus and Loki panels |
+
+Not modified, but affected — see Implementation Notes:
+`ansible/playbooks/utility/u10-verify-observability-tasks.yml` (VERIFY 13).

--- a/website/docs/production/_category_.json
+++ b/website/docs/production/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Production",
+  "position": 5,
+  "link": {
+    "type": "doc",
+    "id": "production/index"
+  }
+}

--- a/website/docs/production/index.md
+++ b/website/docs/production/index.md
@@ -1,0 +1,298 @@
+---
+title: Production
+sidebar_label: Overview
+sidebar_position: 1
+---
+
+# Running UIS in production
+
+UIS is designed so the same stack runs on a laptop, on-premises and in the cloud.
+That promise holds — but a production deployment differs from the developer
+default in ways that are **architectural, not cosmetic**. This section describes
+those differences once, platform-agnostically, and then links to a concrete guide
+per platform.
+
+The developer default optimises for *getting started in one command*. Production
+optimises for *surviving things going wrong*. Everything below follows from that.
+
+---
+
+## The seven decisions that make a deployment production
+
+### 1. State lives outside the cluster
+
+Databases, object storage, the secret store and the image cache should **not** be
+Kubernetes workloads in production.
+
+Three independent reasons, each sufficient on its own:
+
+- **Survivability** — a failed cluster upgrade, expired certificates or a broken
+  CNI should not take your data offline. If the database is outside, you can still
+  reach it while you repair Kubernetes.
+- **Bootstrap** — the cluster needs secrets and images *to start*. Anything on the
+  startup path cannot live inside the thing it starts. A vault in the cluster it
+  protects, or a registry serving the images needed to run that registry, is
+  circular.
+- **Multiple clusters** — dev laptops, a second site and cloud targets all need
+  the same database, object store and secrets. A component inside one cluster
+  cannot serve the others.
+
+In cloud this is natural (RDS, Cloud SQL, S3, Key Vault). On-premises it means
+dedicated hosts or containers beside the cluster. Either way, **UIS services keep
+consuming them by their usual in-cluster names** — the application does not change.
+
+### 2. The management plane is always-on
+
+`./uis` runs the provision-host container against a kubeconfig. In development
+that is your laptop. In production the management plane should be a small
+always-on host that holds the kubeconfigs for every target, so operating the
+platform never depends on a workstation being awake — and so it works identically
+whoever runs it.
+
+It must be on the same overlay network as the clusters it manages, or it can only
+reach what is on its LAN.
+
+### 3. Real secrets, in a real store
+
+The developer defaults are *known values*, shared publicly in this repository.
+They are appropriate for a laptop and dangerous the moment a cluster is
+internet-adjacent — which is one command away.
+
+Production needs: generated per-install secrets, a store outside the cluster
+(see #1), encryption at rest, and a rotation path. See the
+[secrets guide](./secrets) for a working reference implementation.
+
+### 4. A backup is a hypothesis until you have restored it
+
+Backups that run successfully every night can still be useless. Verify by
+restoring — and re-verify after any change to the chain.
+
+A real example from the reference deployment: the database container ran `UTC`
+while the host ran local time, so the dump job executed **three hours after** the
+off-box backup meant to capture it. Every offsite copy held the *previous day's*
+dump. Both jobs reported success every night. **Only a restore test found it.**
+
+### 5. Observability must be able to wake someone
+
+Deploying Prometheus, Loki, Tempo and Grafana is not observability. On the
+reference deployment, after installing the full stack:
+
+- `/api/v1/rules` returned `{"groups":[]}` — **zero alert rules**, so no condition
+  could ever notify anyone;
+- Loki contained only its own deployment test — **no log agent was installed**, so
+  container logs were never collected;
+- every Prometheus target was inside the cluster, so **the external database,
+  object store, host and backups were unmonitored**.
+
+Production needs alerts (starting with *"last successful backup older than N
+hours"*), log collection, and targets outside Kubernetes.
+
+### 6. Decide public versus private per service
+
+Once ingress exists, **anything with a permissive route is on the internet**.
+Admin UIs — Grafana, Temporal, object-store consoles, the identity provider —
+generally should not be. Choose deliberately per service:
+
+- **Private**: an overlay network (Tailscale/WireGuard) or VPN. Simple, and the
+  network *is* the auth boundary.
+- **Public**: a tunnel or load balancer **plus** authentication in front. If your
+  identity provider integrates via reverse-proxy forward-auth, note that some
+  exposure mechanisms bypass the proxy entirely and therefore bypass auth.
+
+### 7. Anything on the startup path must be local
+
+If a deployment must keep running when external providers are unreachable, then
+nothing required to *start* a workload may depend on them. In practice:
+
+| On the startup path | Consequence if remote-only |
+|---|---|
+| Container images | running pods survive; **any restart cannot pull** → the service stays down |
+| Secrets | workloads cannot start |
+| DNS / service discovery | resolution fails |
+
+Cloud is then used for **reach** (public ingress) and **recovery** (offsite
+backup) — never for running.
+
+---
+
+## The parity contract: what a developer must see
+
+None of the above may break UIS's core promise — **a developer running Rancher
+Desktop should be building against the same thing that will run in production.**
+That promise is about the **interface**, not the topology.
+
+### Must be identical (dev and production)
+
+| | Why |
+|---|---|
+| Service names apps connect to (`postgresql.default:5432`, `minio.default:9000`, …) | application config must not change between environments |
+| How an app receives secrets — an ordinary Kubernetes Secret | whether UIS templated it or an operator synced it from a vault is invisible |
+| How an app requests storage — a PVC with no explicit class | the default class differs; the manifest does not |
+| Ingress *mechanism* (Traefik routes) and the reverse-proxy version | see the warning below |
+| `uis deploy` / `uis configure` behaviour and output | the same commands, the same connection JSON |
+
+**`uis configure <service> --app <name>` is the mechanism that makes this work.**
+It provisions per-app resources in *whichever* cluster it targets and returns both
+a local and an in-cluster URL — so **application credentials are generated per
+environment and never promoted**. Dev and production differ in values, never in
+shape.
+
+### May legitimately differ
+
+| | Dev | Production |
+|---|---|---|
+| Where state runs | in-cluster (simple, disposable) | outside the cluster (survivable) |
+| Secret backend | file/template provider | external store + operator |
+| Storage backing | node disk | provisioned block/file storage |
+| Hostnames | `*.localhost` | a real domain and/or an overlay network |
+
+### Should be absent in dev, and explicitly so
+
+Backups, point-in-time recovery, off-site copies, the registry cache, alerting
+and HA are **operational** concerns. A developer does not exercise them, and
+requiring them on a laptop would make the platform hostile to start with. But
+their absence should be *stated* rather than discovered — a developer should
+never assume a laptop deployment is protecting their data.
+
+### ⚠️ Parity depends on the developer's Rancher Desktop version
+
+UIS ingress manifests use Traefik **v3** syntax (`HostRegexp` with named
+matchers, `traefik.io` CRDs). Which Traefik a developer gets is decided entirely
+by their Rancher Desktop version, because k3s bundles it:
+
+| Rancher Desktop / k3s | Traefik chart | Traefik | Result |
+|---|---|---|---|
+| current (k3s v1.36) | 40.1.3 | **3.7.x** | ✅ matches production |
+| old (k3s v1.25) | 25.0.2 | **2.10.5** | ❌ every route 404s |
+
+On the older build the legacy `traefik.containo.us` CRDs are present and the v3
+syntax silently fails to match — **services 404 while the playbooks report
+success and exit 0**. Parity fails in the worst direction: development is the
+broken one, and nothing says so.
+
+**UIS does not check this.** There is no minimum Rancher Desktop / k3s version
+declared or verified anywhere, so a developer on a stale install gets a
+deployment that reports healthy and does not work. A preflight check — assert
+Traefik major ≥3, or assert the k3s version — would turn a confusing afternoon
+into one clear error message.
+
+Any change made for production should be checked against this contract. If it
+forces a developer to configure something differently, the change is in the wrong
+layer.
+
+## Components beside the cluster
+
+Following from #1 and #7, a production UIS install has a recurring set of
+components that are *not* Kubernetes services:
+
+| Component | Why it is outside | Notes |
+|---|---|---|
+| **Database** | survivability, bootstrap, multi-cluster | in-cluster services still reach it by its usual name |
+| **Object storage** | reachable by workers outside the cluster | avoids ingress for internal consumers |
+| **Secret store** | bootstrap + recovery circularity | see [secrets](./secrets) |
+| **Image/registry cache** | the cluster cannot pull the images that start the cluster | also fixes registry rate limits |
+| **Management plane** | must work when the cluster does not | holds kubeconfigs for all targets |
+| **Scheduler for infrastructure jobs** | a backup job must not depend on what it backs up | cluster CronJobs die with the cluster |
+
+### They also need a network — and it should be the most local one available
+
+Once state lives beside the cluster, something has to say *where* it is. That
+address is easy to get wrong in a way that only hurts later.
+
+On the reference deployment every guest was on DHCP, so there was no stable
+address to configure — and the overlay network (Tailscale) was used instead,
+because its addresses do not move. It worked, and it was the wrong layer: the
+database and the cluster were on the **same virtualisation host**, so every
+query was being encrypted and pushed through a WireGuard tunnel to reach a
+neighbour on the same virtual switch.
+
+Three problems, in increasing order of importance:
+
+- **Cost** — 0.733 ms vs 0.153 ms per round trip, plus encryption overhead and a
+  reduced MTU, on traffic that never needed to leave the machine.
+- **A failure mode that did not need to exist** — the overlay path was observed
+  going completely dead for several minutes and then recovering unattended. On
+  the cluster→database path that is a simultaneous outage of every service.
+- **It breaks [decision 7](#7-anything-on-the-startup-path-must-be-local)** — an
+  overlay network depends on a hosted coordination service. A database is on the
+  startup path, so it must not.
+
+**The rule:** *connect components by the most local path that works.* Same host
+→ a host-only bridge. Same LAN → static LAN addresses. Different sites → then,
+and only then, an overlay. Keep the overlay for reaching the platform from
+outside, which is what it is good at.
+
+The trap to recognise: **if you are using an overlay network for its stable
+addressing rather than for its reach, the actual missing piece is addressing.**
+Fix that instead — static addresses, a host-only network, or internal DNS.
+
+---
+
+## Production readiness checklist
+
+| ✔ | Item | Why |
+|---|---|---|
+| ☐ | Secrets generated, no shipped defaults | defaults are published in this repo |
+| ☐ | Secret store outside the cluster | bootstrap + recovery |
+| ☐ | Database outside the cluster, with PITR | dumps alone mean up to 24 h loss |
+| ☐ | **Restore tested**, not just backup run | see #4 |
+| ☐ | Off-site copy of backups | fire/theft/flood |
+| ☐ | Backup-freshness alert | silent failure is the norm |
+| ☐ | Alert rules exist and route somewhere | monitoring ≠ alerting |
+| ☐ | Log collection agent installed | Loki is empty without one |
+| ☐ | Targets outside the cluster monitored | host, DB, storage, backups |
+| ☐ | Registry cache, warmed | restart during an outage |
+| ☐ | Public vs private decided per service | ingress exposes by default |
+| ☐ | Management plane always-on | not a laptop |
+| ☐ | Hosts agree on a timezone | cross-host job ordering |
+| ☐ | Jobs avoid the DST transition hour | a timer can be skipped entirely |
+
+---
+
+## Platform guides
+
+**Two different things are tracked below, and it matters which one you need:**
+
+- **Platform support** — can UIS *provision a cluster* there? (`uis platform up`,
+  host templates, cloud-init)
+- **Production guide** — is there a documented path to the decisions above:
+  state outside the cluster, secrets, backups, alerting, offline capability?
+
+They are independent. A platform can be well supported for development and still
+have no production story — and vice versa.
+
+| Platform | Platform support | Production guide |
+|---|---|---|
+| **Proxmox VE** | ❌ no host template — the cluster is built by hand | ✅ [Available](./proxmox) — the reference deployment |
+| **Azure AKS** | ✅ OpenTofu + scripts + manifests; `uis platform up azure-aks` | ⏳ not yet |
+| **Azure (MicroK8s VM)** | ✅ documented host template | ⏳ not yet |
+| **Google Cloud** | 🟡 cloud-init template only — no platform implementation | ⏳ not yet |
+| **Oracle Cloud (OCI)** | 🟡 cloud-init template only — no platform implementation | ⏳ not yet |
+| **AWS** | ❌ nothing yet | ⏳ not yet |
+| Rancher Desktop | ✅ the development default | n/a — development, not production |
+
+Note the inversion: **Proxmox has a production guide but no provisioning
+support**, while **Azure has provisioning support but no production guide**.
+Closing either gap is useful work; they are separate pieces.
+
+### What a new production guide has to cover
+
+The principles above are platform-independent — a guide only supplies the
+mechanics. Concretely, for each of the [components beside the
+cluster](#components-beside-the-cluster), say which primitive provides it:
+
+| Component | Proxmox (reference) | On a cloud, typically |
+|---|---|---|
+| Database | container + ZFS dataset | managed SQL (RDS / Cloud SQL / Azure Database) |
+| Object storage | container + ZFS dataset | the provider's object store |
+| Secret store | self-hosted vault | the provider's key vault — **but see the caveat below** |
+| Image cache | pull-through registry container | the provider's registry, with caching/replication |
+| Management plane | small always-on container | a small VM, or CI |
+| Infrastructure scheduler | host timers | whatever runs when the cluster does not |
+
+⚠️ **A managed key vault is only appropriate if you accept a hard dependency on
+that provider for cluster startup.** If the deployment must survive provider
+outages, the store has to be local — see
+[decision 7](#7-anything-on-the-startup-path-must-be-local). This is the one
+place where the cloud-native answer and the resilience answer disagree, and it
+should be a deliberate choice per deployment.

--- a/website/docs/production/proxmox.md
+++ b/website/docs/production/proxmox.md
@@ -1,0 +1,221 @@
+---
+title: Proxmox VE
+sidebar_label: Proxmox VE
+sidebar_position: 2
+---
+
+# Production UIS on Proxmox VE
+
+The reference on-premises production deployment: a single Proxmox host running
+one Kubernetes cluster plus the [components beside the cluster](./index#components-beside-the-cluster).
+
+Read [Production overview](./index) first — this page is only the mechanics.
+
+Everything here was built and verified on a real deployment. Where something bit
+us, it is called out as a **⚠️ gotcha** rather than left for you to rediscover.
+
+---
+
+## Topology
+
+| Guest | Type | Purpose |
+|---|---|---|
+| *(host)* | Proxmox VE | hypervisor, ZFS pool, guest backups |
+| `k8s` | VM | the cluster (k3s) |
+| `pg` | LXC | PostgreSQL — outside the cluster |
+| `minio` | LXC | object storage — outside the cluster |
+| `bao` | LXC | secret store — outside the cluster |
+| `registry` | LXC | pull-through image cache — outside the cluster |
+| `ops` | LXC | management plane (provision-host + kubeconfigs) |
+| `nas` | LXC | optional: SMB/NFS file shares |
+
+Containers rather than VMs for the supporting services: lower overhead, and they
+boot in seconds. The cluster itself is a VM — k3s in an LXC is possible but
+fights you over kernel modules and cgroups.
+
+## Storage tiering
+
+With two disks, split them by *purpose*, not size:
+
+| Tier | Disk | Holds | Snapshots? |
+|---|---|---|---|
+| **systems** | fastest/healthiest | guest rootfs, VM system disks, container images | no — rebuildable |
+| **data** | capacity | database, object store, secrets, file shares, backups | yes |
+
+Put the data tier on **ZFS** — snapshots, checksums and compression are what make
+the backup story work. Tune per dataset: `recordsize=16K` for PostgreSQL (matches
+its page size), `1M` for object/blob storage and backup archives.
+
+⚠️ **Kubernetes system disks belong on the systems tier.** Image churn on the data
+disk buys nothing — as a zvol it does not get dataset-level snapshots anyway.
+
+---
+
+## Build sequence
+
+### 1. Host preparation
+
+Update Proxmox, create the ZFS pool, and cap the ARC if guests will use most of
+the RAM (`options zfs zfs_arc_max=…` in `/etc/modprobe.d/zfs.conf`) — otherwise
+ARC and your guests compete.
+
+⚠️ Check the bootloader matches the boot mode. A host booting via EFI with only
+the BIOS GRUB package installed will boot today but silently stop receiving
+bootloader updates.
+
+### 2. Cluster VM
+
+An Ubuntu LTS cloud image plus cloud-init is the fastest path. Then k3s:
+
+```bash
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644" sh -
+```
+
+k3s ships Traefik v3, matching the UIS manifests. It is also what Rancher Desktop
+runs, so development and production behave the same.
+
+⚠️ **Cloud images take their DHCP lease before cloud-init applies the hostname**,
+so DNS registers the host as `ubuntu`. Set the hostname before networking, or
+force a lease renewal afterwards.
+
+### 3. Components beside the cluster
+
+Each in its own container, each with its **data on a tuned ZFS dataset**:
+
+- **PostgreSQL** — install from PGDG for a current version with `pgvector`/`PostGIS`.
+  On ZFS, set `full_page_writes = off`; copy-on-write makes torn pages impossible,
+  so PostgreSQL's own full-page writes are redundant. Keep `pg_wal` in the *same*
+  dataset as the data so a snapshot is atomic and crash-consistent.
+- **Object storage** — MinIO as a systemd service, data on a `recordsize=1M` dataset.
+- **Secret store** — see [secrets](./secrets).
+- **Registry cache** — see step 7.
+
+Expose them on the overlay network so machines outside the cluster (developer
+laptops, workers at other sites) can reach them directly.
+
+#### ⚠️ Making UIS accept an external database
+
+UIS currently assumes PostgreSQL and MinIO run *in* the cluster in two places:
+its dependency check looks for a **Running pod** with a specific label, and some
+playbooks `kubectl exec` **into that pod** to run `psql`. An external database
+satisfies neither.
+
+Until UIS supports an external mode, bridge it with a small in-cluster
+Deployment carrying the expected label:
+
+- **container 1** — a `postgres` image running `sleep infinity`. It must be
+  **first**, because that is where `kubectl exec` lands, and it needs `bash` +
+  `psql`. Set `PGHOST` on it so bare `psql` uses TCP rather than a Unix socket.
+- **container 2** — `socat` forwarding the pod's `:5432` to the real host.
+
+Plus a normal ClusterIP Service selecting it. UIS is then satisfied, playbooks
+work unchanged, and the database stays outside Kubernetes. The same pattern works
+for MinIO (an `mc` container first, socat for `:9000`/`:9001`).
+
+**Do not `uis deploy postgresql` afterwards** — it would replace the bridge.
+
+### 4. Management plane
+
+Install Docker in the `ops` container and run the provision-host there, holding
+kubeconfigs for every target.
+
+⚠️ **Never run `./uis` with `sudo`** — it mounts *root's* `~/.kube` (so the wrong
+kubeconfig) and leaves `.uis.extend` / `.uis.secrets` owned by root.
+
+### 5. Storage classes — request a disk, get a disk
+
+`proxmox-csi-plugin` lets a PVC create a real Proxmox disk and hot-attach it to
+the cluster VM, so services get storage on demand across both tiers:
+
+| Class | Backed by | For |
+|---|---|---|
+| `fast` | systems-tier storage | latency-sensitive workloads, monitoring TSDBs |
+| `standard` *(default)* | data-tier ZFS | general persistent data |
+| `shared` | NFS export from the host | `ReadWriteMany` |
+| `local-path` | node disk | scratch only — not snapshotted |
+
+**Make the backed-up class the default.** UIS service manifests deliberately omit
+`storageClassName` so they inherit the cluster default — one lever then governs
+storage for the whole platform.
+
+⚠️ The node needs `providerID: proxmox://<region>/<vmid>`. k3s sets `k3s://<node>`
+and **providerID is immutable** — set `kubelet-arg: provider-id=…`, restart k3s,
+delete the node object, restart again so it re-registers, then re-apply the
+topology labels.
+
+⚠️ **Prometheus cannot run on NFS** (it needs mmap and POSIX locks) — give it a
+block-backed class.
+
+### 6. Secrets
+
+See the [secrets guide](./secrets). The short version: a store outside the
+cluster, External Secrets Operator inside it, and Kubernetes auth so nothing
+static is stored in the cluster to bootstrap secret access.
+
+### 7. Registry cache
+
+Without it the cluster cannot restart when upstream registries are unreachable.
+See the [registry cache guide](./registry-cache).
+
+### 8. Ingress
+
+Two complementary paths:
+
+- **Private** — an overlay-network ingress for admin UIs. No DNS, no public
+  exposure, no certificates to manage.
+- **Public** — a tunnel to your CDN/edge for the few services that should be
+  reachable, with authentication in front.
+
+⚠️ Some overlay "expose" helpers publish to the **public internet** and **bypass
+the reverse proxy**, so forward-auth middleware does not apply. Read what the
+command actually does before using it for an admin UI.
+
+### 9. Backups — four layers
+
+| Layer | Protects against | Frequency |
+|---|---|---|
+| ZFS snapshots | deletion, bad writes | every 15 min |
+| Database PITR (WAL archiving) | data loss between backups | continuous, RPO ≈ 5 min |
+| Guest backups (`vzdump`) | losing a whole VM/container | nightly, snapshot mode |
+| Off-box copy (restic) | losing the host | nightly |
+
+⚠️ **Order matters, and hosts must agree on a timezone.** A container on UTC and
+a host on local time will run "02:30" and "03:30" jobs three hours apart — with
+the dump landing *after* the backup that was supposed to capture it, so every
+offsite copy is a day stale while both jobs report success.
+
+⚠️ **Avoid scheduling in the DST transition hour** (02:00–03:00 in Europe). At
+spring-forward that hour does not exist and the job is silently skipped.
+
+### 10. Verify the restores
+
+Not optional — see [production overview #4](./index).
+
+- Restore a database dump into a scratch database.
+- Restore a file from the off-box repo and compare it byte-for-byte with the live one.
+- Restore a guest to a spare VMID and boot it.
+  ⚠️ A *privileged* container must be restored with `--unprivileged 0`, or `tar`
+  fails with a uid-mapping error.
+- Do a point-in-time restore into an alternate directory and start a temporary
+  instance on a spare port — this validates PITR without touching production.
+  ⚠️ On Debian, `postgresql.conf` lives in `/etc`, **not** the data directory, so a
+  restored data directory needs a minimal config supplied by hand.
+
+### 11. Observability
+
+Install the stack, then do the part that makes it useful: a log-collection agent,
+alert rules, and scrape targets for the components outside the cluster —
+including backup freshness. See [production overview #5](./index).
+
+---
+
+## What you end up with
+
+- One Kubernetes cluster running the UIS service catalogue.
+- Database, object storage, secrets and image cache **outside** it — each
+  independently restartable, each backed up.
+- Storage on demand across two performance tiers.
+- Private access to admin UIs, public access only where chosen.
+- Four backup layers, **restore-tested**, with point-in-time recovery for the
+  database.
+- A management plane that does not depend on anyone's laptop.

--- a/website/docs/production/registry-cache.md
+++ b/website/docs/production/registry-cache.md
@@ -1,0 +1,86 @@
+---
+title: Registry cache
+sidebar_label: Registry cache
+sidebar_position: 4
+---
+
+# Registry cache
+
+Without a local image cache, a cluster **cannot restart when upstream registries
+are unreachable**. Running pods survive — their layers are already on the node —
+but any restart, reschedule or scale-up fails to pull, and the service stays down.
+
+That is the worst shape of failure: invisible until you need recovery, and it
+bites hardest when something else is already broken.
+
+Two everyday benefits besides outages:
+
+- **Rate limits.** Anonymous pulls from public registries are throttled per IP; a
+  cluster redeploying a stack can hit the limit mid-deploy.
+- **Speed and bandwidth.** Re-deploying a full stack re-pulls gigabytes otherwise
+  — and developer machines can use the same cache.
+
+## It must live outside the cluster
+
+A registry inside the cluster cannot serve the images required to start that
+cluster. After a cold boot the cache's own pod needs an image, which needs the
+cache. (In-cluster peer-to-peer layer sharing is useful for multi-node clusters
+but does not solve cold start.)
+
+## Shape
+
+`registry:2` proxies exactly one upstream, so one instance per registry:
+
+| Port | Upstream |
+|---|---|
+| 5000 | Docker Hub |
+| 5001 | `registry.k8s.io` |
+| 5002 | `ghcr.io` |
+| 5003 | `quay.io` |
+
+Alternatives worth evaluating: `zot` (multiple upstreams in one instance) or
+Harbor (heavier, but garbage collection and auth included).
+
+Point the cluster at them — for k3s, `/etc/rancher/k3s/registries.yaml`:
+
+```yaml
+mirrors:
+  docker.io:
+    endpoint: ["http://<cache-host>:5000"]
+  registry.k8s.io:
+    endpoint: ["http://<cache-host>:5001"]
+```
+
+k3s renders `certs.d/<registry>/hosts.toml` from this on restart. Upstream remains
+the fallback, so the cache fails open.
+
+## ⚠️ Warming the cache — the trap
+
+**`crictl pull` does not warm the cache** when the image is already on the node.
+It is a no-op that never contacts the mirror. On the reference build a warming
+loop reported `pulled ok=41 failed=0` while the cache actually held **four
+repositories**.
+
+Request each image **from the mirror endpoint** instead:
+
+```bash
+skopeo copy --src-tls-verify=false \
+  docker://<cache-host>:5000/library/<image>:<tag> dir:/tmp/warm && rm -rf /tmp/warm
+```
+
+⚠️ Official Docker Hub images need `library/` inserted in the mirror path.
+
+**Verify with `/v2/_catalog`, never with the pull command's exit status.**
+
+## Verify it actually works
+
+The only meaningful test: block internet egress on **both** the cache host and a
+cluster node, remove an image from the node, and pull it again. It should succeed
+from cache. Remember to remove the test firewall rules afterwards.
+
+## Housekeeping
+
+The cache grows as tags churn. `registry:2` needs `REGISTRY_STORAGE_DELETE_ENABLED=true`
+plus a periodic `registry garbage-collect`. The cache is fully reconstructible, so
+it is a reasonable candidate to exclude from offsite backup — and it must be
+re-warmed after deploying new services.

--- a/website/docs/production/secrets.md
+++ b/website/docs/production/secrets.md
@@ -1,0 +1,112 @@
+---
+title: Secrets
+sidebar_label: Secrets
+sidebar_position: 3
+---
+
+# Secrets in production
+
+UIS ships secret **distribution** — templates rendered into one Kubernetes Secret
+applied to every namespace. That is the right shape for a laptop. Production also
+needs secret **management**: a store, encryption at rest, scoped access, audit and
+rotation.
+
+On a real deployment, the developer default measured as: cluster secret encryption
+**disabled**, and one Secret containing **54 keys, base64 only, replicated into 13
+namespaces** — so read access in any namespace yields every credential.
+
+## The shape
+
+```
+backend (per environment)      cloud → managed key vault
+   │                           on-prem → self-hosted store
+   ▼
+External Secrets Operator      identical in both
+   ▼
+ordinary Kubernetes Secret     the application is unchanged
+```
+
+**This is the important property:** an application's manifests are identical in
+cloud and on-premises. Only the `ClusterSecretStore` backend differs — the same
+trick UIS already uses for services.
+
+## Why the store lives outside the cluster
+
+Beyond the general [production principles](./index#1-state-lives-outside-the-cluster):
+you need secrets to *start* a cluster, and to *rebuild* a dead one. A vault inside
+the cluster it protects is circular.
+
+**And for a deployment that must survive provider outages, the store must be local
+too** — a cloud KMS on the startup path means no cloud, no cluster.
+
+## Choosing a store
+
+| Option | Notes |
+|---|---|
+| **OpenBao** | MPL-2.0, Vault-API compatible, light. **Auto-unseal without a cloud KMS** (static key, PKCS#11/TPM). Used for the reference build. |
+| HashiCorp Vault | Same features; BUSL licence — source-available, not OSI open source. |
+| Infisical | Strong UI, MIT core, no seal concept — but documented at 2–4 CPU / 4–8 GB per instance. |
+| SOPS + age | No service at all; excellent for GitOps. No audit, API or dynamic secrets. |
+| Sealed Secrets | Controller key lives **inside** the cluster → fails the bootstrap test. |
+
+⚠️ **Auto-unseal matters more than it looks.** A vault that seals on restart needs
+a human after every power cut. Verify unattended reboot before calling it done.
+
+## Reference build (OpenBao)
+
+1. **Container beside the cluster**, data on a snapshotted dataset.
+2. **Auto-unseal configured before initialising** — otherwise you inherit a Shamir
+   seal and manual unsealing. Then `operator init` with recovery shares.
+3. **Verify by rebooting** and confirming `Sealed: false` with no intervention.
+4. **Kubernetes auth**, so the operator authenticates with its own ServiceAccount
+   token — no static credential stored in the cluster. This is the closest
+   equivalent to a cloud "managed identity".
+5. **External Secrets Operator** + a `ClusterSecretStore`; services then consume
+   ordinary Secrets.
+
+Then a service consumes a secret like this:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+spec:
+  secretStoreRef: { name: <store>, kind: ClusterSecretStore }
+  target: { name: myapp-secrets }
+  data:
+    - secretKey: API_KEY
+      remoteRef: { key: myapp, property: api_key }
+```
+
+## Restrict the network
+
+A vault on a flat LAN is reachable by every device on it. Enable TLS (with the
+service IP in the certificate SANs) and firewall the API to the hosts that need
+it. If peers share an L2 segment, match on **MAC as well as IP** — that survives
+DHCP changes without router configuration.
+
+⚠️ Putting the vault on an overlay network **without ACLs** is worse than a
+restricted LAN: every node on the overlay can then reach it.
+
+## What developers see: nothing
+
+Secrets fall into three groups and developers meet only one:
+
+| Group | Source | Developer sees it? |
+|---|---|---|
+| App credentials | `uis configure <svc> --app <name>` — minted **per environment**, never promoted | yes, as connection JSON |
+| Platform secrets | the vault | no |
+| Third-party app secrets | today, the values template | sometimes |
+
+Local development is unchanged: no vault to install, no login, offline work still
+possible. This mirrors cloud practice — nobody runs a managed key vault on a laptop.
+
+The one genuine change is where a *production* third-party API key goes, which is
+the natural place for a future `uis secret set` command.
+
+## Operating it
+
+- Rotation is always two parts: change the credential in the owning system, then
+  update the store. **The store does not rotate anything for you.**
+- The recovery keys are the one artifact that must live **outside every machine** —
+  a password manager or paper.
+- Revoke the initial root token once setup is complete.


### PR DESCRIPTION
These ten files existed only in the working tree of a machine whose root
filesystem failed on 2026-08-06. Committing them so they survive.

Investigations (findings from building a production deployment on Proxmox):
- system-observability: the stack deploys but cannot alert; zero rules, no log
  agent, nothing outside the cluster scraped
- system-registry-cache: the cluster cannot restart offline without a
  pull-through cache, and crictl pull does not warm one
- system-backup-and-scheduling: UIS deploys six stateful services and has
  neither a backup capability nor a scheduling primitive
- cli-stack-profiles and service-grafana-optional-datasources: authored by the
  agent working on the iMac, included here so its work is not lost with the host

New docs/production section: the seven decisions that separate a production
deployment from the developer default, the dev/prod parity contract, a
Proxmox reference guide, the secrets guide, and the registry cache guide.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR