### PR TITLE
Docs: explain the observability architecture, both halves of it

### DIFF
--- a/website/docs/services/observability/index.md
+++ b/website/docs/services/observability/index.md
@@ -1,12 +1,21 @@
 ---
 title: Observability
 sidebar_label: Observability
-description: Metrics, logs, and traces with Prometheus, Grafana, Loki, and Tempo
+description: How UIS answers "is it up?" and "why is it slow?" — the in-cluster stack, the external watchdog, and why you need both
 ---
 
 # Observability
 
-The observability package provides metrics, logs, and traces for all services running in UIS. All components are designed to work together as an integrated stack.
+UIS observability answers two different questions, and they need two different
+systems:
+
+| Question | Answered by | Runs |
+|---|---|---|
+| **Why is it slow? What happened?** | Prometheus, Loki, Tempo, Grafana | **inside** the cluster |
+| **Is it up?** | Uptime Kuma | **outside** the cluster |
+
+Most of this page is about why that split is structural rather than a matter of
+taste.
 
 ## Services
 
@@ -17,10 +26,9 @@ The observability package provides metrics, logs, and traces for all services ru
 | [Tempo](./tempo.md) | Distributed tracing backend | `./uis deploy tempo` |
 | [OTLP Collector](./otel.md) | Telemetry pipeline routing to all backends | `./uis deploy otel-collector` |
 | [Grafana](./grafana.md) | Visualization dashboards for all data | `./uis deploy grafana` |
+| [Uptime Kuma](./uptime-kuma.md) | External availability watchdog — **deploy elsewhere** | `./uis deploy uptime-kuma` |
 
 ## Quick Start
-
-Deploy the full observability stack in order:
 
 ```bash
 ./uis stack install observability
@@ -36,19 +44,129 @@ Or deploy individually:
 ./uis deploy grafana
 ```
 
-## How It Works
+All of the above deploy to the `monitoring` namespace.
+
+[Uptime Kuma](./uptime-kuma.md) is deliberately **not** part of that stack
+install. Deploying it next to what it watches defeats its purpose — see below.
+
+## The in-cluster stack
 
 ```
 Applications → OTLP Collector → Prometheus (metrics)
-                               → Loki (logs)
-                               → Tempo (traces)
-                                      ↓
-                                   Grafana (visualization)
+                              → Loki (logs)
+                              → Tempo (traces)
+                                     ↓
+                                  Grafana (visualization)
 ```
 
-1. Applications send telemetry via OTLP protocol to the collector
-2. The collector routes data to the appropriate backend
-3. Grafana queries all three backends for unified visualization
-4. Pre-built dashboards show service health and telemetry pipeline status
+1. Applications send telemetry via OTLP to the collector
+2. The collector routes each signal to the appropriate backend
+3. Grafana queries all three for unified visualization
+4. Pre-built dashboards show service health and pipeline status
 
-All services deploy to the `monitoring` namespace.
+This is deep, high-cardinality, and cheap to query — because it lives next to
+what it measures. That adjacency is also its one structural limit.
+
+## Why an external watchdog is not optional
+
+**A monitoring system cannot report its own death.** If the cluster is gone,
+so is the Prometheus that would have told you. If the node is wedged, so is
+Alertmanager. This is not a configuration gap you can close with more rules — no
+amount of in-cluster alerting produces a signal when the cluster stops.
+
+The consequence is the failure mode worth naming:
+
+:::danger Absence renders as green
+A monitor that was never created is indistinguishable from one that is passing.
+A dashboard with no data looks calm. Alertmanager with zero rules never fires.
+Silence and health look identical.
+:::
+
+So each layer is watched by something **outside** it:
+
+```mermaid
+flowchart TD
+    S["Services and applications"] -->|"metrics, logs, traces"| P["In-cluster stack<br/>Prometheus · Loki · Tempo · Grafana"]
+    C["Cluster, hosts, external dependencies"] -->|"probes and heartbeats"| W["External watchdog<br/>Uptime Kuma, another machine"]
+    W -->|"alerts"| PH["Your phone"]
+    H["A second machine, or an off-site service"] -->|"dead-man's switch"| W
+    H -->|"alerts directly, not via the watchdog"| PH
+```
+
+Each box can only report on things below it, never on itself:
+
+| Layer | Blind to |
+|---|---|
+| In-cluster stack | the cluster being down |
+| External watchdog | its own host being down |
+| Second machine | the whole site losing power or internet |
+
+Read it as a rule rather than a diagram: **whatever watches layer N must not
+live in layer N.** Applied honestly it does not terminate — a watchdog on a
+second machine still cannot report a site-wide power failure. At some point you
+accept a boundary; the discipline is knowing where you put it instead of
+discovering it during an incident.
+
+## Three kinds of signal
+
+The watchdog and the in-cluster stack are not just differently placed. They
+detect different classes of failure.
+
+| Signal | Direction | Detects | Missed by |
+|---|---|---|---|
+| **Probe** | pull — something asks | an endpoint stopped answering | nothing much; this is the well-covered case |
+| **Heartbeat** | push — a job reports in | **work that stopped happening** | metrics-based alerting, badly |
+| **Dead-man** | absence of a push | the watchdog itself died | everything else, by definition |
+
+Heartbeats are the capability nothing else provides. When a scheduled job simply
+stops running, no pod crashes, no endpoint goes down, and no error rate moves —
+there is nothing for a threshold to fire on. A heartbeat that stops arriving is
+unambiguous, and a heartbeat window is a deadline rather than a threshold.
+
+:::tip Push after the success check, never before
+A job that calls its heartbeat URL unconditionally reports success when it fails.
+That is worse than no heartbeat, because it manufactures confidence. Put the call
+after the job's own success check — in a shell script under `set -e`, that means
+the last line; in a systemd unit, `ExecStartPost`, which runs only if `ExecStart`
+exited 0.
+:::
+
+## Two rules for probes
+
+**Probe what a user depends on, not the process that provides it.** Whether a pod
+is `Running` is the in-cluster stack's job. Whether the endpoint answers is the
+watchdog's.
+
+**A 200 can lie.** Check content, not just status. A gateway can return HTTP 200
+while its database is unreachable, because the response never touched the
+database. Match a keyword you would only see if the thing genuinely works.
+
+## Alerting
+
+An alert that nobody receives is a log entry, and a dashboard nobody is watching
+is a screensaver. Uptime Kuma supports many notification providers; the choice
+matters less than two properties:
+
+- **It must not depend on the thing being monitored.** A channel that routes
+  through your own infrastructure fails exactly when you need it.
+- **It must be quiet when things are fine.** Attach alerting only to monitors
+  whose failure is both real and actionable. Anything that pages for a laptop
+  going to sleep, or for a job that was never started, trains you to swipe alerts
+  away — and then you swipe away the real one.
+
+See [Uptime Kuma](./uptime-kuma.md) for configuration.
+
+## What is automated today, and what is not
+
+:::info Monitor definitions are still manual
+UIS deploys the watchdog, seeds its admin account, and needs no browser wizard.
+It does **not** yet create monitors for the services you deploy — you define
+those yourself in the Uptime Kuma UI.
+
+Automating it, so that `uis deploy <service>` produces a monitor with no
+configuration written by anyone, is designed but not shipped:
+`PLAN-system-observability-006-service-probes` in the
+[ai-developer plans](../../ai-developer/plans/index.md). Two related plans cover
+per-service dashboards and declaring external dependencies as Services so probes
+can discover them like anything else.
+:::


### PR DESCRIPTION
The observability index described the in-cluster stack and **did not mention the external watchdog at all**, even though Uptime Kuma ships as a service. A reader came away thinking Prometheus and Grafana were the whole picture.

## The structure it now documents

| Question | Answered by | Runs |
|---|---|---|
| Why is it slow? What happened? | Prometheus, Loki, Tempo, Grafana | **inside** the cluster |
| Is it up? | Uptime Kuma | **outside** the cluster |

And why that split is structural, not a preference: **a monitoring system cannot report its own death.** If the cluster is gone, so is the Prometheus that would have told you. No amount of in-cluster alerting closes that.

## The layering rule

> Whatever watches layer N must not live in layer N.

| Layer | Blind to |
|---|---|
| In-cluster stack | the cluster being down |
| External watchdog | its own host being down |
| Second machine | the whole site losing power or internet |

Including the honest part: **the recursion doesn't terminate.** A watchdog on a second machine still can't report a site-wide power cut. The discipline is choosing where you put the boundary instead of discovering it mid-incident.

## Three signal classes

Probe (pull), heartbeat (push), dead-man (absence of a push) — and why heartbeats are the one capability nothing else provides: when a scheduled job stops running, no pod crashes, no endpoint goes down, no error rate moves. There is nothing for a threshold to fire on.

Plus the rule that a heartbeat pushed *before* its success check is worse than no heartbeat, because it manufactures confidence.

## What it does not claim

UIS deploys the watchdog and seeds its admin account. It does **not** yet create monitors for the services you deploy. The page says so, and points at the plan, rather than implying automation a user would go looking for and not find.

Uses mermaid and titled admonitions, both already used elsewhere in the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR