### PR TITLE
Fail the LiteLLM deploy when the database schema was not created

### DIFF
--- a/ansible/playbooks/210-setup-litellm.yml
+++ b/ansible/playbooks/210-setup-litellm.yml
@@ -252,6 +252,108 @@
       ansible.builtin.debug:
         var: litellm_service.stdout_lines
 
+    # ---- schema verification & repair -------------------------------------
+    # The chart's migration Job reports Completed even when prisma fails with
+    # P1000, so a fresh install can end with an empty database while every
+    # other check passes. Verify the schema really exists; repair it if not;
+    # fail loudly rather than printing SUCCESS over a broken install.
+    - name: 20a. Read LiteLLM DB password from the ai secret
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ merged_kubeconf_file }}"
+        api_version: v1
+        kind: Secret
+        namespace: "{{ ai_namespace }}"
+        name: urbalurba-secrets
+      register: litellm_ai_secret
+      no_log: true
+
+    - name: 20b. Count tables in the litellm schema
+      ansible.builtin.shell: |
+        kubectl exec -n default deploy/postgresql -c postgresql -- \
+          env PGPASSWORD="$PGPW" psql -h postgresql.default.svc.cluster.local \
+          -U litellm -d litellm -tAc \
+          "select count(*) from information_schema.tables where table_schema='public'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+        PGPW: "{{ litellm_ai_secret.resources[0].data.LITELLM_POSTGRESQL__PASSWORD | b64decode }}"
+      register: litellm_table_count
+      changed_when: false
+      failed_when: false
+
+    - name: 20c. Display schema state
+      ansible.builtin.debug:
+        msg: "LiteLLM schema tables found: {{ litellm_table_count.stdout | default('0') | trim }}"
+
+    - name: 20d. Repair schema when migrations did not apply
+      ansible.builtin.shell: |
+        POD=$(kubectl get pod -n {{ ai_namespace }} -l app.kubernetes.io/name=litellm -o name | head -1)
+        SCHEMA=$(kubectl exec -n {{ ai_namespace }} "$POD" -- sh -c \
+          'find / -name schema.prisma -path "*litellm_proxy_extras*" 2>/dev/null | head -1' | tr -d '\r')
+        echo "repairing with schema: $SCHEMA"
+        kubectl exec -n {{ ai_namespace }} "$POD" -- prisma migrate deploy --schema "$SCHEMA"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: litellm_schema_repair
+      when: (litellm_table_count.stdout | default('0') | trim | int) < 50
+
+    - name: 20e. Re-count tables after repair
+      ansible.builtin.shell: |
+        kubectl exec -n default deploy/postgresql -c postgresql -- \
+          env PGPASSWORD="$PGPW" psql -h postgresql.default.svc.cluster.local \
+          -U litellm -d litellm -tAc \
+          "select count(*) from information_schema.tables where table_schema='public'"
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+        PGPW: "{{ litellm_ai_secret.resources[0].data.LITELLM_POSTGRESQL__PASSWORD | b64decode }}"
+      register: litellm_table_count_after
+      changed_when: false
+      failed_when: false
+      when: litellm_schema_repair.changed | default(false)
+
+    - name: 20f. Restart LiteLLM so it picks up the repaired schema
+      ansible.builtin.command: >
+        kubectl rollout restart deployment/litellm -n {{ ai_namespace }}
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      when: litellm_schema_repair.changed | default(false)
+
+    # Without this the playbook returns while the new pod is still starting,
+    # so anything that immediately queries /v1/models gets an empty list.
+    - name: 20f2. Wait for the restarted deployment to become ready
+      ansible.builtin.command: >
+        kubectl rollout status deployment/litellm -n {{ ai_namespace }} --timeout=240s
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: litellm_rollout_wait
+      changed_when: false
+      when: litellm_schema_repair.changed | default(false)
+
+    - name: 20f3. Wait for the API to actually answer
+      ansible.builtin.shell: |
+        kubectl run apiready-$RANDOM -n {{ ai_namespace }} --rm -i --restart=Never \
+          --image=curlimages/curl:latest --quiet -- \
+          curl -s -o /dev/null -w '%{http_code}' -m 10 \
+          http://litellm.{{ ai_namespace }}.svc.cluster.local:4000/v1/models </dev/null
+      environment:
+        KUBECONFIG: "{{ merged_kubeconf_file }}"
+      register: litellm_api_ready
+      until: litellm_api_ready.stdout is search('200|401')
+      retries: 20
+      delay: 6
+      changed_when: false
+      when: litellm_schema_repair.changed | default(false)
+
+    - name: 20g. FAIL if the database schema is still missing
+      ansible.builtin.fail:
+        msg: >-
+          LiteLLM database schema was not created. Tables found:
+          {{ (litellm_table_count_after.stdout | default(litellm_table_count.stdout) | default('0')) | trim }}.
+          The proxy will appear to work (models come from the ConfigMap) but
+          virtual keys and spend tracking will fail silently.
+          Check: kubectl logs -n {{ ai_namespace }} -l app.kubernetes.io/name=litellm | grep P1000
+      when: >-
+        ((litellm_table_count_after.stdout | default(litellm_table_count.stdout) | default('0')) | trim | int) < 50
+
     - name: 21. Display final status
       ansible.builtin.debug:
         msg:

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-service-litellm-install-reliability.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-service-litellm-install-reliability.md
@@ -1,0 +1,237 @@
+# Investigate: `uis deploy litellm` reports success on a broken install
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Make `uis deploy litellm` produce a working install every time from a
+clean state, and make it fail loudly when it does not.
+
+**Last Updated**: 2026-08-06
+
+**Verified on**: Proxmox host `odin` / k3s `asgard`, PostgreSQL 18 running
+**outside** the cluster, LiteLLM 1.97.0
+
+---
+
+## Questions to Answer
+
+1. Does `uis deploy litellm` work on a genuinely clean install?
+2. If not, why — and why does the playbook report success?
+3. Can the install be made deterministic?
+4. Is UIS deploying a version of LiteLLM we can reproduce?
+
+---
+
+## Current State
+
+`uis deploy litellm` exits 0, prints `✅ SUCCESS - LiteLLM is running and
+verified`, and registers the service for autostart. `/v1/models` answers.
+
+On a clean install none of that means the install worked.
+
+---
+
+## Findings
+
+### F1 — ⚠️ UIS cannot test its own clean install
+
+`210-remove-litellm.yml` line 10:
+
+```
+# Note: The PostgreSQL database 'litellm' is NOT deleted.
+```
+
+`uis undeploy litellm` removes the Helm release and the ConfigMap but leaves the
+database and role. **Every reinstall after the first is therefore an upgrade
+onto an existing schema**, which hides first-install failures completely. This
+finding is what made the rest of the investigation possible: the bug is
+invisible until the database is dropped by hand.
+
+The utility playbook `u10-litellm-create-postgres.yml` already implements
+`-e operation=delete` (drop database, drop role, terminate connections). The
+remove playbook simply never calls it.
+
+### F2 — On a truly clean install, the schema is never created
+
+With the database and role dropped first:
+
+```
+PLAY RECAP  ...  failed=0        <- UIS reports success
+tables in litellm db : 0         <- schema never created
+models exposed       : 0
+virtual key          : FAIL
+```
+
+The proxy still serves `/v1/models` because **the model list comes from the
+`ai-models-litellm` ConfigMap, not from the database**. So every check UIS
+performs passes while virtual keys, spend tracking and budgets are silently
+dead. This is the same end state previously seen on the Rancher Desktop host,
+where the database was found with zero tables and had to be repaired by hand.
+
+### F3 — The cause is not credentials, ordering, or a race
+
+The chart's migration Job fails with:
+
+```
+Error: P1000: Authentication failed against database server at
+`postgresql.default.svc.cluster.local`, the provided database credentials
+for `litellm` are not valid.
+LiteLLM Proxy: Database migration failed but continuing startup.
+```
+
+Each of these was tested and ruled out:
+
+| Hypothesis | Test | Result |
+|---|---|---|
+| Wrong password | `psql` from a pod with the exact secret value | **AUTH OK** |
+| Unexpanded `$(VAR)` in DATABASE_URL | read the resolved value inside the pod | correct user, 24-char password, correct host |
+| URL-unsafe characters in the password | charset check | alphanumeric only |
+| Secrets applied after the DB step | inspect deploy log ordering | secrets → DB → helm, correct |
+| Role created too late (race) | pre-create DB+role, verify `AUTH OK`, *then* deploy | **still 0 tables** |
+
+And `prisma migrate deploy` run by hand **inside the same pod, with the same
+environment, succeeds every time.**
+
+The failure is also **intermittent** — across five clean cycles the Job produced
+4 × P1000 twice and 0 × P1000 twice. Prime remaining suspect is Prisma's own
+warning, emitted immediately before the failure:
+
+```
+prisma:warn Prisma doesn't know which engines to download for the
+Linux distro "wolfi". Falling back to ...
+```
+
+i.e. an upstream image/engine problem, not a UIS configuration problem. **Root
+cause is not yet proven**, which is why the chosen fix is to detect and repair
+rather than to "correct the credentials".
+
+### F4 — The playbook declares success unconditionally
+
+Task 21 prints `✅ SUCCESS - LiteLLM is running and verified` with no `when:`
+condition, including the lines "API responding: ✅ Models loaded and verified".
+Task 9 (service connectivity) carries `ignore_errors: true`. Nothing anywhere
+checks that the database schema exists.
+
+### F5 — The playbook returns before the service is ready
+
+There is no wait between the rollout and the end of the play, so a caller that
+immediately queries `/v1/models` gets an empty list from a pod that is still
+starting. Observed repeatedly as `models exposed : 0` on an otherwise healthy
+install.
+
+### F6 — The image is an unpinned rolling tag
+
+`220-litellm-config.yaml`:
+
+```yaml
+image:
+  repository: ghcr.io/berriai/litellm-database
+  tag: "main-latest"          # <- rolling main-branch build
+  pullPolicy: Always
+```
+
+This currently resolves to **LiteLLM 1.97.0**, while the latest *stable* upstream
+release is **v1.95.0**. So UIS is not behind — it is running pre-release code
+from the main branch, and **the version can change on any pod restart**. The
+Helm chart is likewise unpinned (`helm show chart oci://...` with no `--version`).
+This breaks reproducibility and the dev/prod parity promise: two installs a week
+apart are not the same platform.
+
+The tag also carries a stale comment: `# Back to latest - should have the fix`.
+
+### F7 — The default ConfigMap is Docker-Desktop-only
+
+When no `ai-models-litellm` ConfigMap exists, task 3.1 creates one pointing at:
+
+```yaml
+api_base: "http://host.docker.internal:11434"
+```
+
+`host.docker.internal` resolves under Docker Desktop / Rancher Desktop and
+**nowhere else**. On a real k3s node the default model is unreachable, so a
+first-time install on a server has a model list that cannot answer.
+
+### F8 — Model verification reads the wrong ConfigMap
+
+Task 13 reads a ConfigMap named `litellm-config`, but tasks 3/3.1 create
+`ai-models-litellm`. Guarded by `when: litellm_configmap.resources | length > 0`,
+so it silently skips and the "expected model count" check never runs.
+
+---
+
+## How to reproduce
+
+`uis undeploy` is not sufficient — the database must be dropped:
+
+```bash
+# 1. remove the release
+./uis undeploy litellm
+
+# 2. drop what undeploy leaves behind (see F1)
+psql -c "drop database if exists litellm"
+psql -c "drop role if exists litellm"
+
+# 3. reinstall
+./uis deploy litellm
+
+# 4. the check UIS does not do
+psql -d litellm -c "select count(*) from information_schema.tables
+                    where table_schema='public'"   # -> 0 on a failed install
+```
+
+A working install has **69+ tables**.
+
+---
+
+## Options
+
+### Option A: Fix the credentials passed to the migration Job
+
+**Pros:** addresses a root cause, if that is the root cause.
+**Cons:** the credentials were proven correct (F3). There is nothing to fix, and
+the failure is intermittent and appears to originate in the upstream image.
+
+### Option B: Detect and repair — verify the schema, run the migration if absent, fail loudly if it cannot be created
+
+**Pros:** deterministic outcome regardless of the upstream cause; turns a silent
+failure into either a working install or a loud error; the repair
+(`prisma migrate deploy` in-pod) is proven to work every time.
+**Cons:** treats a symptom; carries an extra step that becomes dead code if
+upstream is fixed.
+
+### Option C: Wait for upstream
+
+**Pros:** no local change.
+**Cons:** ships a platform whose database silently does not initialise.
+
+---
+
+## Recommendation
+
+**Option B**, plus the independent defects F1, F5, F6, F7, F8.
+
+Detect-and-repair is the right call even though it is not a root-cause fix,
+because the verification step is *itself* missing functionality: no UIS service
+currently checks that the database it depends on was actually initialised. The
+repair is a bonus; the check is the real deliverable. If upstream later fixes
+the Job, the check stays valuable and the repair simply never fires.
+
+**Generalises beyond LiteLLM:** every UIS service backed by a database has this
+same blind spot. Worth considering a shared post-install schema assertion.
+
+---
+
+## Next Steps
+
+- [x] Create `PLAN-service-litellm-001-schema-verify.md` — verify/repair/fail loudly
+- [ ] Create `PLAN-service-litellm-002-version-pinning.md` — pin chart + image
+- [ ] Create `PLAN-service-litellm-003-undeploy-purge.md` — allow a true clean removal
+- [ ] Create `PLAN-service-litellm-004-config-portability.md` — F7 + F8
+
+**Related:**
+[INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md) —
+a failing install that reports success is the same class of problem as a
+monitoring stack that cannot alert.

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-litellm-002-version-pinning.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-litellm-002-version-pinning.md
@@ -1,0 +1,124 @@
+# Fix: pin the LiteLLM chart and image to reproducible versions
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Two installs of the same UIS revision must deploy the same LiteLLM.
+
+**Investigation**: [INVESTIGATE-service-litellm-install-reliability.md](./INVESTIGATE-service-litellm-install-reliability.md)
+
+**Priority**: High
+
+**Last Updated**: 2026-08-06
+
+---
+
+## Problem
+
+`manifests/220-litellm-config.yaml` pins nothing:
+
+```yaml
+image:
+  repository: ghcr.io/berriai/litellm-database
+  tag: "main-latest"          # rolling main-branch build
+  pullPolicy: Always
+```
+
+and `210-setup-litellm.yml` installs the chart with no `--version`.
+
+Consequences:
+
+- `main-latest` is **pre-release code from the main branch**. It currently
+  resolves to LiteLLM **1.97.0** while the newest stable release is **v1.95.0**.
+- With `pullPolicy: Always`, **any pod restart can silently change the version**
+  — including a restart triggered by an unrelated node event.
+- A developer on Rancher Desktop and a production cluster installed a week apart
+  are running different code. This breaks the parity promise directly.
+- Reproducing a bug report becomes guesswork, because "which version" has no
+  answer.
+
+The tag also carries a stale debugging comment: `# Back to latest - should have
+the fix`.
+
+---
+
+## Solution
+
+Pin both the chart and the image to explicit stable versions, in one place, with
+a documented procedure for moving them.
+
+---
+
+## Phase 1: Pin
+
+### Tasks
+
+- [ ] 1.1 Determine the newest stable LiteLLM release and the matching
+      `litellm-helm` chart version (stable = no `-rc`/`-dev` suffix)
+- [ ] 1.2 Replace `tag: "main-latest"` with the stable image tag in
+      `manifests/220-litellm-config.yaml`; remove the stale comment
+- [ ] 1.3 Change `pullPolicy: Always` to `IfNotPresent` — with a fixed tag,
+      `Always` only adds a registry round trip and a failure mode when the
+      registry is unreachable (relevant to offline restart, see the registry
+      cache investigation)
+- [ ] 1.4 Add `--version <chart-version>` to the `helm upgrade --install` command
+      in `210-setup-litellm.yml`
+- [ ] 1.5 Record both versions in a comment at the top of the values file, with
+      the date they were chosen
+
+### Validation
+
+```bash
+kubectl get deploy litellm -n ai \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+# -> ghcr.io/berriai/litellm-database:<pinned tag>, not main-latest
+
+helm list -n ai   # chart version matches the pin
+```
+
+User confirms the pinned version deploys and serves models.
+
+---
+
+## Phase 2: Make upgrading deliberate
+
+### Tasks
+
+- [ ] 2.1 Document the upgrade procedure: how to find the current stable
+      release, how to bump both pins together, how to roll back
+- [ ] 2.2 Note the constraint that image and chart versions must be moved
+      together, since chart values keys can change between majors
+
+### Validation
+
+User confirms the procedure is followable without reading the chart source.
+
+---
+
+## Acceptance Criteria
+
+- [ ] No rolling tags (`main-latest`, `latest`) anywhere in the LiteLLM manifests
+- [ ] The Helm install specifies an explicit chart version
+- [ ] A pod restart cannot change the running version
+- [ ] The upgrade path is documented
+- [ ] `pullPolicy` is appropriate for a fixed tag
+
+---
+
+## Implementation Notes
+
+Worth checking whether other services carry the same problem before closing
+this out — the fix is per-service, but the *policy* ("no rolling tags in
+manifests") should be uniform. There is an existing
+`INVESTIGATE-system-version-pinning.md` in the backlog; this plan should be
+reconciled with it rather than duplicating it.
+
+---
+
+## Files to Modify
+
+- `manifests/220-litellm-config.yaml`
+- `ansible/playbooks/210-setup-litellm.yml`

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-litellm-003-undeploy-purge.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-litellm-003-undeploy-purge.md
@@ -1,0 +1,122 @@
+# Feature: let `uis undeploy` remove the database it created
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Make a genuinely clean reinstall possible, so install bugs cannot hide
+behind leftover state.
+
+**Investigation**: [INVESTIGATE-service-litellm-install-reliability.md](./INVESTIGATE-service-litellm-install-reliability.md)
+
+**Priority**: Medium
+
+**Last Updated**: 2026-08-06
+
+---
+
+## Problem
+
+`210-remove-litellm.yml` states plainly:
+
+```
+# Note: The PostgreSQL database 'litellm' is NOT deleted.
+```
+
+Keeping user data by default is the right instinct. The problem is that there is
+**no supported way to remove it**, which means:
+
+- **Install bugs are unfalsifiable.** Every reinstall after the first lands on an
+  existing schema, so a broken first-install path stays hidden. This is exactly
+  how finding F2 went unnoticed — the failure only became visible after dropping
+  the database by hand.
+- Testing an install requires knowing the internals: which database, which role,
+  and that `u10-litellm-create-postgres.yml` already has a `delete` mode.
+- The same gap applies to every UIS service with a database.
+
+The capability already exists and is simply never invoked: `u10` implements
+`-e operation=delete`, which terminates connections, drops the database and
+drops the role.
+
+---
+
+## Solution
+
+Add an explicit, opt-in purge. Never the default.
+
+---
+
+## Phase 1: Purge flag
+
+### Tasks
+
+- [ ] 1.1 Add a `--purge` (or `-e purge_data=true`) option to
+      `uis undeploy litellm`
+- [ ] 1.2 When set, call
+      `utility/u10-litellm-create-postgres.yml -e operation=delete`
+- [ ] 1.3 Require confirmation unless a `--force`/non-interactive flag is given —
+      `u10` already has `1.10-FORCE. Skip confirmation for automated deletion`
+- [ ] 1.4 Update the removal summary so it states what *was* deleted, replacing
+      the current unconditional "database was NOT deleted" line
+- [ ] 1.5 Make the default path (no flag) print how to purge, so the option is
+      discoverable
+
+### Validation
+
+```bash
+./uis undeploy litellm --purge
+psql -c "select 1 from pg_database where datname='litellm'"  # -> no rows
+psql -c "select 1 from pg_roles    where rolname='litellm'"  # -> no rows
+./uis deploy litellm
+psql -d litellm -c "select count(*) from information_schema.tables
+                    where table_schema='public'"             # -> 69+
+```
+
+User confirms a clean reinstall works end to end.
+
+---
+
+## Phase 2: Generalise
+
+### Tasks
+
+- [ ] 2.1 Identify the other UIS services that create databases
+      (postgresql-backed: authentik, temporal, openwebui, …)
+- [ ] 2.2 Decide whether `--purge` becomes a standard `uis undeploy` option
+      rather than a per-service one
+- [ ] 2.3 Document the convention in the service-authoring guide
+
+### Validation
+
+User confirms the approach is consistent across services.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uis undeploy litellm` still preserves data by default
+- [ ] `--purge` removes database and role, with confirmation
+- [ ] A purge followed by a deploy yields a fully populated schema
+- [ ] The removal output tells the truth about what was and was not deleted
+- [ ] Non-interactive use is possible for CI/testing
+
+---
+
+## Implementation Notes
+
+This is the plan that makes the others testable. Without it, verifying
+`PLAN-001` required a hand-written teardown that drops the database out-of-band.
+Worth doing early even though it is rated Medium.
+
+⚠️ Purge is destructive and irreversible. It must never be implied by
+`undeploy` alone, and must not be reachable by a typo — prefer a long flag over
+a short one.
+
+---
+
+## Files to Modify
+
+- `ansible/playbooks/210-remove-litellm.yml`
+- the `uis` CLI undeploy verb (argument parsing + help text)

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-litellm-004-config-portability.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-litellm-004-config-portability.md
@@ -1,0 +1,133 @@
+# Fix: default LiteLLM config only works on Docker Desktop
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: A first-time `uis deploy litellm` should produce a usable model list on
+any cluster, and the playbook's model check should actually run.
+
+**Investigation**: [INVESTIGATE-service-litellm-install-reliability.md](./INVESTIGATE-service-litellm-install-reliability.md)
+
+**Priority**: Medium
+
+**Last Updated**: 2026-08-06
+
+---
+
+## Problem
+
+Two independent defects in the same area.
+
+### F7 — `host.docker.internal` in the default ConfigMap
+
+When no `ai-models-litellm` ConfigMap exists, task 3.1 creates one containing:
+
+```yaml
+- model_name: llama3.2
+  litellm_params:
+    model: ollama_chat/llama3.2
+    api_base: "http://host.docker.internal:11434"
+```
+
+`host.docker.internal` is a Docker Desktop / Rancher Desktop convenience name. On
+a real k3s node it does not resolve. A first install on a server therefore ends
+with exactly one model, which cannot answer — while `/v1/models` still lists it,
+so the failure only appears at inference time.
+
+This is a dev-only assumption baked into the default path: the same class of
+problem as the Traefik v2/v3 mismatch, where the developer environment and the
+server environment quietly diverge.
+
+### F8 — The model verification task reads the wrong ConfigMap
+
+Task 13 reads a ConfigMap named `litellm-config`:
+
+```yaml
+name: litellm-config
+```
+
+but tasks 3 and 3.1 create **`ai-models-litellm`**. The task is guarded by
+`when: litellm_configmap.resources | length > 0`, so it finds nothing, skips
+silently, and the "expected model count" comparison in tasks 14–15 never runs.
+A verification step that never executes is worse than no verification, because
+the play still prints "Models loaded and verified".
+
+---
+
+## Solution
+
+Make the default portable and honest, and fix the ConfigMap reference so the
+existing check does its job.
+
+---
+
+## Phase 1: Portable default
+
+### Tasks
+
+- [ ] 1.1 Decide the default behaviour when no model ConfigMap exists. Options:
+      (a) ship no models and say so clearly, (b) detect Rancher Desktop and only
+      then use `host.docker.internal`, (c) ship a commented-out example
+- [ ] 1.2 Implement the chosen default in task 3.1
+- [ ] 1.3 Make the deploy output state plainly when the model list is empty or
+      placeholder-only, and how to supply a real one
+- [ ] 1.4 Document the "apply your ConfigMap *before* `uis deploy litellm`"
+      pattern — the playbook only creates a default when one is absent, which is
+      the supported way to keep a custom model list across redeploys
+
+### Validation
+
+```bash
+./uis deploy litellm      # on a non-Docker-Desktop cluster
+# default model list is either empty-and-stated, or reachable
+```
+
+User confirms a first install on a server is not silently broken.
+
+---
+
+## Phase 2: Fix the model check
+
+### Tasks
+
+- [ ] 2.1 Change task 13 to read `ai-models-litellm`
+- [ ] 2.2 Confirm tasks 14–15 now compare expected vs actual model names
+- [ ] 2.3 Decide whether a mismatch should warn or fail; given the pattern in
+      this investigation, prefer failing over printing SUCCESS
+
+### Validation
+
+```bash
+./uis deploy litellm
+# task 15 output lists the models from ai-models-litellm and compares them
+```
+
+User confirms the check runs and reports real numbers.
+
+---
+
+## Acceptance Criteria
+
+- [ ] No `host.docker.internal` on a code path that runs on a server
+- [ ] A first install either has working models or says clearly that it has none
+- [ ] Task 13 reads the ConfigMap that actually exists
+- [ ] The model count comparison executes rather than skipping
+- [ ] The pre-apply pattern for custom model lists is documented
+
+---
+
+## Implementation Notes
+
+Recommend option (a) for Phase 1.1 — ship no models and say so. A placeholder
+that looks like a model but cannot answer is the same silent-success pattern
+this whole investigation is about. An empty list with a clear message is honest
+and immediately actionable.
+
+---
+
+## Files to Modify
+
+- `ansible/playbooks/210-setup-litellm.yml` (tasks 3.1 and 13)

--- a/website/docs/ai-developer/plans/completed/PLAN-service-litellm-001-schema-verify.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-service-litellm-001-schema-verify.md
@@ -1,0 +1,138 @@
+# Fix: verify the LiteLLM database schema, repair it, and fail loudly
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Completed
+
+**Goal**: `uis deploy litellm` must never report success when the database
+schema was not created.
+
+**Investigation**: [INVESTIGATE-service-litellm-install-reliability.md](./INVESTIGATE-service-litellm-install-reliability.md)
+
+**Priority**: High
+
+**Last Updated**: 2026-08-06
+
+**Completed**: 2026-08-06
+
+---
+
+## Problem
+
+On a clean install the chart's migration Job fails with `P1000` and exits
+`Completed` anyway. The playbook never checks the schema, so the deploy reports
+`✅ SUCCESS` with an empty database. The proxy appears healthy because models are
+served from the ConfigMap, but virtual keys, spend tracking and budgets fail
+silently. See findings F2–F4 in the investigation.
+
+## Solution
+
+Add a verification block at the end of `210-setup-litellm.yml` that:
+
+1. counts tables in the `litellm` schema,
+2. runs `prisma migrate deploy` inside the pod if the schema is missing,
+3. restarts the deployment and waits for it to serve,
+4. **fails the play** if the schema is still absent.
+
+Deliberately *not* attempting to fix the credentials — they were proven correct
+(F3). This detects and repairs an upstream failure whose root cause is not yet
+established.
+
+---
+
+## Phase 1: Verification and repair — ✅ DONE
+
+### Tasks
+
+- [x] 1.1 Add task `20a` — read the LiteLLM DB password from `urbalurba-secrets`
+      in the `ai` namespace (`no_log: true`)
+- [x] 1.2 Add task `20b` — count tables via `kubectl exec` into the `postgresql`
+      pod's first container (which carries `psql`); pass the password through the
+      task `environment` rather than the command line
+- [x] 1.3 Add task `20c` — display the table count
+- [x] 1.4 Add task `20d` — when fewer than 50 tables, locate
+      `litellm_proxy_extras/schema.prisma` in the pod and run
+      `prisma migrate deploy`
+- [x] 1.5 Add task `20e` — re-count after repair
+- [x] 1.6 Add task `20f` — restart the deployment so it picks up the schema
+- [x] 1.7 Add task `20g` — `ansible.builtin.fail` with an actionable message if
+      the schema is still missing
+
+### Validation
+
+```bash
+psql -d litellm -c "select count(*) from information_schema.tables
+                    where table_schema='public'"   # -> 69+
+```
+
+---
+
+## Phase 2: Readiness — ✅ DONE
+
+Discovered during Phase 1 validation: the play returned while the restarted pod
+was still starting, so an immediate `/v1/models` query returned an empty list
+(finding F5).
+
+### Tasks
+
+- [x] 2.1 Add task `20f2` — `kubectl rollout status --timeout=240s` after the
+      restart
+- [x] 2.2 Add task `20f3` — poll `/v1/models` until it answers `200` or `401`
+      (retries: 20, delay: 6)
+
+### Validation
+
+Five consecutive clean cycles report 5 models rather than 0.
+
+---
+
+## Acceptance Criteria
+
+- [x] A clean install (database and role dropped) produces a populated schema
+- [x] The play fails, rather than printing SUCCESS, when the schema cannot be created
+- [x] `/v1/models` answers before the play returns
+- [x] Virtual key generation works after install
+- [x] Repeatable across multiple clean cycles
+
+---
+
+## Verification performed
+
+Five full teardown → install cycles, each starting from
+`drop database litellm; drop role litellm`:
+
+| | schema | serving-pod auth errors | models | completion |
+|---|---|---|---|---|
+| run 1 | 69 tables ✅ | 0 | 5 | `'CLEAN'` |
+| run 2 | 69 tables ✅ | 0 | 5 | `'CLEAN'` |
+| run 3 | 77 tables ✅ | 0 | 5 | `'CLEAN'` |
+| run 4 | 69 tables ✅ | 0 | 5 | `'CLEAN'` |
+| run 5 | 77 tables ✅ | 0 | 5 | `'CLEAN'` |
+
+Before the fix the same procedure produced `0 tables` with `failed=0`.
+
+The upstream migration Job still logs `P1000` on some runs (4 occurrences in two
+of the five cycles, 0 in the others). Task `20d` repairs it; the **serving pod**
+has zero auth errors in all runs. Table counts differ (69 vs 77) depending on
+whether the upstream Job succeeded before the repair ran — both are complete
+schemas.
+
+---
+
+## Implementation Notes
+
+- The `postgresql` shim's **first** container is `postgres:18` and carries
+  `psql`, which is what makes the table count possible without adding an image.
+- The password is passed via the task `environment:` (`PGPW`), never as a
+  command-line argument, so it does not appear in process listings.
+- The 50-table threshold distinguishes "no schema" from "complete schema"
+  (69+) without being brittle about the exact count, which grows with each
+  upstream migration.
+
+---
+
+## Files to Modify
+
+- `ansible/playbooks/210-setup-litellm.yml`


### PR DESCRIPTION
On a clean install `uis deploy litellm` reported success while the database
was empty. The chart's migration Job fails with P1000 and still exits
Completed, and the playbook never checked the schema. The proxy looks healthy
because models come from the ai-models-litellm ConfigMap rather than the
database, so virtual keys, spend tracking and budgets failed silently.

This was invisible until now because `uis undeploy` deliberately keeps the
database, so every reinstall after the first landed on an existing schema.

Add tasks 20a-20g to 210-setup-litellm.yml:
- count tables in the litellm schema
- run `prisma migrate deploy` in-pod when the schema is missing
- restart, wait for the rollout, and poll /v1/models until it answers
- fail the play, instead of printing SUCCESS, if the schema is still absent

Credentials were ruled out as the cause: the exact secret authenticates from a
pod, the URL resolves correctly, ordering is right, and pre-creating the role
does not help. The upstream Job failure is intermittent and preceded by
Prisma's "unknown engines for Linux distro wolfi" warning, so this detects and
repairs rather than claiming a root-cause fix.

Verified across five teardown/install cycles from a fully clean state
(database and role dropped): schema populated every time, serving pod free of
auth errors, models listed, completions served. Before the change the same
procedure produced 0 tables with failed=0.

Also adds the investigation and the remaining plans it produced:
version pinning (the image is the rolling main-latest tag), an undeploy purge
option so clean installs can be tested, and default-config portability
(host.docker.internal, plus a verification task reading the wrong ConfigMap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR