### PR TITLE
uptime-kuma: honour `uis undeploy --purge`

### DIFF
--- a/ansible/playbooks/230-remove-uptime-kuma.yml
+++ b/ansible/playbooks/230-remove-uptime-kuma.yml
@@ -3,12 +3,22 @@
 # Remove Uptime Kuma from the cluster
 #
 # The PVC is KEPT by default: it holds the monitor definitions, the notification
-# configuration and the whole uptime history, none of which is reproducible.
-# Remove it explicitly with -e remove_pvc=true.
+# configuration and the whole uptime history.
 #
 # Usage:
+#   uis undeploy uptime-kuma                 keep the data
+#   uis undeploy uptime-kuma --purge         delete it too
+#
 #   ansible-playbook 230-remove-uptime-kuma.yml
 #   ansible-playbook 230-remove-uptime-kuma.yml -e remove_pvc=true
+#
+# `uis undeploy --purge` passes `_purge=true`, which is the CLI-wide convention
+# for "remove persistent state". Both spellings are honoured: _purge so the
+# standard CLI flag works, remove_pvc so direct playbook runs keep working.
+#
+# Leaving the PVC behind makes install bugs unfalsifiable - every reinstall after
+# the first lands on an existing database, so a broken first-install path stays
+# hidden. That is exactly how the empty-username seeding bug survived a redeploy.
 
 - name: Remove Uptime Kuma
   hosts: localhost
@@ -17,7 +27,9 @@
 
   vars:
     _target: "{{ target_host | default('rancher-desktop') }}"
-    _remove_pvc: "{{ remove_pvc | default(false) | bool }}"
+    # Either spelling: _purge from `uis undeploy --purge`, remove_pvc from a
+    # direct playbook run.
+    _remove_pvc: "{{ (remove_pvc | default(false) | bool) or (_purge | default(false) | bool) }}"
     merged_kubeconf_file: "/mnt/urbalurbadisk/.uis.secrets/generated/kubeconfig/kubeconf-all"
     namespace: "monitoring"
     component_name: "uptime-kuma"
@@ -53,7 +65,7 @@
         kubeconfig: "{{ merged_kubeconf_file }}"
       failed_when: false
 
-    - name: "4. Remove PVC (only when remove_pvc=true)"
+    - name: "4. Remove PVC (only with --purge / remove_pvc=true)"
       kubernetes.core.k8s:
         state: absent
         kind: PersistentVolumeClaim
@@ -69,4 +81,4 @@
         msg:
           - "{{ component_name }} removed from {{ namespace }}"
           - "{{ 'PVC deleted - monitor history and notification config are gone' if _remove_pvc else 'PVC kept - monitors, notifications and history survive a redeploy' }}"
-          - "{{ '' if _remove_pvc else 'To remove the data too: ansible-playbook 230-remove-uptime-kuma.yml -e remove_pvc=true' }}"
+          - "{{ '' if _remove_pvc else 'To remove the data too: uis undeploy uptime-kuma --purge' }}"


### PR DESCRIPTION
## Problem

`uis undeploy uptime-kuma --purge` left the PVC behind and reported success.

The CLI already implements `--purge` — it prompts for confirmation, supports `--yes`, and passes `_purge=true` to the removal playbook. `230-remove-uptime-kuma.yml` only read its own `remove_pvc`, so the flag silently did nothing for this service.

## Fix

```yaml
_remove_pvc: "{{ (remove_pvc | default(false) | bool) or (_purge | default(false) | bool) }}"
```

Both spellings honoured — `_purge` for the CLI flag, `remove_pvc` so direct playbook runs keep working. The completion message now points at `uis undeploy uptime-kuma --purge` instead of a raw `ansible-playbook` invocation.

## Why it matters

Keeping data by default is right. Having **no supported way to remove it** is not: every reinstall after the first lands on an existing database, so a broken first-install path stays hidden. That is how the empty-username seeding bug survived a redeploy — it only became visible after dropping the volume by hand.

Same reasoning as `PLAN-service-litellm-003-undeploy-purge`, which documents the general case.

## Verification on assist

```
uis undeploy uptime-kuma --purge --yes
  TASK [4. Remove PVC (only with --purge / remove_pvc=true)]  changed
  "PVC deleted - monitor history and notification config are gone"

uis deploy uptime-kuma
  "Account seeded on this run - no browser wizard needed."
  ✓ deployed successfully
```

Two complete purge-and-rebuild cycles reproduced a byte-identical 19-monitor set, including identical heartbeat push tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR