### PR TITLE
Plan: declare external dependencies as shim Services

### DIFF
--- a/website/docs/ai-developer/plans/backlog/PLAN-system-dependencies-shim-services.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-dependencies-shim-services.md
@@ -1,0 +1,245 @@
+# Declare external dependencies as shim Services
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Every dependency UIS has on something outside the cluster is declared
+as a `Service` with explicit `Endpoints`, so that discovery, monitoring and
+documentation all read it from one place instead of each rediscovering it.
+
+**Last Updated**: 2026-08-08
+
+**Investigations**:
+- [INVESTIGATE-system-monitor-definitions-with-services](./INVESTIGATE-system-monitor-definitions-with-services.md) — asked how monitors stay in step with services
+- [INVESTIGATE-system-migrate-hosts-to-platforms](./INVESTIGATE-system-migrate-hosts-to-platforms.md) — installations differ in what is inside the cluster
+
+**Related**: [PLAN-system-observability-006-service-probes](./PLAN-system-observability-006-service-probes.md)
+consumes what this produces, and contains a factual error this plan corrects
+(see Implementation Notes).
+
+**Priority**: Medium
+
+---
+
+## Problem
+
+UIS depends on things that do not run in the cluster. On the reference
+installation that is OpenBao, a registry pull-through cache, the production
+PostgreSQL, and two Ollama hosts.
+
+Some of these are declared. Most are not:
+
+```
+ai/m1-ollama     → 192.168.68.70:11434     declared: Service + Endpoints
+ai/mac-ollama    → 192.168.68.58:11434     declared: Service + Endpoints
+OpenBao          → 192.168.68.77:8200      an IP in External Secrets' config
+registry cache   → 192.168.68.78:5000      an IP in containerd's config
+```
+
+An undeclared dependency is invisible to everything that would otherwise
+benefit from knowing about it. Nothing can enumerate it, nothing can probe it,
+and nothing can tell you what breaks when it goes away.
+
+This surfaced through monitoring, but monitoring is not the problem. Writing
+availability probes forced the question *"what does this installation actually
+depend on?"* and the answer turned out not to exist in any one place.
+
+### Why this is not a monitoring concern
+
+The naive fix is a hand-maintained list of external endpoints for the watchdog.
+That was drafted and rejected: it asks the operator for addresses UIS already
+has, and it drifts the moment anything moves.
+
+The observation that makes it cheap instead:
+
+> **If something in the cluster must reach it, it can be a Service. If it is a
+> Service, everything that consumes Services gets it for free.**
+
+A `Service` with manually-managed `Endpoints` is the standard Kubernetes way to
+name something outside the cluster. Consumers connect to a stable DNS name
+rather than an IP; when the address changes, one object changes.
+
+Monitoring is then a *consequence*, not a mechanism. A probe attached to
+`ai/m1-ollama` needs no hostname from the user — identical to an in-cluster
+service. The probe renderer cannot tell the difference, and should not be able
+to.
+
+### The rule this produces
+
+> **If you are hand-writing a monitor for something UIS depends on, the bug is
+> a missing shim — not a missing monitor.**
+
+Applied to the reference installation's 19 monitors:
+
+| | Count | |
+|---|---|---|
+| In-cluster services | 4 | automatic today — litellm, grafana, temporal, authentik |
+| Shim exists | 2 | automatic today — m1-ollama, mac-ollama |
+| **Needs a shim** | **4** | **bao, registry-cache, external postgresql, external minio** |
+| Derivable, not hand-written | 1 | k3s API — the watchdog's kubeconfig already holds the URL |
+| Genuinely installation-specific | 3 | hypervisor, NAS, the watchdog's own host |
+| Job heartbeats | 5 | not services; nothing can discover a job |
+
+Ten of fourteen service monitors become automatic. The three that remain are
+things UIS did not deploy and cannot be expected to know about, which is the
+honest boundary.
+
+---
+
+## Phase 1: The dependency artifact
+
+A service declares what it needs from outside the cluster, in the same place it
+declares everything else about itself.
+
+### Tasks
+
+- [ ] 1.1 Define a `dependencies` artifact alongside the service definition —
+      fields: `name`, `port`, `protocol`, and a human-readable `why`
+- [ ] 1.2 Address resolution comes from `urbalurba-secrets` or the installation
+      config, **never from the artifact** — the artifact is installation-agnostic
+      and ships with the product
+- [ ] 1.3 Render to a `Service` (no selector) plus an `Endpoints` object
+- [ ] 1.4 Absent address ⇒ dependency not present in this installation ⇒ no
+      Service rendered, and no error. An installation running everything
+      in-cluster declares nothing and notices nothing
+
+### Validation
+
+```bash
+uis dependencies list      # what this installation reaches outside the cluster
+```
+
+Output on a stock all-in-cluster install: empty.
+
+---
+
+## Phase 2: Probes attach to Services uniformly
+
+### Tasks
+
+- [ ] 2.1 The probe renderer from PLAN-006 resolves targets through the Service
+      only — it must have no branch for "external"
+- [ ] 2.2 Verify a shim-backed probe and an in-cluster probe render identically
+      apart from the resolved endpoint
+
+### Validation
+
+Rendered output for `m1-ollama` (shim) and `litellm` (in-cluster) differ only in
+name, port and path.
+
+---
+
+## Phase 3: Shim the reference installation's dependencies
+
+Ordered by bootstrap risk, lowest first.
+
+### Tasks
+
+- [ ] 3.1 `registry-cache` — nothing in the cluster resolves it through DNS
+      today (containerd reads a static config), so the shim is additive and
+      safe to land first
+- [ ] 3.2 `postgresql` — the external production instance. Consumers are
+      Temporal, Authentik and LiteLLM. **Ordering matters**: the shim must exist
+      before any consumer is pointed at it
+- [ ] 3.3 `minio` — same shape, fewer consumers
+- [ ] 3.4 `bao` — **last, and see Implementation Notes**. External Secrets needs
+      the vault before most of the cluster exists, so this shim must not depend
+      on anything the vault provides
+
+### Validation
+
+```bash
+kubectl get endpoints -A          # every declared dependency resolves
+uis dependencies list             # matches
+```
+
+Each consumer still works after being pointed at the Service name.
+
+---
+
+## Phase 4: Narrow what is left to the user
+
+### Tasks
+
+- [ ] 4.1 Rewrite PLAN-006 Phase 4.4. It currently describes
+      `.uis.extend/monitors.yaml` as the place for anything external. Invert it:
+      **the extend file is for things UIS does not depend on.** Anything it
+      depends on gets a shim
+- [ ] 4.2 Derive the cluster API monitor from the watchdog's kubeconfig rather
+      than having anyone type it
+- [ ] 4.3 Document the rule in the service-authoring guide, with the test from
+      the Problem section stated as a rule
+
+### Validation
+
+A stock install has an empty or absent `.uis.extend/monitors.yaml`. The
+reference installation's shrinks from six entries to three, and each remaining
+entry is something UIS demonstrably did not deploy.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Every external dependency is a `Service` with `Endpoints`
+- [ ] The probe renderer contains no special case for external targets
+- [ ] Address values come from secrets or installation config, never from a
+      product-shipped artifact
+- [ ] An all-in-cluster installation declares no dependencies and sees no
+      change in behaviour
+- [ ] `.uis.extend/monitors.yaml` contains only things UIS did not deploy
+- [ ] Consumers reach dependencies by DNS name; an address change touches one
+      object
+
+---
+
+## Implementation Notes
+
+**Correction to PLAN-006.** Its Implementation Notes state that on the
+reference deployment PostgreSQL runs outside the cluster behind a shim Service,
+and reason from that. Verified on `asgard` 2026-08-08: `default/postgresql` and
+`default/minio` are ordinary in-cluster services with pod endpoints
+(`10.42.0.203`, `10.42.0.204`). The production PostgreSQL on Proxmox has no
+shim at all. The architectural argument in that note is sound and this plan
+adopts it — but it describes a target state, not the current one, and should be
+reworded to say so.
+
+**Bao is bootstrap-sensitive.** External Secrets consumes the vault before most
+of the cluster exists. A shim that depends on anything the vault provides is
+circular. Keep it plain — Service and Endpoints, static address from
+installation config, no secret reference. This is also why it is sequenced
+last: it is the one where being wrong is expensive.
+
+**A shim proves the path, not the health of the far end.** This is a feature for
+Temporal, whose real dependency is the whole path — shim, network, external
+process. It is a limitation for a probe: `bao` answers `503` when sealed, and a
+sealed vault is useless even though the path is fine. The probe's
+`accepted_statuscodes` still has to encode that. Declaring the dependency does
+not remove the need to know what "healthy" means for it.
+
+**Endpoints are not reconciled.** A manually-managed `Endpoints` object is
+static. If an external host's address changes, the shim points at nothing and
+the failure is a connection timeout at the consumer. This is a real downgrade
+from a raw IP in config only in that it adds one indirection — but it is the
+indirection that makes the address knowable and monitorable, and the probe on
+the shim is exactly what detects it. Do not add address auto-discovery; it
+would reintroduce the coupling this removes.
+
+**Why not `ExternalName`.** `ExternalName` returns a CNAME and requires the
+target to have a resolvable DNS name. The reference installation's dependencies
+are bare IPs on a LAN. Service-plus-Endpoints also gives real port mapping,
+which `ExternalName` does not.
+
+---
+
+## Files to Modify
+
+- `provision-host/uis/services/<category>/dependencies/<id>.yaml` (new, per service)
+- `provision-host/uis/manage/uis-dependencies.sh` (new)
+- `provision-host/uis/manage/uis-cli.sh` — register the `dependencies` verb
+- `manifests/` — shim Service + Endpoints per Phase 3
+- `PLAN-system-observability-006-service-probes.md` — Phase 4.4 and the
+  PostgreSQL note
+- the service-authoring guide — document the `dependencies` artifact and the rule

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-006-service-probes.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-006-service-probes.md
@@ -185,9 +185,13 @@ A monitor appears in Uptime Kuma without anyone opening the UI.
 - [ ] 4.3 `uis monitors check` — compare intended against the ConfigMap **and**
       against what Kuma is running, so a wedged AutoKuma is visible. Reconcilers
       fail silently; that is the same absence-renders-as-green trap
-- [ ] 4.4 Optional `.uis.extend/monitors.yaml` for targets UIS did not deploy —
-      a hypervisor, a NAS, machines outside the cluster, job heartbeats. **Empty
-      or absent on a stock install.**
+- [ ] 4.4 Optional `.uis.extend/monitors.yaml` — **only for things UIS does not
+      depend on**: a hypervisor, a NAS, the watchdog's own host, job heartbeats.
+      Anything UIS *depends on* is declared as a shim Service instead and
+      discovered like any other Service — see
+      [PLAN-system-dependencies-shim-services](./PLAN-system-dependencies-shim-services.md).
+      If you find yourself hand-writing a monitor for a dependency, the bug is a
+      missing shim. **Empty or absent on a stock install.**
 
 ### Validation
 
@@ -213,13 +217,21 @@ uis undeploy redis && uis monitors check   # gone, no orphan
 
 ## Implementation Notes
 
-**Probe through the Service, not the container.** On the reference deployment
-PostgreSQL runs *outside* the cluster behind a shim Service. Probing
-`postgresql.default:5432` tests the whole path — shim, network, external
-container — which is what Temporal and Authentik actually depend on. Probing the
-database host directly would stay green while that path was broken. It also
-means installations that externalise state need no special handling: UIS sees an
-ordinary Service either way.
+**Probe through the Service, not the container.** Where a dependency runs
+outside the cluster behind a shim Service, probing `postgresql.default:5432`
+tests the whole path — shim, network, external process — which is what Temporal
+and Authentik actually depend on. Probing the database host directly would stay
+green while that path was broken. It also means installations that externalise
+state need no special handling: UIS sees an ordinary Service either way.
+
+⚠️ **This describes the target state, not the reference installation today.**
+Verified on `asgard` 2026-08-08: `default/postgresql` and `default/minio` are
+ordinary in-cluster services with pod endpoints; the production PostgreSQL on
+Proxmox has no shim, and the only shims that exist are the two Ollama hosts. An
+earlier revision of this note asserted the shim already existed and reasoned
+from it. Getting there is
+[PLAN-system-dependencies-shim-services](./PLAN-system-dependencies-shim-services.md),
+which this plan should be read alongside.
 
 **Why not keep the direct-to-database reconciler.** The reference deployment has
 a working one, and it was tempting to promote it. Reading Kuma's own `add`

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-006-service-probes.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-006-service-probes.md
@@ -91,24 +91,28 @@ Uptime Kuma. UIS writes files; AutoKuma reconciles them over Socket.IO.
 Docker Swarm providers are supported "on an as-is basis… basically looking for a
 maintainer". The file source has no such caveat.
 
-### The interface is a ConfigMap
+### The interface is a Secret
 
 ```
 uis monitors apply
       │  renders one .json per monitor
       ▼
-ConfigMap  uptime-kuma-monitors          ← the only thing UIS writes
-      │  mounted at AUTOKUMA__STATIC_MONITORS
-      ▼
-AutoKuma  (sidecar next to Uptime Kuma)
+Secret  uptime-kuma-monitors             ← the only thing UIS writes
+      │  mounted, then flattened with `cp -L` into an emptyDir
+      ▼                                    (Kubernetes mounts it as symlinks
+AutoKuma  (its own Deployment, PVC on /data)  AutoKuma will not follow)
       │  Socket.IO
       ▼
 Uptime Kuma
 ```
 
-A key added to the ConfigMap creates a monitor; a key removed deletes one. That
-is the whole contract, and it is entirely within Kubernetes primitives UIS
-already uses.
+A key added creates a monitor; a key removed deletes one. That is the whole
+contract, and it is entirely within Kubernetes primitives UIS already uses.
+
+A Secret rather than a ConfigMap because a rendered probe can carry a resolved
+`Authorization` header. The two indirections — flatten, and the PVC — are not
+design choices; they are worked around because AutoKuma fails silently without
+them. See Phase 3.
 
 ---
 
@@ -140,7 +144,7 @@ Both files parse; neither contains a hostname or a secret value.
       `Ingress`/`IngressRoute` for the external hostname the watchdog needs
 - [ ] 2.3 Resolve `auth:` by reading the named key from `urbalurba-secrets`
 - [ ] 2.4 Render each probe to AutoKuma's monitor JSON schema
-- [ ] 2.5 Write them into the `uptime-kuma-monitors` ConfigMap, one key per monitor
+- [ ] 2.5 Write them into the `uptime-kuma-monitors` Secret, one key per monitor
 
 ### Validation
 
@@ -157,22 +161,41 @@ written by hand.
 
 ### Tasks
 
-- [ ] 3.1 Add AutoKuma as a second container in the `uptime-kuma` StatefulSet —
-      it needs no storage of its own and shares the pod's lifecycle
-- [ ] 3.2 Mount the `uptime-kuma-monitors` ConfigMap at `AUTOKUMA__STATIC_MONITORS`
-- [ ] 3.3 Authenticate with `AUTOKUMA__KUMA__USERNAME` / `..._PASSWORD` from
+⚠️ **This phase was prototyped on the reference installation 2026-08-08. Four
+things in the original draft were wrong, and every one of them failed silently.**
+The tasks below are corrected; the reasoning is in Implementation Notes.
+
+- [ ] 3.1 Deploy AutoKuma as its **own Deployment**, not a sidecar. Both
+      containers in a pod start together, Kuma needs ~30s before it accepts
+      Socket.IO, and AutoKuma makes **one** connect attempt and then never
+      retries. As a separate Deployment it targets the Service and the restart
+      loop is the retry
+- [ ] 3.2 Give it a **PVC for `/data`**. It holds AutoKuma's id → monitor
+      mapping. The original draft said "needs no storage of its own" — without
+      it, every restart re-creates every monitor as a new one
+- [ ] 3.3 Mount the monitor definitions, then **copy them to a plain directory
+      with an init container** (`cp -L` into an `emptyDir`). Kubernetes presents
+      a Secret/ConfigMap as symlinks into a hidden `..data/`, and AutoKuma's file
+      scanner does not follow them
+- [ ] 3.4 Use a **Secret, not a ConfigMap** — a rendered probe can carry a
+      resolved `Authorization` header
+- [ ] 3.5 Authenticate with `AUTOKUMA__KUMA__USERNAME` / `..._PASSWORD` from
       `urbalurba-secrets` — the same `uptime-kuma-admin-*` keys the setup
       playbook already seeds, so no new credential
-- [ ] 3.4 Set `AUTOKUMA__ON_DELETE=delete` with a grace period
-- [ ] 3.5 Pin the AutoKuma image, as with every other image
+- [ ] 3.6 Set `AUTOKUMA__ON_DELETE=delete` with a grace period
+- [ ] 3.7 Pin the AutoKuma image — and use `2.0.0`, **not** `v2.0.0`: the
+      v-prefixed tag is single-arch and will not pull on arm64
 
 ### Validation
 
 ```bash
-kubectl logs -n monitoring uptime-kuma-0 -c autokuma   # connected, monitors synced
+kubectl logs -n monitoring deploy/autokuma          # connected, monitors synced
+kubectl rollout restart deployment/autokuma -n monitoring
+# monitor count must be UNCHANGED afterwards — this is the /data regression test
 ```
 
-A monitor appears in Uptime Kuma without anyone opening the UI.
+A monitor appears in Uptime Kuma without anyone opening the UI, and a restart
+does not duplicate it.
 
 ---
 
@@ -180,9 +203,9 @@ A monitor appears in Uptime Kuma without anyone opening the UI.
 
 ### Tasks
 
-- [ ] 4.1 `uis deploy <service>` adds its probe to the ConfigMap
+- [ ] 4.1 `uis deploy <service>` adds its probe to the Secret
 - [ ] 4.2 `uis undeploy <service>` removes it — AutoKuma then deletes the monitor
-- [ ] 4.3 `uis monitors check` — compare intended against the ConfigMap **and**
+- [ ] 4.3 `uis monitors check` — compare intended against the Secret **and**
       against what Kuma is running, so a wedged AutoKuma is visible. Reconcilers
       fail silently; that is the same absence-renders-as-green trap
 - [ ] 4.4 Optional `.uis.extend/monitors.yaml` — **only for things UIS does not
@@ -208,7 +231,7 @@ uis undeploy redis && uis monitors check   # gone, no orphan
       with **zero user configuration**
 - [ ] No endpoint or hostname is ever written by the user
 - [ ] `uis undeploy <service>` removes the monitor
-- [ ] UIS writes only a ConfigMap — never Kuma's database or Socket.IO API
+- [ ] UIS writes only a Secret — never Kuma's database or Socket.IO API
 - [ ] `uis monitors check` detects a stalled AutoKuma, not just missing files
 - [ ] Probe definitions contain secret *names*, never values
 - [ ] A stock install needs no `.uis.extend/monitors.yaml`
@@ -241,6 +264,35 @@ handler settled it: creating a monitor also calls `updateMonitorNotification`
 those. Pinning the version makes the *schema* knowable, as it should — but the
 work is reimplementing the application, not reading its tables.
 
+**Four AutoKuma behaviours, all silent, all found by prototyping (2026-08-08).**
+Listed because each one presents as "working" and would cost an implementer the
+same day it cost here.
+
+1. *Sidecar does not work.* Pod containers start together, Kuma needs ~30s, and
+   AutoKuma makes one connect attempt then goes quiet — `Error during connect`,
+   `Timeout while waiting for Kuma`, then nothing. Its own Deployment turns
+   CrashLoopBackOff into the retry mechanism.
+2. *Secret and ConfigMap mounts are symlink trees.* Kubernetes presents
+   `name.json -> ..data/name.json` with `..data` itself a symlink to a
+   timestamped directory. AutoKuma's scanner does not follow them: it connects,
+   runs its migrations, finds no files, logs nothing, and syncs nothing. Copy
+   with `cp -L` into an `emptyDir` first.
+3. *`/data/autokuma.db` must be persisted.* It is the id → monitor mapping. With
+   an ephemeral filesystem every restart re-creates every monitor as a new one —
+   one restart took 19 monitors to 38, every name duplicated, no error anywhere.
+4. *AutoKuma does not generate push tokens.* A push monitor rendered without one
+   is created with an empty token, has no callable URL, and can never go UP; it
+   only accumulates DOWN beats. The renderer must emit `push_token`.
+
+**Derive push tokens, do not randomise them.** A push token *is* the URL a job
+calls. Random tokens mean every rebuild reissues every URL, and the old URL goes
+quietly silent rather than failing loudly. Deriving them —
+`HMAC-SHA256(salt, monitor name)` — makes the whole set reproducible from one
+secret, so a wipe-and-rebuild leaves every job's existing URL working. Verified
+on the reference installation: two complete purge-and-rebuild cycles produced
+byte-identical monitors and tokens. The salt becomes a secret that must be
+backed up; losing it silently orphans every heartbeat caller.
+
 **Retain the drift check.** AutoKuma reconciles continuously, so drift
 self-heals — which means a *stopped* AutoKuma looks exactly like a healthy one.
 Phase 4.3 exists for that, and the reference implementation's `--check` already
@@ -258,7 +310,7 @@ no new secret, nothing extra to rotate.
 - `provision-host/uis/services/<category>/probes/<id>.yaml` (new, per service)
 - `provision-host/uis/manage/uis-monitors.sh` (new)
 - `provision-host/uis/manage/uis-cli.sh` — register the `monitors` verb
-- `manifests/230-uptime-kuma-statefulset.yaml` — add the AutoKuma container
-- `ansible/playbooks/230-setup-uptime-kuma.yml` — create the ConfigMap
+- `manifests/230-autokuma-deployment.yaml` (new) — Deployment + PVC, not a sidecar
+- `ansible/playbooks/230-setup-uptime-kuma.yml` — create the Secret and deploy AutoKuma
 - `PLAN-system-observability-003-service-dashboards.md` — extend to three artifacts
 - the service-authoring guide — document the `probes` artifact


### PR DESCRIPTION
## Why

Writing availability probes forced the question *"what does this installation actually depend on?"* — and the answer did not exist in any one place.

```
ai/m1-ollama     → 192.168.68.70:11434     declared: Service + Endpoints
ai/mac-ollama    → 192.168.68.58:11434     declared: Service + Endpoints
OpenBao          → 192.168.68.77:8200      an IP in External Secrets' config
registry cache   → 192.168.68.78:5000      an IP in containerd's config
```

An undeclared dependency is invisible to everything that would otherwise benefit from knowing about it.

## The idea

> If something in the cluster must reach it, it can be a Service. If it is a Service, everything that consumes Services gets it for free.

Monitoring becomes a *consequence* rather than a mechanism — a probe on `ai/m1-ollama` needs no hostname from the user, exactly like an in-cluster service. This replaces an earlier draft that had the operator hand-maintain a list of external endpoints.

The rule it produces:

> **If you are hand-writing a monitor for something UIS depends on, the bug is a missing shim — not a missing monitor.**

Ten of the reference installation's fourteen service monitors become automatic. The three that remain are a hypervisor, a NAS and the watchdog's own host — things UIS did not deploy and cannot be expected to know about.

## Also corrects PLAN-006

That plan asserts PostgreSQL already runs outside the cluster behind a shim, and reasons from it. Verified on `asgard` 2026-08-08: `default/postgresql` and `default/minio` are ordinary in-cluster services with pod endpoints, and the external production PostgreSQL has no shim. The architectural argument holds as a *target* state; the note now says so, and Phase 4.4 is inverted to match — `.uis.extend/monitors.yaml` is for things UIS does **not** depend on.

## Note for review

Contains RFC1918 LAN addresses from the reference installation as worked examples. Not secrets, and consistent with existing plans in this repo, but flagging it since this repo is public.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR