### PR TITLE
Rescue the Mac Ollama operational notes from the failed iMac

### DIFF
--- a/hosts/mac-ollama/README-cpu-limitation.md
+++ b/hosts/mac-ollama/README-cpu-limitation.md
@@ -1,0 +1,166 @@
+# pgvector does not work on this host (CPU limitation)
+
+## Symptom
+
+Open WebUI crash-loops at startup, and **all of PostgreSQL restarts with it**:
+
+```
+open-webui-0   0/1   Error   3 (61s ago)
+```
+
+Open WebUI log:
+
+```
+sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
+server closed the connection unexpectedly
+[SQL: CREATE INDEX IF NOT EXISTS idx_document_chunk_vector
+      ON document_chunk USING ivfflat (vector vector_cosine_ops) WITH (lists = 100)]
+```
+
+PostgreSQL log (`kubectl logs postgresql-0 -n default`):
+
+```
+LOG:  client backend (PID 4838) was terminated by signal 4: Illegal instruction
+DETAIL:  Failed process was running: CREATE INDEX ... USING ivfflat (...)
+LOG:  terminating any other active server processes
+LOG:  all server processes terminated; reinitializing
+```
+
+## Root cause
+
+This host's CPU is an **Intel Core i5-2400S** (Sandy Bridge, 2011). It has SSE4.2
+and AVX, but **no AVX2 and no FMA**.
+
+The pgvector 0.8.2 build shipped in the Bitnami PostgreSQL image compiles its
+distance functions for a newer instruction set. Executing them raises SIGILL
+(signal 4, illegal instruction).
+
+This is not an index-tuning problem. It is not memory. Verified at the lowest
+possible level — the vector *type* works, but every distance *operator* kills
+the backend:
+
+```bash
+PGPW=$(kubectl get secret urbalurba-secrets -n default -o jsonpath='{.data.PGPASSWORD}' | base64 -d)
+
+# works - type parsing is plain C
+kubectl exec -n default postgresql-0 -- env PGPASSWORD="$PGPW" \
+  psql -U postgres -d openwebui -tAc "SELECT '[1,2,3]'::vector"
+# -> [1,2,3]
+
+# crashes the server - SIMD distance kernel
+kubectl exec -n default postgresql-0 -- env PGPASSWORD="$PGPW" \
+  psql -U postgres -d openwebui -tAc "SELECT '[1,2,3]'::vector <-> '[4,5,6]'::vector"
+# -> server closed the connection unexpectedly
+```
+
+Because a SIGILL in any backend forces the postmaster to terminate *all*
+connections and reinitialize, every Open WebUI restart attempt also bounced
+LiteLLM's database connection. Switching vector stores fixes both.
+
+Changing `PGVECTOR_INDEX_METHOD` to `hnsw` does **not** help — hnsw builds use
+the same distance kernels. There is no "skip the index" option; Open WebUI
+always calls `_ensure_vector_index()`.
+
+## Fix applied
+
+`VECTOR_DB` switched from `pgvector` to `chroma` (Open WebUI's own upstream
+default). Chroma is embedded in the pod and persists to the `openwebui-data`
+PVC, so no extra service is needed.
+
+Chroma was verified on this CPU before deploying:
+
+```bash
+kubectl run chroma-test -n ai --rm -i --restart=Never \
+  --image=ghcr.io/open-webui/open-webui:0.11.0 --quiet --command -- \
+python3 -c "
+import chromadb
+c = chromadb.PersistentClient(path='/tmp/ctest')
+col = c.get_or_create_collection('testcol')
+col.add(ids=['a','b'], embeddings=[[0.1]*384, [0.2]*384])
+print('CHROMA OK ->', col.query(query_embeddings=[[0.15]*384], n_results=2)['ids'])
+"
+# -> CHROMA OK -> [['b', 'a']]
+```
+
+Note the collection name must be 3+ characters or Chroma rejects it.
+
+## IMPORTANT: this patch is not durable
+
+The change is made to `/mnt/urbalurbadisk/manifests/208-openwebui-config.yaml`
+**inside the uis-provision-host container image**. UIS has no override
+mechanism for Helm values — `.uis.extend/` only holds cluster and host config.
+
+So `./uis pull` (or anything that recreates the container) **reverts it**, and
+the next `./uis deploy openwebui` will crash-loop again and take PostgreSQL
+down with it.
+
+After any `./uis pull`, re-apply with:
+
+```bash
+./mac-ollama/patch-openwebui-vectordb.sh
+```
+
+---
+
+# Second, unrelated issue: Traefik v2 vs v3 IngressRoute syntax
+
+## Symptom
+
+Both playbooks report `IngressRoute: ✅ Traefik routing configured`, but the
+URLs return 404 — from the host *and* from inside the cluster:
+
+```bash
+curl -H "Host: openwebui.localhost" http://127.0.0.1/    # -> 404
+```
+
+## Root cause
+
+UIS manifests use **Traefik v3** syntax:
+
+```yaml
+match: HostRegexp(`openwebui\..+`)
+```
+
+Rancher Desktop's k3s ships **Traefik v2.10.5**, where `HostRegexp` is not a
+plain regex — it needs `{name:pattern}` capture groups. Under v2 the v3 form
+matches nothing, so Traefik falls through to its default 404.
+
+This affects **every** UIS service, not just these two — 18+ manifests in
+`/mnt/urbalurbadisk/manifests/` use the v3 form:
+
+```bash
+docker exec uis-provision-host grep -rln HostRegexp /mnt/urbalurbadisk/manifests/
+```
+
+## Fix applied
+
+The two deployed routes were rewritten in place to the v2 form:
+
+```yaml
+match: HostRegexp(`openwebui.{rest:.+}`)
+```
+
+Verified: `http://openwebui.localhost` and `http://litellm.localhost` both
+return HTTP 200 from the host.
+
+## IMPORTANT: this also reverts
+
+`uis deploy litellm` and `uis deploy openwebui` re-apply the shipped manifests,
+restoring the v3 syntax and breaking the URLs again. Re-run
+`./mac-ollama/patch-openwebui-vectordb.sh` after either deploy — it fixes both
+routes and is safe to run repeatedly.
+
+The real fix is either upgrading this cluster's Traefik to v3, or correcting the
+UIS manifests upstream. Both are bigger decisions than this deployment.
+
+---
+
+## Longer-term options
+
+- Upstream a `VECTOR_DB` override into UIS's `.uis.extend/` mechanism.
+- Deploy `qdrant` (`uis deploy qdrant`) and set `VECTOR_DB=qdrant` — UIS already
+  provisions `qdrant-data` / `qdrant-snapshots` PVCs. Qdrant does runtime CPU
+  feature detection, so it should be safe here, but it was not tested.
+- Run PostgreSQL from an image whose pgvector is built for a baseline x86-64
+  target, or build pgvector from source with `-march=x86-64`.
+- Move this workload to a host newer than 2011.

--- a/hosts/mac-ollama/README.md
+++ b/hosts/mac-ollama/README.md
@@ -1,0 +1,18 @@
+# Mac Ollama backends — operational notes
+
+Rescued from the iMac on 2026-08-07, the day after its root filesystem failed.
+These existed nowhere else and are not reproducible from the rest of the repo.
+
+| File | Why it is kept |
+|---|---|
+| `wake-macs.sh` | Wake-on-LAN for the two Macs. Still needed: the M4 sleeps in 9–16 minute cycles and a sleeping Mac answers ICMP while every TCP port is closed, so `ping` is not a liveness check |
+| `README-cpu-limitation.md` | Why pgvector cannot run on the 2011 iMac: no AVX2/FMA, and a SIGILL in a distance operator kills the **postmaster**, not just the query — taking down every database on that instance |
+| `mac-ollama-design.md` | The selector-less Service + hand-managed Endpoints pattern, so a backend address change is a one-file edit with no LiteLLM restart |
+
+## Deliberately not rescued
+
+- `M1-LITELLM-SETUP.md` — points at the dead iMac gateway and contains its API
+  key in plaintext. Superseded; not committed
+- `00/01/02/03-*.yaml` — superseded by `hosts/asgard/ollama-backends.yaml` and
+  `hosts/asgard/litellm-models.yaml`
+- `patch-openwebui-vectordb.sh` — a workaround for a machine that no longer runs

--- a/hosts/mac-ollama/mac-ollama-design.md
+++ b/hosts/mac-ollama/mac-ollama-design.md
@@ -1,0 +1,235 @@
+# External Ollama backends for LiteLLM
+
+LiteLLM runs in the cluster; the models do not. Two Macs on the network serve
+them, each exposed as a selector-less Service with hand-managed Endpoints so it
+gets a stable cluster DNS name.
+
+| Backend | Host | Service DNS | Address | Reached via |
+|---|---|---|---|---|
+| M4 Pro | `MBP-J4G0G066W2` | `mac-ollama.ai.svc.cluster.local:11434` | `192.168.68.58` | LAN (DHCP) |
+| M1 | `tecMacDev` | `m1-ollama.ai.svc.cluster.local:11434` | `100.127.6.20` | Tailscale |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `00-mac-ollama-endpoint.yaml` | M4 Service + Endpoints |
+| `02-m1-ollama-endpoint.yaml` | M1 Service + Endpoints |
+| `01-litellm-models.yaml` | `ai-models-litellm` ConfigMap — the LiteLLM model list |
+| `patch-openwebui-vectordb.sh` | Re-applies the two local UIS workarounds |
+| `README-cpu-limitation.md` | Why pgvector is unusable here, and the Traefik v2/v3 fix |
+
+Apply order matters only on a fresh install: `210-setup-litellm.yml` creates a
+default ConfigMap *only if one does not exist*, so apply `01-litellm-models.yaml`
+**before** `uis deploy litellm` to keep your own model list.
+
+```bash
+kubectl apply -f 00-mac-ollama-endpoint.yaml
+kubectl apply -f 02-m1-ollama-endpoint.yaml
+kubectl apply -f 01-litellm-models.yaml
+kubectl rollout restart deployment/litellm -n ai   # only after editing the ConfigMap
+```
+
+## Model naming
+
+Unprefixed names are on the **M4**. Everything on the **M1** is prefixed `m1-`.
+
+This is deliberate. `gemma3:4b`, `llava:7b` and `nomic-embed-text` exist on both
+machines. LiteLLM treats two entries sharing a `model_name` as a load-balancing
+pool, so without the prefix you could not tell — or control — which Mac served a
+given request. The prefix keeps them addressable independently.
+
+If you *want* failover across both Macs for a given model, that is the one case
+to drop the prefix: give both entries the same `model_name` and LiteLLM will
+distribute between them.
+
+| Model | M4 | M1 |
+|---|---|---|
+| gpt-oss:20b | `gpt-oss:20b`, `mac-gpt-oss-balanced` | — |
+| gemma4 | `gemma4:latest` | — |
+| qwen3:8b | `qwen3:8b` | — |
+| qwen2.5-coder:7b | `qwen2.5-coder:7b` | — |
+| deepseek-coder:6.7b | `deepseek-coder:6.7b` | — |
+| deepseek-r1 | — | `m1-deepseek-r1` |
+| mistral | — | `m1-mistral` |
+| gemma3:4b | `gemma3:4b` | `m1-gemma3:4b` |
+| llava:7b | `llava:7b` | `m1-llava:7b` |
+| nomic-embed-text | `nomic-embed-text` | `m1-nomic-embed-text` |
+
+## Known rough edge: a sleeping Mac hangs the request
+
+Neither address survives its laptop sleeping, and the failure is slow rather
+than clean. `litellm_settings.request_timeout` is `600`, so a call to a model on
+a sleeping Mac can hang for up to **10 minutes** before erroring — measured at
+45s with no response and still climbing.
+
+That timeout is high on purpose: a large local model can be slow to first token,
+and lowering it globally would break legitimate long generations on the M4. If
+the hang becomes annoying, the better fixes are per-model `timeout` overrides on
+the fast small models, or a LiteLLM `fallbacks` entry so a sleeping host rolls
+over to the other Mac instead of stalling.
+
+First thing to check when `m1-*` or unprefixed models start timing out: **is the
+Mac awake?**
+
+## When an address changes
+
+Only the endpoint file needs editing — the LiteLLM config refers to DNS names,
+and no restart is needed because the name is resolved per request.
+
+```bash
+getent hosts MBP-J4G0G066W2.local     # M4, LAN
+getent hosts tecMacDev.local          # M1, LAN
+getent hosts tecMacDev                # M1, Tailscale
+# update the ip in the matching *-endpoint.yaml, then kubectl apply -f it
+```
+
+The M4 is **not on Tailscale**, so it uses its LAN address and there is no
+alternative for it — `getent hosts MBP-J4G0G066W2` returns nothing. Its DHCP
+address moves, so `00-mac-ollama-endpoint.yaml` needs updating when it does.
+
+The M1 is on the tailnet, so it uses its Tailscale address, which does not move
+and also works when that laptop is off the LAN.
+
+## Using LiteLLM from your other machines
+
+LiteLLM speaks the OpenAI API, so anything that accepts a custom base URL works.
+
+### Endpoints
+
+| From | Base URL | Notes |
+|---|---|---|
+| Anything on the tailnet | `http://imac/v1` | **Preferred.** MagicDNS, stable, works off-LAN |
+| Anything on the tailnet | `http://100.84.7.57/v1` | Same, by IP |
+| Same LAN only | `http://192.168.68.55/v1` | This host's LAN IP — **DHCP, will move** |
+| This machine | `http://litellm.localhost/v1` | Also serves the admin UI |
+
+Prefer the tailnet name. The LAN address is a DHCP lease and changes; `imac`
+does not, and keeps working when a laptop leaves the house.
+
+### Why a bare IP works at all
+
+UIS routes LiteLLM by hostname (`HostRegexp(litellm.{rest:.+})`), which is
+useless to SDKs — they send `Host: <ip>`, which matches nothing, and Traefik
+returns 404. Rancher Desktop does not forward NodePorts to the host either, so
+that escape hatch is closed.
+
+`03-litellm-lan-access.yaml` adds a second, host-independent route matching
+`PathPrefix(/v1)` at the lowest priority. Any hostname reaches the API, while
+every existing Host-based rule still wins — `openwebui.localhost/v1` still goes
+to Open WebUI. Apply it with `kubectl apply -f 03-litellm-lan-access.yaml`; it
+is a separate object from the UIS-managed `litellm` IngressRoute, so
+`uis deploy litellm` will not wipe it.
+
+### Getting a key
+
+The admin/master key:
+
+```bash
+kubectl get secret urbalurba-secrets -n ai \
+  -o jsonpath='{.data.LITELLM_PROXY_MASTER_KEY}' | base64 -d
+```
+
+**Do not hand that out** — it is an admin credential. Issue a per-machine
+virtual key instead, optionally scoped to specific models:
+
+```bash
+MASTER=$(kubectl get secret urbalurba-secrets -n ai \
+  -o jsonpath='{.data.LITELLM_PROXY_MASTER_KEY}' | base64 -d)
+
+curl -s -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' \
+  -d '{"key_alias":"laptop","models":["m1-mistral","gemma3:4b"],"max_budget":10}' \
+  http://litellm.localhost/key/generate
+```
+
+Verified: a key scoped to `m1-mistral` gets `200` for that model and `403` for
+anything else. Revoke with `/key/delete`, or manage keys in the admin UI at
+<http://litellm.localhost/ui>.
+
+### Client examples
+
+Environment variables — picked up by most OpenAI-compatible tooling:
+
+```bash
+export OPENAI_BASE_URL="http://imac/v1"
+export OPENAI_API_KEY="sk-...your-virtual-key..."
+```
+
+curl:
+
+```bash
+curl http://imac/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-oss:20b","messages":[{"role":"user","content":"hello"}]}'
+```
+
+Python:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://imac/v1", api_key="sk-...")
+print(client.chat.completions.create(
+    model="m1-mistral",
+    messages=[{"role": "user", "content": "hello"}],
+).choices[0].message.content)
+```
+
+List what is available: `curl -s http://imac/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"`
+
+Remember the model naming rule above — unprefixed names run on the M4,
+`m1-*` on the M1 — and that a request to a sleeping Mac hangs rather than
+failing fast.
+
+## Keeping the Macs awake
+
+Both Macs sleep, and a sleeping backend is the most likely cause of `m1-*` or
+unprefixed models failing. Two halves to this: recovery and prevention.
+
+### Recovery — wake it from here
+
+```bash
+./wake-macs.sh          # wake any backend that is not responding
+./wake-macs.sh m4       # just the M4
+```
+
+Both Macs have "Wake for network access" enabled, so a Wake-on-LAN magic packet
+brings them back. Verified on the M4: asleep ~30 minutes with every TCP port
+closed, awake and serving on the first poll after the packet.
+
+### Prevention — must be done ON each Mac
+
+This cannot be configured from the Linux box. On the Mac itself:
+
+```bash
+# never sleep while on the power adapter
+sudo pmset -c sleep 0
+
+# kernel-level sleep veto (persists until cleared or reboot)
+sudo pmset -a disablesleep 1
+
+# confirm it took
+pmset -g | grep -i sleepdisabled     # expect: SleepDisabled  1
+
+# to undo later
+sudo pmset -a disablesleep 0
+```
+
+Scoped to a single session instead, no sudo, ends when you Ctrl-C it:
+
+```bash
+caffeinate -is ollama serve
+```
+
+**The lid is the catch.** On Apple Silicon from macOS Ventura onward, closing
+the lid triggers a hardware magnet check that forces sleep — and *neither*
+`pmset disablesleep` *nor* `caffeinate` overrides it. The only supported ways to
+run with the lid shut are clamshell mode (external display + keyboard + power)
+or simply leaving the lid open.
+
+So for an always-available Ollama box: plugged into power, lid open (or full
+clamshell), `pmset -c sleep 0`. Keep `wake-macs.sh` as the fallback for when it
+sleeps anyway.
+
+Note that `disablesleep 1` persists until cleared or you reboot — a laptop left
+that way will not sleep overnight either.

--- a/hosts/mac-ollama/wake-macs.sh
+++ b/hosts/mac-ollama/wake-macs.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Wake a sleeping Mac Ollama backend with a Wake-on-LAN magic packet.
+#
+#   ./wake-macs.sh          # wake whichever backends are not responding
+#   ./wake-macs.sh m4       # wake just the M4
+#   ./wake-macs.sh m1       # wake just the M1
+#
+# WHY THIS WORKS: both Macs have "Wake for network access" enabled, so the
+# Wi-Fi chip stays reachable while the CPU sleeps. A magic packet brings the
+# machine back. Verified on the M4 2026-08-02: asleep for ~30 min, all TCP
+# ports closed, woke and served Ollama on the first poll after the packet.
+#
+# This is a RECOVERY tool, not a prevention one. To stop the Macs sleeping in
+# the first place, see the "Keeping the Macs awake" section in README.md - that
+# has to be configured on each Mac, it cannot be done from here.
+#
+# NOTE ON MAC ADDRESSES: both Macs use Apple "Private Wi-Fi Address"
+# randomisation (the a6:/d6: prefixes are locally-administered). The address is
+# stable per network, but if you toggle Private Wi-Fi Address on the Mac, or
+# join a different network, re-read it with:
+#
+#     ping -c1 <ip> >/dev/null; ip neigh show <ip>
+
+set -uo pipefail
+
+# name:ip:mac
+BACKENDS=(
+    "m4:192.168.68.58:a6:c1:40:ca:2a:da"
+    "m1:192.168.68.70:d6:18:47:95:84:36"
+)
+
+# Derive the real subnet broadcast rather than assuming a /24. This LAN is a
+# /22 (192.168.68.0/22), so the broadcast is 192.168.71.255 - hardcoding
+# 192.168.68.255 would silently target an ordinary host address instead.
+BROADCAST="$(ip -4 route get 192.168.68.58 2>/dev/null |
+    grep -oP 'dev \K\S+' |
+    head -1 |
+    xargs -r -I{} ip -4 addr show {} 2>/dev/null |
+    grep -oP 'brd \K[0-9.]+' |
+    head -1)"
+BROADCAST="${BROADCAST:-255.255.255.255}"
+
+WANT="${1:-all}"
+
+send_magic() {
+    local mac="$1" ip="$2"
+    python3 - "$mac" "$ip" "$BROADCAST" <<'PY'
+import socket, sys
+mac, ip, bcast = sys.argv[1], sys.argv[2], sys.argv[3]
+pkt = b'\xff' * 6 + bytes.fromhex(mac.replace(':', '')) * 16
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+for tgt in [(bcast, 9), ('255.255.255.255', 9), (ip, 9), (bcast, 7)]:
+    try:
+        s.sendto(pkt, tgt)
+    except OSError:
+        pass
+PY
+}
+
+is_up() {
+    curl -s --max-time 5 "http://$1:11434/api/version" 2>/dev/null | grep -q version
+}
+
+rc=0
+for entry in "${BACKENDS[@]}"; do
+    name="${entry%%:*}"
+    rest="${entry#*:}"
+    ip="${rest%%:*}"
+    mac="${rest#*:}"
+
+    [ "$WANT" != "all" ] && [ "$WANT" != "$name" ] && continue
+
+    if is_up "$ip"; then
+        echo "$name ($ip): already awake"
+        continue
+    fi
+
+    echo "$name ($ip): asleep - sending magic packet to $mac"
+    send_magic "$mac" "$ip"
+
+    woke=false
+    for i in $(seq 1 12); do
+        if is_up "$ip"; then
+            echo "$name ($ip): awake after ~$((i * 5))s"
+            woke=true
+            break
+        fi
+    done
+
+    if [ "$woke" = false ]; then
+        echo "$name ($ip): STILL ASLEEP after ~60s." >&2
+        echo "  - is the Mac powered and on this network?" >&2
+        echo "  - is 'Wake for network access' still enabled on it?" >&2
+        echo "  - has the private Wi-Fi MAC changed? (see note at top of this script)" >&2
+        rc=1
+    fi
+done
+
+exit $rc


### PR DESCRIPTION
These three files existed only on the iMac's disks and are not reproducible
from anything else in the repo.

- wake-macs.sh: Wake-on-LAN for the two Ollama backends. Still needed — the M4
  sleeps in 9-16 minute cycles, and a sleeping Mac answers ICMP while every TCP
  port is closed, so ping is not a liveness check.
- README-cpu-limitation.md: why pgvector cannot run on the 2011 iMac. No
  AVX2/FMA, and a SIGILL in a distance operator kills the postmaster rather than
  the query, taking down every database on that instance.
- mac-ollama-design.md: the selector-less Service plus hand-managed Endpoints
  pattern, which makes a backend address change a one-file edit with no LiteLLM
  restart. This is the design replicated in hosts/asgard/ollama-backends.yaml.

Not rescued: M1-LITELLM-SETUP.md (superseded, and contains the dead gateway's
API key in plaintext), the four endpoint manifests (superseded by hosts/asgard/),
and patch-openwebui-vectordb.sh (a workaround for a machine that no longer runs).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR