### PR TITLE
uptime-kuma: AutoKuma is part of the service

### DIFF
--- a/ansible/playbooks/230-remove-uptime-kuma.yml
+++ b/ansible/playbooks/230-remove-uptime-kuma.yml
@@ -35,6 +35,17 @@
     component_name: "uptime-kuma"
 
   tasks:
+    - name: "0. Remove AutoKuma (part of this service)"
+      # Before the StatefulSet: AutoKuma reconciles continuously, and leaving it
+      # running against a disappearing Kuma just produces connect errors.
+      kubernetes.core.k8s:
+        state: absent
+        api_version: apps/v1
+        kind: Deployment
+        name: autokuma
+        namespace: "{{ namespace }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
     - name: "1. Remove IngressRoute"
       kubernetes.core.k8s:
         state: absent
@@ -75,6 +86,28 @@
         kubeconfig: "{{ merged_kubeconf_file }}"
       when: _remove_pvc
       failed_when: false
+
+    - name: "4.1 Remove AutoKuma's state PVC (only with --purge)"
+      # Holds AutoKuma's id -> monitor mapping. Keeping it across a purge would
+      # leave it pointing at monitor ids that no longer exist.
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: autokuma-data
+        namespace: "{{ namespace }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      when: _remove_pvc
+
+    - name: "4.2 Remove the rendered monitor definitions (only with --purge)"
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: uptime-kuma-monitors
+        namespace: "{{ namespace }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      when: _remove_pvc
 
     - name: "5. Removal complete"
       ansible.builtin.debug:

--- a/ansible/playbooks/230-setup-uptime-kuma.yml
+++ b/ansible/playbooks/230-setup-uptime-kuma.yml
@@ -22,6 +22,9 @@
     manifests_folder: "/mnt/urbalurbadisk/manifests"
     statefulset_file: "{{ manifests_folder }}/230-uptime-kuma-statefulset.yaml"
     ingressroute_file: "{{ manifests_folder }}/230-uptime-kuma-ingressroute.yaml"
+    # AutoKuma is PART OF THIS SERVICE, not a service of its own. Uptime Kuma
+    # without it is an empty dashboard you have to fill in by hand.
+    autokuma_file: "{{ manifests_folder }}/230-uptime-kuma-autokuma.yaml"
     # History retention. Kuma's default is 180 days; the watchdog is expected to
     # run on modest/flash storage, so trim it. Override with
     # -e kuma_retention_days=N.
@@ -83,6 +86,28 @@
       delay: 6
       until: kuma_http.stdout is search('200|302')
       changed_when: false
+
+    - name: "5.1 Deploy AutoKuma (the monitor reconciler, part of this service)"
+      # After task 5, so Kuma is already answering and AutoKuma's first connect
+      # attempt succeeds rather than relying on its restart loop.
+      kubernetes.core.k8s:
+        state: present
+        src: "{{ autokuma_file }}"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+
+    - name: "5.2 Wait for AutoKuma to be ready"
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ namespace }}"
+        label_selectors:
+          - "app=autokuma"
+        kubeconfig: "{{ merged_kubeconf_file }}"
+      register: autokuma_pods
+      retries: 30
+      delay: 10
+      until: >
+        autokuma_pods.resources | length > 0 and
+        autokuma_pods.resources[0].status.phase == "Running"
 
     - name: "6. Verify the data volume is mounted"
       ansible.builtin.shell: >

--- a/ansible/playbooks/230-setup-uptime-kuma.yml
+++ b/ansible/playbooks/230-setup-uptime-kuma.yml
@@ -252,6 +252,79 @@
       changed_when: false
       failed_when: kuma_retention_check.stdout | trim != kuma_retention_days | string
 
+    # ---- alert channel -----------------------------------------------------
+    # An installed watchdog that notifies nobody is a dashboard. This is the
+    # step that makes it a watchdog.
+    #
+    # ⚠️ Seeded here rather than left to AutoKuma. AutoKuma CAN manage
+    # notifications - a file with "type": "notification" is accepted and alerts
+    # deliver correctly - but 2.0.0 never converges, rewriting the channel every
+    # ~5 seconds forever. That is a database write every 5s on what is usually
+    # flash storage.
+    - name: "9.3 Is an alert channel configured?"
+      ansible.builtin.set_fact:
+        _ntfy_topic: "{{ (kuma_secret.resources[0].data['uptime-kuma-ntfy-topic'] | default('') | b64decode) | trim }}"
+        _ntfy_server: "{{ (kuma_secret.resources[0].data['uptime-kuma-ntfy-server'] | default('') | b64decode) | trim or 'https://ntfy.sh' }}"
+      no_log: true
+
+    - name: "9.4 Note that alerting is not configured"
+      # Not a failure. A watchdog with no channel still monitors - the user just
+      # has to look. Say so plainly rather than deploying silently.
+      ansible.builtin.debug:
+        msg:
+          - "No alert channel configured - nothing will notify you."
+          - "Set UPTIME_KUMA_NTFY_TOPIC in the secrets template, then:"
+          - "  uis secrets generate && uis secrets apply && uis deploy uptime-kuma"
+      when: _ntfy_topic | length == 0
+
+    - name: "9.5 Seed the ntfy alert channel"
+      # Idempotent on name. Config is JSON on stdin so the topic never appears
+      # in a process list.
+      ansible.builtin.shell: |
+        set -o pipefail
+        printf '%s' "$CFG" | kubectl exec -i -n {{ namespace }} {{ component_name }}-0 \
+          --kubeconfig {{ merged_kubeconf_file }} -- sh -c '
+            read -r C
+            sqlite3 /app/data/kuma.db <<SQL
+        insert into notification (name, active, user_id, is_default, config)
+        select "uis-alerts", 1, 1, 0, '"'"'$C'"'"'
+        where not exists (select 1 from notification where name = "uis-alerts");
+        SQL
+          '
+      args:
+        executable: /bin/bash
+      environment:
+        # ⚠️ Build a mapping and serialise with to_json. A hand-written JSON
+        # STRING here does not survive: Ansible sees something that looks like a
+        # Python literal, converts it to a dict, and str()s it back with single
+        # quotes - which sqlite then rejects as a syntax error. Verified.
+        CFG: >-
+          {{ {'name': 'uis-alerts',
+              'type': 'ntfy',
+              'ntfyserverurl': _ntfy_server,
+              'ntfytopic': _ntfy_topic,
+              'ntfyPriority': 5,
+              'ntfyAuthenticationMethod': 'none',
+              'ntfyIcon': '',
+              'isDefault': false,
+              'applyExisting': false} | to_json }}
+      when: _ntfy_topic | length > 0
+      no_log: true
+      changed_when: true
+
+    - name: "9.6 Verify the channel is usable, not merely present"
+      # A row existing is not the same as it working. Check the stored config
+      # parses and carries the provider type Kuma dispatches on.
+      ansible.builtin.command: >
+        kubectl exec -n {{ namespace }} {{ component_name }}-0
+        --kubeconfig {{ merged_kubeconf_file }} --
+        sqlite3 /app/data/kuma.db
+        "select json_extract(config,'$.type') from notification where name='uis-alerts';"
+      register: kuma_notif_check
+      changed_when: false
+      failed_when: kuma_notif_check.stdout | trim != 'ntfy'
+      when: _ntfy_topic | length > 0
+
     - name: "10. Restart so needSetup is recomputed / settings cache is reloaded"
       # Kuma caches settings in memory, so a retention change needs a restart to
       # take effect - not just the row being written.

--- a/manifests/230-uptime-kuma-autokuma.yaml
+++ b/manifests/230-uptime-kuma-autokuma.yaml
@@ -1,0 +1,175 @@
+# 230-autokuma-deployment.yaml
+#
+# Description:
+# AutoKuma - reconciles monitor definition files into Uptime Kuma over its
+# Socket.IO interface, so UIS never writes to Kuma's database to manage monitors.
+# Definitions arrive as one JSON per monitor in the `uptime-kuma-monitors`
+# Secret; adding a key creates a monitor, removing one deletes it.
+#
+# Usage:
+#   kubectl apply -f 230-autokuma-deployment.yaml
+#
+# Prerequisites:
+# - monitoring namespace, with uptime-kuma running
+# - urbalurba-secrets with uptime-kuma-admin-user / uptime-kuma-admin-password
+# - Secret `uptime-kuma-monitors` (created by `uis monitors apply`; may be empty)
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# ⚠️ SIX BEHAVIOURS ARE ENCODED BELOW. EVERY ONE OF THEM FAILS SILENTLY.
+# All were found by prototyping on a live installation; none produce an error.
+# Changing any of them will appear to work.
+#
+#   1. Separate Deployment, not a sidecar in the uptime-kuma pod
+#   2. strategy: Recreate, not the default RollingUpdate
+#   3. /data must be a PVC
+#   4. The Secret must be flattened with `cp -L` before AutoKuma reads it
+#   5. Image tag 2.0.0, not v2.0.0
+#   6. Notifications are NOT managed here (see the note at the bottom)
+# ─────────────────────────────────────────────────────────────────────────────
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: autokuma-data
+  namespace: monitoring
+  labels:
+    app: autokuma
+spec:
+  # (3) AutoKuma keeps its id -> entity mapping in /data. That mapping is how it
+  # knows a monitor it created earlier is the same monitor on the next pass.
+  # Without persistence every pod restart re-creates every monitor as a new one:
+  # observed going from 19 monitors to 38, every name duplicated, no error
+  # anywhere.
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autokuma
+  namespace: monitoring
+  labels:
+    app: autokuma
+spec:
+  replicas: 1
+  # (2) /data is ReadWriteOnce and holds a lock-protected store, so only one
+  # AutoKuma may hold it. RollingUpdate starts the new pod before terminating
+  # the old, leaving two instances running - and because the definitions are
+  # COPIED into an emptyDir (see 4), the two can be working from different file
+  # sets. Observed: two pods coexisting for 20+ minutes, one of them still
+  # holding a monitor that had been deleted.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: autokuma
+  template:
+    metadata:
+      labels:
+        app: autokuma
+    spec:
+      initContainers:
+        # Kuma needs ~30s before it accepts Socket.IO. This is not the
+        # correctness guarantee - the restart loop is - but it avoids a noisy
+        # first failure on a cold boot. Targets the Service, not localhost,
+        # because this is a different pod.
+        - name: wait-for-kuma
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -s -o /dev/null -m 5 http://uptime-kuma.monitoring.svc.cluster.local:3001/; do
+                echo "waiting for uptime-kuma..."; sleep 5
+              done
+              echo "uptime-kuma is answering"
+        # (4) Kubernetes projects a Secret as a tree of symlinks into a hidden
+        # ..data/ directory:
+        #     asgard-k3s-api.json -> ..data/asgard-k3s-api.json
+        #     ..data              -> ..2026_08_07_23_49_10.3043089993/
+        # AutoKuma's file scanner does not follow them. It connects, runs its
+        # migrations, finds no files, logs NOTHING, and syncs NOTHING - which
+        # reads exactly like "there is nothing to do". `cp -L` dereferences the
+        # symlinks so it sees real files.
+        - name: flatten-monitors
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              # An empty Secret is normal on a stock install; do not fail on it.
+              cp -L /secret-monitors/*.json /monitors/ 2>/dev/null || true
+              echo "monitor definitions: $(ls -1 /monitors 2>/dev/null | wc -l)"
+          volumeMounts:
+            - { name: monitors-secret, mountPath: /secret-monitors, readOnly: true }
+            - { name: monitors, mountPath: /monitors }
+      containers:
+        - name: autokuma
+          # (5) 2.0.0, NOT v2.0.0. The v-prefixed tag is single-arch and will
+          # not pull on arm64 - which is exactly where a watchdog tends to run.
+          image: ghcr.io/bigboot/autokuma:2.0.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: AUTOKUMA__KUMA__URL
+              value: "http://uptime-kuma.monitoring.svc.cluster.local:3001"
+            # The same admin the setup playbook seeds - no extra credential.
+            - name: AUTOKUMA__KUMA__USERNAME
+              valueFrom:
+                secretKeyRef: { name: urbalurba-secrets, key: uptime-kuma-admin-user }
+            - name: AUTOKUMA__KUMA__PASSWORD
+              valueFrom:
+                secretKeyRef: { name: urbalurba-secrets, key: uptime-kuma-admin-password }
+            - name: AUTOKUMA__STATIC_MONITORS
+              value: "/monitors"
+            # Removing a definition removes the monitor. This is what keeps
+            # `uis undeploy <service>` from leaving an orphaned monitor behind,
+            # without UIS having to implement deletion itself.
+            - name: AUTOKUMA__ON_DELETE
+              value: "delete"
+            - name: AUTOKUMA__DELETE_GRACE_PERIOD
+              value: "120"
+            # The file source is the supported one. AutoKuma's Kubernetes and
+            # Docker Swarm providers are documented as as-is and looking for a
+            # maintainer.
+            - name: AUTOKUMA__DOCKER__ENABLED
+              value: "false"
+          volumeMounts:
+            # Read-only: the init container populated this.
+            - { name: monitors, mountPath: /monitors, readOnly: true }
+            - { name: data, mountPath: /data }
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits:   { cpu: 500m, memory: 128Mi }
+      volumes:
+        # A Secret rather than a ConfigMap: a rendered probe can carry a
+        # resolved Authorization header.
+        - name: monitors-secret
+          secret:
+            secretName: uptime-kuma-monitors
+            optional: true
+        - name: monitors
+          emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: autokuma-data
+#
+# (6) ⚠️ NOTIFICATIONS ARE DELIBERATELY NOT MANAGED HERE.
+#
+# AutoKuma *can* own the alert channel: a file with `"type": "notification"` is
+# accepted by the file source (undocumented - upstream only documents Docker
+# labels), monitors then resolve `notification_name_list` by name, and alerts
+# deliver correctly. It was verified working end to end.
+#
+# It is not used because AutoKuma 2.0.0 never converges on notifications: it
+# re-sends "Updating notification" every ~5 seconds, forever, which is a Kuma
+# database write every 5s - on a watchdog that typically runs on flash storage.
+# Confirmed with a single instance and a freshly cleared state store, so it is
+# not a duplicate-pod artifact. Upstream calls notification support experimental.
+#
+# The channel and its monitor attachments are seeded by the setup playbook
+# instead. AutoKuma leaves them alone because it has no record of them.
+#
+# Consequence: rendered monitor files must NOT contain `notification_name_list`,
+# or AutoKuma logs a resolve warning for every monitor on every pass.

--- a/manifests/230-uptime-kuma-discovery-rbac.yaml
+++ b/manifests/230-uptime-kuma-discovery-rbac.yaml
@@ -1,0 +1,50 @@
+# Read-only identity for monitor discovery from another cluster.
+#
+# ⚠️ The watchdog must NEVER hold cluster-admin. It only needs to answer
+# "what services exist and where are they reachable", which is three read verbs
+# on three resource types. Copying an admin kubeconfig onto the watchdog host
+# would put full control of this cluster on a machine whose whole purpose is to
+# be outside it - and, on the reference installation, on a Raspberry Pi with its
+# root filesystem on a microSD card.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monitor-discovery
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitor-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list"]
+  - apiGroups: ["traefik.io", "traefik.containo.us"]
+    resources: ["ingressroutes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitor-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitor-discovery
+subjects:
+  - kind: ServiceAccount
+    name: monitor-discovery
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitor-discovery-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: monitor-discovery
+type: kubernetes.io/service-account-token

--- a/provision-host/uis/lib/monitors.py
+++ b/provision-host/uis/lib/monitors.py
@@ -210,6 +210,17 @@ def load_probes(services_dir):
     return out
 
 
+def read_secret_key(key, namespace="monitoring"):
+    """A single key out of urbalurba-secrets. Values never live in YAML."""
+    import base64
+    r = subprocess.run(
+        ["kubectl", "get", "secret", "urbalurba-secrets", "-n", namespace,
+         "-o", f"jsonpath={{.data.{key}}}"], capture_output=True, text=True)
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    return base64.b64decode(r.stdout.strip()).decode().strip()
+
+
 def push_token(salt, name):
     """Heartbeat tokens are DERIVED, never random.
 
@@ -233,6 +244,7 @@ def render_monitor(name, kind, value, probe):
     attachments instead.
     """
     o = {"name": name,
+         "_notify": probe.get("notify", True),
          "interval": int(probe.get("interval", 60)),
          "max_retries": int(probe.get("maxretries", 2)),
          "retry_interval": int(probe.get("retry_interval", 60)),
@@ -318,6 +330,7 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
             m = dict(defaults)
             m.update(entry)
             o = {"name": m["name"], "type": m["type"],
+                 "_notify": m.get("notify", True),
                  "interval": int(m.get("interval", 60)),
                  "max_retries": int(m.get("maxretries", 2)),
                  "retry_interval": int(m.get("retry_interval", 60)),
@@ -333,7 +346,18 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
                     o["accepted_statuscodes"] = m["accepted_statuscodes"]
             elif m["type"] == "port":
                 o["hostname"], o["port"] = m["hostname"], int(m["port"])
-            elif m["type"] == "push":
+            # auth_header_secret names a key in urbalurba-secrets - never a
+            # value. Resolved at render time so the secret lives in exactly one
+            # place and the definition stays safe to read.
+            if m.get("auth_header_secret"):
+                hv = read_secret_key(m["auth_header_secret"])
+                if hv:
+                    o["headers"] = json.dumps({"Authorization": hv})
+                else:
+                    sys.exit(f"ERROR: {m['name']} references auth_header_secret "
+                             f"'{m['auth_header_secret']}' but that key is not in "
+                             f"urbalurba-secrets")
+            if m["type"] == "push":
                 if not salt:
                     sys.exit("ERROR: a push monitor needs uptime-kuma-push-salt "
                              "in urbalurba-secrets - without it the heartbeat "
@@ -342,6 +366,67 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
             monitors.append(o)
 
     return monitors, skipped, in_cluster
+
+
+def kuma_sql(namespace, query):
+    r = subprocess.run(
+        ["kubectl", "exec", "-n", namespace, "uptime-kuma-0", "--",
+         "sqlite3", "-separator", "\x1f", "/app/data/kuma.db", query],
+        capture_output=True, text=True)
+    if r.returncode != 0:
+        return None
+    return [l.split("\x1f") for l in r.stdout.strip().splitlines() if l.strip()]
+
+
+def attach_alerts(namespace, monitors, wait=180):
+    """Attach the alert channel to every monitor that should page.
+
+    Done here rather than by AutoKuma: AutoKuma resolves notification names only
+    against notifications it manages, and letting it manage the channel makes it
+    rewrite that channel every ~5 seconds forever.
+
+    Insert-only, so a channel a human attached by hand is never removed.
+    """
+    rows = kuma_sql(namespace,
+                    f"select id from notification where name='{NOTIFICATION_NAME}';")
+    if not rows:
+        print(f"\n  no '{NOTIFICATION_NAME}' channel - nothing will notify you.")
+        print("  Set UPTIME_KUMA_NTFY_TOPIC and redeploy uptime-kuma.")
+        return 0
+    nid = rows[0][0]
+
+    # AutoKuma creates monitors asynchronously; wait for them rather than
+    # attaching to a half-populated set.
+    want = {m["name"] for m in monitors if m.get("_notify", True)}
+    import time
+    deadline = time.time() + wait
+    while time.time() < deadline:
+        have = {r[0] for r in (kuma_sql(namespace, "select name from monitor;") or [])}
+        if want <= have:
+            break
+        time.sleep(5)
+
+    ids = {r[0]: r[1] for r in (kuma_sql(namespace, "select name, id from monitor;") or [])}
+    attached = {r[0] for r in (kuma_sql(
+        namespace,
+        "select m.name from monitor m join monitor_notification mn "
+        f"on mn.monitor_id=m.id where mn.notification_id={nid};") or [])}
+    added = 0
+    for name in sorted(want):
+        if name in attached or name not in ids:
+            continue
+        kuma_sql(namespace, "insert into monitor_notification (monitor_id, "
+                            f"notification_id) values ({ids[name]}, {nid});")
+        added += 1
+    missing = sorted(want - set(ids))
+    print(f"\n  alerting: {added} newly attached, {len(attached)} already, "
+          f"{len(monitors) - len(want)} deliberately silent")
+    if missing:
+        # Loud: these were rendered but Kuma does not have them, so they cannot
+        # be attached and are not being watched.
+        print(f"  ⚠️  {len(missing)} rendered but absent from Uptime Kuma "
+              f"(AutoKuma may be wedged): {', '.join(missing)}")
+    return added
 
 
 def main():
@@ -382,14 +467,17 @@ def main():
         if args.outdir:
             os.makedirs(args.outdir, exist_ok=True)
             for m in monitors:
-                json.dump(m, open(f"{args.outdir}/{m['name']}.json", "w"), indent=2)
+                json.dump({k: v for k, v in m.items() if k != "_notify"},
+                          open(f"{args.outdir}/{m['name']}.json", "w"), indent=2)
             print(f"\n  wrote {len(monitors)} files to {args.outdir}")
         return 0
 
     if args.action == "apply":
         import base64
+        # _notify is UIS bookkeeping; AutoKuma must not see it.
+        clean = [{k: v for k, v in m.items() if k != "_notify"} for m in monitors]
         data = {f"{m['name']}.json": base64.b64encode(
-            json.dumps(m, indent=2).encode()).decode() for m in monitors}
+            json.dumps(m, indent=2).encode()).decode() for m in clean}
         secret = {"apiVersion": "v1", "kind": "Secret",
                   "metadata": {"name": "uptime-kuma-monitors",
                                "namespace": args.namespace},
@@ -399,6 +487,7 @@ def main():
         if p.returncode != 0:
             sys.exit(f"ERROR: {p.stderr.strip()}")
         print(f"\n  applied {len(monitors)} definitions to uptime-kuma-monitors")
+        attach_alerts(args.namespace, monitors)
         return 0
 
     if args.action == "check":

--- a/provision-host/uis/lib/monitors.py
+++ b/provision-host/uis/lib/monitors.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Render availability monitors for the services UIS has deployed.
+
+THE GOAL
+`uis deploy <service>` should result in that service being monitored, with no
+configuration written by the user. They ran a deploy command; they should not
+also have to know the service's hostname, health path, or which secret holds its
+API key.
+
+Both halves of a monitor are already known:
+
+  HOW to probe  - path, keyword, which secret: ships with the service as
+                  services/<category>/probes/<id>.yaml
+  WHERE it is   - discovered from the Service / Ingress that `uis deploy` created
+
+⚠️ THE WATCHDOG IS OUTSIDE THE CLUSTER, WHICH CONSTRAINS "WHERE".
+Uptime Kuma is deliberately deployed away from the platform it watches - a
+monitor inside a cluster cannot report that cluster being down. So a ClusterIP
+is useless to it: `litellm.ai.svc.cluster.local` does not resolve from another
+machine. Endpoint resolution must yield something reachable from outside, and
+when it cannot, that service is reported as unmonitorable rather than silently
+skipped. Silence is the failure mode this whole subsystem exists to prevent.
+"""
+
+import ipaddress
+import json
+import os
+import subprocess
+import sys
+
+# Kubernetes pod CIDR. An Endpoints address outside it means the Service is a
+# shim pointing at something beyond the cluster - which, unlike a ClusterIP, an
+# external watchdog CAN reach.
+POD_CIDRS = ["10.42.0.0/16", "10.244.0.0/16"]
+
+NOTIFICATION_NAME = "uis-alerts"
+
+
+def kubectl_json(args):
+    r = subprocess.run(["kubectl"] + args + ["-o", "json"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"ERROR: kubectl {' '.join(args)} failed: {r.stderr.strip()}")
+    return json.loads(r.stdout)
+
+
+def is_pod_ip(addr):
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return any(ip in ipaddress.ip_network(c) for c in POD_CIDRS)
+
+
+def load_cluster():
+    """One read of everything endpoint resolution needs."""
+    out = {"Service": {}, "Endpoints": {}, "Ingress": [], "IngressRoute": []}
+    d = kubectl_json(["get", "svc,endpoints,ingress", "-A"])
+    for i in d.get("items", []):
+        k, md = i["kind"], i["metadata"]
+        if k in ("Service", "Endpoints"):
+            out[k][(md["namespace"], md["name"])] = i
+        elif k == "Ingress":
+            out["Ingress"].append(i)
+    # IngressRoute is a CRD and may not exist (no Traefik). Not an error.
+    try:
+        d = kubectl_json(["get", "ingressroute", "-A"])
+        out["IngressRoute"] = d.get("items", [])
+    except SystemExit:
+        pass
+    return out
+
+
+def tailnet_hosts(cluster):
+    """service -> globally resolvable FQDN, via the tailscale ingress class.
+
+    This is the best possible answer for an external watchdog: a real DNS name
+    with a real certificate, reachable from anywhere on the tailnet, with no
+    Host-header trickery and no dependence on the cluster's ingress IP.
+    """
+    found = {}
+    for i in cluster["Ingress"]:
+        if i["spec"].get("ingressClassName") != "tailscale":
+            continue
+        lb = i.get("status", {}).get("loadBalancer", {}).get("ingress", [])
+        host = lb[0].get("hostname") if lb else None
+        if not host:
+            continue                      # provisioned but not ready yet
+        ns = i["metadata"]["namespace"]
+        for r in i["spec"].get("rules", []):
+            for p in r.get("http", {}).get("paths", []):
+                found[(ns, p["backend"]["service"]["name"])] = host
+        db = i["spec"].get("defaultBackend", {}).get("service", {}).get("name")
+        if db:
+            found[(ns, db)] = host
+    return found
+
+
+def external_endpoint(cluster, ns, name):
+    """A shim Service's real address, if it has one.
+
+    A Service whose Endpoints point outside the pod CIDR is a declared
+    dependency on something beyond the cluster - an external database, an Ollama
+    host on the LAN. The address is right there in the Endpoints object, so the
+    watchdog needs nothing from the user.
+    """
+    e = cluster["Endpoints"].get((ns, name))
+    if not e:
+        return None
+    for subset in e.get("subsets") or []:
+        for a in subset.get("addresses") or []:
+            if not is_pod_ip(a["ip"]):
+                ports = subset.get("ports") or []
+                return (a["ip"], ports[0]["port"] if ports else None)
+    return None
+
+
+def watchdog_is_in_cluster(cluster, namespace="monitoring"):
+    """Is Uptime Kuma running in the cluster we are rendering for?
+
+    This is THE question that decides how endpoints resolve, and it is answered
+    by looking rather than by asking the user to configure it.
+
+    Both topologies are legitimate and UIS supports both:
+
+      Production  - the watchdog runs on a separate machine, because a monitor
+                    inside a cluster cannot report that cluster being down.
+                    Endpoints must be reachable from outside.
+
+      Development - a developer running UIS on Rancher Desktop has one cluster.
+                    Uptime Kuma runs in it, ClusterIP resolves fine, and MORE is
+                    monitorable than in production (in-cluster-only services
+                    like PostgreSQL included).
+
+    Same command, same probe artifacts, same service definitions - only the
+    resolved address differs. That is what keeps dev and prod comparable instead
+    of merely similar.
+    """
+    return (namespace, "uptime-kuma") in cluster["Service"]
+
+
+def cluster_local(cluster, ns, name):
+    """In-cluster DNS name and port for a Service."""
+    svc = cluster["Service"].get((ns, name), {})
+    ports = svc.get("spec", {}).get("ports") or []
+    if not ports:
+        return None
+    return (f"{name}.{ns}.svc.cluster.local", ports[0].get("port"))
+
+
+def resolve(cluster, ts, ns, name, in_cluster=False):
+    """Where the watchdog can reach this service.""" if False else """Where the watchdog can reach this service.
+
+    Returns (kind, value, why) or (None, None, reason-it-cannot-be-reached).
+    Order matters: prefer a real hostname over an IP, and an IP over nothing.
+    """
+    # In-cluster watchdog: Service DNS is the correct target. It is also the
+    # most honest one - it tests the same path other pods use, and it does not
+    # depend on ingress being configured at all.
+    if in_cluster:
+        cl = cluster_local(cluster, ns, name)
+        if cl:
+            return ("hostport", cl, "in-cluster Service DNS")
+    if (ns, name) in ts:
+        return ("url", f"https://{ts[(ns, name)]}", "tailnet ingress")
+    ext = external_endpoint(cluster, ns, name)
+    if ext:
+        return ("hostport", ext, "shim Service - external endpoint")
+    svc = cluster["Service"].get((ns, name), {})
+    stype = svc.get("spec", {}).get("type")
+    if stype == "LoadBalancer":
+        lb = svc.get("status", {}).get("loadBalancer", {}).get("ingress", [])
+        if lb:
+            addr = lb[0].get("hostname") or lb[0].get("ip")
+            if addr:
+                return ("host", addr, "LoadBalancer")
+    # ClusterIP with only pod endpoints. Reachable from inside the cluster and
+    # nowhere else. Reported, never silently dropped.
+    return (None, None,
+            "only reachable inside the cluster (ClusterIP). An external "
+            "watchdog cannot probe it - expose it, give it a shim, or rely on "
+            "the services that depend on it failing their own probes")
+
+
+def load_probes(services_dir):
+    """probe artifacts shipped with services: <category>/probes/<id>.yaml"""
+    try:
+        import yaml
+    except ImportError:
+        sys.exit("ERROR: pyyaml not installed")
+    out = {}
+    if not os.path.isdir(services_dir):
+        return out
+    for category in sorted(os.listdir(services_dir)):
+        pdir = os.path.join(services_dir, category, "probes")
+        if not os.path.isdir(pdir):
+            continue
+        for fn in sorted(os.listdir(pdir)):
+            if not fn.endswith((".yaml", ".yml")):
+                continue
+            with open(os.path.join(pdir, fn)) as fh:
+                doc = yaml.safe_load(fh) or {}
+            sid = fn.rsplit(".", 1)[0]
+            # `service:` names the Kubernetes Service when it differs from the
+            # service id - temporal's is temporal-web, authentik's is
+            # authentik-server. Without this the probe silently matches nothing,
+            # which is the failure mode the whole subsystem exists to avoid.
+            out[sid] = {"service": doc.get("service", sid),
+                        "probes": doc.get("probes", [])}
+    return out
+
+
+def push_token(salt, name):
+    """Heartbeat tokens are DERIVED, never random.
+
+    A push token is the URL a job calls. Random tokens mean every rebuild
+    reissues every URL, and the old URL then goes quietly silent rather than
+    failing loudly - the job keeps exiting 0 while nothing records it. Deriving
+    from one salt makes the whole set reproducible: purge and rebuild, and every
+    already-wired job keeps working untouched.
+    """
+    import hashlib
+    import hmac
+    return hmac.new(salt.encode(), name.encode(), hashlib.sha256).hexdigest()[:32]
+
+
+def render_monitor(name, kind, value, probe):
+    """One AutoKuma static-monitor definition.
+
+    ⚠️ Never emits notification_name_list. AutoKuma resolves that only against
+    notifications IT manages, and letting it manage the channel makes it rewrite
+    the channel every ~5s forever. The setup playbook owns the channel and its
+    attachments instead.
+    """
+    o = {"name": name,
+         "interval": int(probe.get("interval", 60)),
+         "max_retries": int(probe.get("maxretries", 2)),
+         "retry_interval": int(probe.get("retry_interval", 60)),
+         "active": True}
+    ptype = probe.get("type", "http")
+    if ptype == "http":
+        base = value if kind == "url" else f"http://{value[0]}:{value[1]}"
+        o["url"] = base.rstrip("/") + probe.get("path", "/")
+        o["type"] = "http"
+        if probe.get("keyword"):
+            o["type"] = "keyword"      # Kuma models keyword as its own type
+            o["keyword"] = probe["keyword"]
+        if probe.get("accepted_statuscodes"):
+            o["accepted_statuscodes"] = probe["accepted_statuscodes"]
+        if probe.get("ignore_tls"):
+            o["ignore_tls"] = True
+    elif ptype in ("tcp", "port"):
+        o["type"] = "port"
+        if kind == "hostport":
+            o["hostname"], o["port"] = value[0], int(value[1])
+        else:
+            return None                # a URL is not a TCP target
+    elif ptype == "push":
+        o["type"] = "push"
+    return o
+
+
+def deployed_services(cluster):
+    """Services UIS deployed, as (namespace, name), keyed by service id.
+
+    Matches a probe artifact's filename to a Kubernetes Service of the same
+    name. That is the convention `uis deploy` already produces.
+    """
+    out = {}
+    for (ns, name) in cluster["Service"]:
+        out.setdefault(name, (ns, name))
+    return out
+
+
+def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
+    """Everything that should be monitored, plus everything that cannot be.
+
+    Returns (monitors, skipped). `skipped` is never discarded: a service that
+    silently fails to get a monitor is indistinguishable from one that is
+    passing, which is the exact trap this subsystem exists to close.
+    """
+    cluster = load_cluster()
+    ts = tailnet_hosts(cluster)
+    probes = load_probes(services_dir)
+    svc = deployed_services(cluster)
+
+    if watchdog == "auto":
+        in_cluster = watchdog_is_in_cluster(cluster)
+    else:
+        in_cluster = (watchdog == "in-cluster")
+    monitors, skipped = [], []
+    for sid, spec in sorted(probes.items()):
+        plist = spec["probes"]
+        target = spec["service"]
+        if target not in svc:
+            continue                       # service not deployed here
+        ns, name = svc[target]
+        kind, value, why = resolve(cluster, ts, ns, name, in_cluster)
+        if kind is None:
+            skipped.append((sid, why))
+            continue
+        for p in plist:
+            mname = sid if p.get("id") in (None, "gateway") else f"{sid}-{p['id']}"
+            m = render_monitor(mname, kind, value, p)
+            if m is None:
+                skipped.append((mname, f"probe type {p.get('type')} needs a "
+                                       f"host:port, but {sid} resolved to a URL"))
+                continue
+            monitors.append(m)
+
+    # Targets UIS did NOT deploy: a hypervisor, a NAS, a laptop, a job.
+    # Absent on a stock install, and that is the normal case.
+    if extend_file and os.path.isfile(extend_file):
+        import yaml
+        doc = yaml.safe_load(open(extend_file)) or {}
+        defaults = doc.get("defaults", {})
+        for entry in doc.get("monitors", []):
+            m = dict(defaults)
+            m.update(entry)
+            o = {"name": m["name"], "type": m["type"],
+                 "interval": int(m.get("interval", 60)),
+                 "max_retries": int(m.get("maxretries", 2)),
+                 "retry_interval": int(m.get("retry_interval", 60)),
+                 "active": True}
+            if m["type"] == "http":
+                o["url"] = m["url"]
+                if m.get("keyword"):
+                    o["type"] = "keyword"
+                    o["keyword"] = m["keyword"]
+                if m.get("ignore_tls"):
+                    o["ignore_tls"] = True
+                if m.get("accepted_statuscodes"):
+                    o["accepted_statuscodes"] = m["accepted_statuscodes"]
+            elif m["type"] == "port":
+                o["hostname"], o["port"] = m["hostname"], int(m["port"])
+            elif m["type"] == "push":
+                if not salt:
+                    sys.exit("ERROR: a push monitor needs uptime-kuma-push-salt "
+                             "in urbalurba-secrets - without it the heartbeat "
+                             "URL cannot be derived and would change on rebuild")
+                o["push_token"] = push_token(salt, m["name"])
+            monitors.append(o)
+
+    return monitors, skipped, in_cluster
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser(prog="uis monitors")
+    ap.add_argument("action", choices=["render", "apply", "check"])
+    ap.add_argument("--services-dir", default="/mnt/urbalurbadisk/provision-host/uis/services")
+    ap.add_argument("--extend", default="/mnt/urbalurbadisk/.uis.extend/monitors.yaml")
+    ap.add_argument("--namespace", default="monitoring")
+    ap.add_argument("--outdir")
+    ap.add_argument("--watchdog", choices=["auto", "in-cluster", "external"],
+                    default="auto",
+                    help="where Uptime Kuma runs. auto detects it by looking for "
+                         "the service in the target cluster; override when "
+                         "rendering for a watchdog that is not up yet")
+    args = ap.parse_args()
+
+    salt = os.environ.get("UPTIME_KUMA_PUSH_SALT")
+    monitors, skipped, in_cluster = build(args.services_dir, args.extend, salt,
+                                          args.watchdog)
+
+    where = ("IN-CLUSTER (development topology - a watchdog here cannot report "
+             "this cluster being down)" if in_cluster else
+             "EXTERNAL (production topology)")
+    print(f"  watchdog: {where}")
+    print(f"  monitors: {len(monitors)}   not monitorable: {len(skipped)}")
+    for m in monitors:
+        print(f"    {m['type']:<8} {m['name']:<28} "
+              f"{m.get('url') or str(m.get('hostname','')) + ':' + str(m.get('port',''))}")
+    if skipped:
+        # Loud on purpose. A deployed service with no monitor must never be
+        # mistaken for a healthy one.
+        print(f"\n  NOT MONITORED ({len(skipped)}):")
+        for sid, why in skipped:
+            print(f"    {sid}: {why}")
+
+    if args.action == "render":
+        if args.outdir:
+            os.makedirs(args.outdir, exist_ok=True)
+            for m in monitors:
+                json.dump(m, open(f"{args.outdir}/{m['name']}.json", "w"), indent=2)
+            print(f"\n  wrote {len(monitors)} files to {args.outdir}")
+        return 0
+
+    if args.action == "apply":
+        import base64
+        data = {f"{m['name']}.json": base64.b64encode(
+            json.dumps(m, indent=2).encode()).decode() for m in monitors}
+        secret = {"apiVersion": "v1", "kind": "Secret",
+                  "metadata": {"name": "uptime-kuma-monitors",
+                               "namespace": args.namespace},
+                  "type": "Opaque", "data": data}
+        p = subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(secret),
+                           capture_output=True, text=True)
+        if p.returncode != 0:
+            sys.exit(f"ERROR: {p.stderr.strip()}")
+        print(f"\n  applied {len(monitors)} definitions to uptime-kuma-monitors")
+        return 0
+
+    if args.action == "check":
+        # Compare intent against what Kuma is ACTUALLY running. AutoKuma
+        # self-heals drift, so a stopped AutoKuma looks exactly like a healthy
+        # one - checking only the Secret would miss that entirely.
+        r = subprocess.run(
+            ["kubectl", "exec", "-n", args.namespace, "uptime-kuma-0", "--",
+             "sqlite3", "/app/data/kuma.db", "select name from monitor;"],
+            capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit("ERROR: could not read Uptime Kuma - is it deployed?")
+        live = {l.strip() for l in r.stdout.splitlines() if l.strip()}
+        want = {m["name"] for m in monitors}
+        missing, extra = sorted(want - live), sorted(live - want)
+        if missing:
+            print(f"\n  MISSING from Uptime Kuma ({len(missing)}) - NOT being "
+                  f"monitored. If the definitions are applied, AutoKuma is "
+                  f"wedged:")
+            for n in missing:
+                print(f"    - {n}")
+        if extra:
+            print(f"\n  in Uptime Kuma but not declared ({len(extra)}):")
+            for n in extra:
+                print(f"    - {n}")
+        if not (missing or extra or skipped):
+            print("\n  OK - Uptime Kuma matches what UIS deployed")
+            return 0
+        return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/provision-host/uis/lib/monitors.py
+++ b/provision-host/uis/lib/monitors.py
@@ -36,8 +36,22 @@ POD_CIDRS = ["10.42.0.0/16", "10.244.0.0/16"]
 NOTIFICATION_NAME = "uis-alerts"
 
 
-def kubectl_json(args):
-    r = subprocess.run(["kubectl"] + args + ["-o", "json"],
+# Two clusters, deliberately separate.
+#   FROM - where the services are.       Read-only. Discovery.
+#   TO   - where the watchdog runs.      Written to.
+# They are the same cluster for a developer on Rancher Desktop, and different in
+# production, because a watchdog inside the cluster it watches cannot report that
+# cluster being down.
+CTX_FROM = None
+CTX_TO = None
+
+
+def _ctx(ctx):
+    return ["--context", ctx] if ctx else []
+
+
+def kubectl_json(args, ctx=None):
+    r = subprocess.run(["kubectl"] + _ctx(ctx) + args + ["-o", "json"],
                        capture_output=True, text=True)
     if r.returncode != 0:
         sys.exit(f"ERROR: kubectl {' '.join(args)} failed: {r.stderr.strip()}")
@@ -55,7 +69,7 @@ def is_pod_ip(addr):
 def load_cluster():
     """One read of everything endpoint resolution needs."""
     out = {"Service": {}, "Endpoints": {}, "Ingress": [], "IngressRoute": []}
-    d = kubectl_json(["get", "svc,endpoints,ingress", "-A"])
+    d = kubectl_json(["get", "svc,endpoints,ingress", "-A"], CTX_FROM)
     for i in d.get("items", []):
         k, md = i["kind"], i["metadata"]
         if k in ("Service", "Endpoints"):
@@ -64,7 +78,7 @@ def load_cluster():
             out["Ingress"].append(i)
     # IngressRoute is a CRD and may not exist (no Traefik). Not an error.
     try:
-        d = kubectl_json(["get", "ingressroute", "-A"])
+        d = kubectl_json(["get", "ingressroute", "-A"], CTX_FROM)
         out["IngressRoute"] = d.get("items", [])
     except SystemExit:
         pass
@@ -115,7 +129,7 @@ def external_endpoint(cluster, ns, name):
     return None
 
 
-def watchdog_is_in_cluster(cluster, namespace="monitoring"):
+def watchdog_in_from_cluster(cluster, namespace="monitoring"):
     """Is Uptime Kuma running in the cluster we are rendering for?
 
     This is THE question that decides how endpoints resolve, and it is answered
@@ -214,8 +228,9 @@ def read_secret_key(key, namespace="monitoring"):
     """A single key out of urbalurba-secrets. Values never live in YAML."""
     import base64
     r = subprocess.run(
-        ["kubectl", "get", "secret", "urbalurba-secrets", "-n", namespace,
-         "-o", f"jsonpath={{.data.{key}}}"], capture_output=True, text=True)
+        ["kubectl"] + _ctx(CTX_TO) + ["get", "secret", "urbalurba-secrets",
+         "-n", namespace, "-o", f"jsonpath={{.data.{key}}}"],
+        capture_output=True, text=True)
     if r.returncode != 0 or not r.stdout.strip():
         return None
     return base64.b64decode(r.stdout.strip()).decode().strip()
@@ -233,6 +248,33 @@ def push_token(salt, name):
     import hashlib
     import hmac
     return hmac.new(salt.encode(), name.encode(), hashlib.sha256).hexdigest()[:32]
+
+
+def resolve_auth(probe):
+    """Resolve `auth: bearer:<SECRET_KEY>` to a header value.
+
+    Returns (headers_json, error). The probe names a KEY in urbalurba-secrets,
+    never a value, so definitions stay safe to read and the secret lives in one
+    place.
+
+    ⚠️ A missing key must NOT yield an unauthenticated monitor. That produces a
+    401, which reads as "the service is down" and pages someone about a
+    configuration mistake. Better to refuse to create the monitor and say why.
+    """
+    spec = probe.get("auth")
+    if not spec:
+        return None, None
+    if ":" not in spec:
+        return None, f"unrecognised auth spec '{spec}' (expected bearer:KEY)"
+    scheme, key = spec.split(":", 1)
+    if scheme != "bearer":
+        return None, f"unsupported auth scheme '{scheme}' (only bearer:KEY)"
+    val = read_secret_key(key)
+    if not val:
+        return None, (f"needs secret key '{key}' in urbalurba-secrets. Without "
+                      f"it the probe would get 401 and page you about a config "
+                      f"mistake, so no monitor was created")
+    return json.dumps({"Authorization": f"Bearer {val}"}), None
 
 
 def render_monitor(name, kind, value, probe):
@@ -261,6 +303,11 @@ def render_monitor(name, kind, value, probe):
             o["accepted_statuscodes"] = probe["accepted_statuscodes"]
         if probe.get("ignore_tls"):
             o["ignore_tls"] = True
+        headers, err = resolve_auth(probe)
+        if err:
+            return err                 # a string means "cannot build this one"
+        if headers:
+            o["headers"] = headers
     elif ptype in ("tcp", "port"):
         o["type"] = "port"
         if kind == "hostport":
@@ -297,7 +344,10 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
     svc = deployed_services(cluster)
 
     if watchdog == "auto":
-        in_cluster = watchdog_is_in_cluster(cluster)
+        # Only in-cluster if the watchdog lives in the SAME cluster we are
+        # discovering from. Different contexts means production topology, even
+        # if a Kuma happens to exist in both.
+        in_cluster = (CTX_FROM == CTX_TO) and watchdog_in_from_cluster(cluster)
     else:
         in_cluster = (watchdog == "in-cluster")
     monitors, skipped = [], []
@@ -314,6 +364,9 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
         for p in plist:
             mname = sid if p.get("id") in (None, "gateway") else f"{sid}-{p['id']}"
             m = render_monitor(mname, kind, value, p)
+            if isinstance(m, str):
+                skipped.append((mname, m))
+                continue
             if m is None:
                 skipped.append((mname, f"probe type {p.get('type')} needs a "
                                        f"host:port, but {sid} resolved to a URL"))
@@ -365,12 +418,28 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
                 o["push_token"] = push_token(salt, m["name"])
             monitors.append(o)
 
+    # ⚠️ Duplicate names would silently overwrite each other: definitions are
+    # written as <name>.json, so the second one wins and the first monitor just
+    # never exists. Refuse instead. Almost always this means the extend file
+    # lists something UIS can now discover on its own.
+    seen, dupes = set(), []
+    for m in monitors:
+        if m["name"] in seen:
+            dupes.append(m["name"])
+        seen.add(m["name"])
+    if dupes:
+        sys.exit(
+            "ERROR: duplicate monitor names: " + ", ".join(sorted(set(dupes))) +
+            "\n\nEach becomes <name>.json, so one would silently replace the "
+            "other.\nIf UIS discovered it, remove it from .uis.extend/monitors.yaml "
+            "-\nthe extend file is only for targets UIS did NOT deploy.")
+
     return monitors, skipped, in_cluster
 
 
 def kuma_sql(namespace, query):
     r = subprocess.run(
-        ["kubectl", "exec", "-n", namespace, "uptime-kuma-0", "--",
+        ["kubectl"] + _ctx(CTX_TO) + ["exec", "-n", namespace, "uptime-kuma-0", "--",
          "sqlite3", "-separator", "\x1f", "/app/data/kuma.db", query],
         capture_output=True, text=True)
     if r.returncode != 0:
@@ -437,6 +506,11 @@ def main():
     ap.add_argument("--extend", default="/mnt/urbalurbadisk/.uis.extend/monitors.yaml")
     ap.add_argument("--namespace", default="monitoring")
     ap.add_argument("--outdir")
+    ap.add_argument("--from", dest="ctx_from", metavar="CONTEXT",
+                    help="kube context to DISCOVER services in (read-only). "
+                         "Defaults to the current context")
+    ap.add_argument("--to", dest="ctx_to", metavar="CONTEXT",
+                    help="kube context where Uptime Kuma runs. Defaults to --from")
     ap.add_argument("--watchdog", choices=["auto", "in-cluster", "external"],
                     default="auto",
                     help="where Uptime Kuma runs. auto detects it by looking for "
@@ -444,7 +518,17 @@ def main():
                          "rendering for a watchdog that is not up yet")
     args = ap.parse_args()
 
-    salt = os.environ.get("UPTIME_KUMA_PUSH_SALT")
+    global CTX_FROM, CTX_TO
+    CTX_FROM = args.ctx_from
+    CTX_TO = args.ctx_to or args.ctx_from
+    if CTX_FROM or CTX_TO:
+        print(f"  discovering in: {CTX_FROM or '(current)'}   "
+              f"watchdog in: {CTX_TO or '(current)'}")
+
+    # Read from the WATCHDOG's cluster, not whichever context happens to be
+    # current - with --from/--to they are different clusters.
+    salt = os.environ.get("UPTIME_KUMA_PUSH_SALT") or read_secret_key(
+        "uptime-kuma-push-salt", args.namespace)
     monitors, skipped, in_cluster = build(args.services_dir, args.extend, salt,
                                           args.watchdog)
 
@@ -482,11 +566,25 @@ def main():
                   "metadata": {"name": "uptime-kuma-monitors",
                                "namespace": args.namespace},
                   "type": "Opaque", "data": data}
-        p = subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(secret),
-                           capture_output=True, text=True)
+        p = subprocess.run(["kubectl"] + _ctx(CTX_TO) + ["apply", "-f", "-"],
+                           input=json.dumps(secret), capture_output=True, text=True)
         if p.returncode != 0:
             sys.exit(f"ERROR: {p.stderr.strip()}")
         print(f"\n  applied {len(monitors)} definitions to uptime-kuma-monitors")
+
+        # ⚠️ REQUIRED, not an optimisation. The init container copies the Secret
+        # into an emptyDir with `cp -L` (because AutoKuma will not follow the
+        # symlinks Kubernetes projects), and that copy is made ONCE at pod
+        # start. Updating the Secret alone changes nothing AutoKuma can see:
+        # `apply` would report success and silently do nothing.
+        print("  restarting AutoKuma so it re-reads the definitions...")
+        subprocess.run(["kubectl"] + _ctx(CTX_TO) +
+                       ["rollout", "restart", "deployment/autokuma",
+                        "-n", args.namespace], capture_output=True, text=True)
+        subprocess.run(["kubectl"] + _ctx(CTX_TO) +
+                       ["rollout", "status", "deployment/autokuma",
+                        "-n", args.namespace, "--timeout=300s"],
+                       capture_output=True, text=True)
         attach_alerts(args.namespace, monitors)
         return 0
 
@@ -495,9 +593,9 @@ def main():
         # self-heals drift, so a stopped AutoKuma looks exactly like a healthy
         # one - checking only the Secret would miss that entirely.
         r = subprocess.run(
-            ["kubectl", "exec", "-n", args.namespace, "uptime-kuma-0", "--",
-             "sqlite3", "/app/data/kuma.db", "select name from monitor;"],
-            capture_output=True, text=True)
+            ["kubectl"] + _ctx(CTX_TO) + ["exec", "-n", args.namespace,
+             "uptime-kuma-0", "--", "sqlite3", "/app/data/kuma.db",
+             "select name from monitor;"], capture_output=True, text=True)
         if r.returncode != 0:
             sys.exit("ERROR: could not read Uptime Kuma - is it deployed?")
         live = {l.strip() for l in r.stdout.splitlines() if l.strip()}

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -2555,10 +2555,15 @@ cmd_monitors() {
             ;;
         *)
             log_error "Unknown monitors subcommand: $subcmd"
-            echo "Usage: uis monitors [render|apply|check]"
+            echo "Usage: uis monitors [render|apply|check] [--from CTX] [--to CTX]"
             echo "  render  show what would be monitored, change nothing"
-            echo "  apply   write the definitions; AutoKuma picks them up"
+            echo "  apply   write the definitions and restart AutoKuma"
             echo "  check   compare intent against what Uptime Kuma is running"
+            echo ""
+            echo "  --from  cluster to discover services in (read-only)"
+            echo "  --to    cluster where Uptime Kuma runs. Defaults to --from."
+            echo "          Use both when the watchdog is outside the platform"
+            echo "          it watches, which is the production arrangement."
             exit "$EXIT_GENERAL_ERROR"
             ;;
     esac

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -2525,6 +2525,45 @@ cmd_host_create() {
 # Secrets Commands
 # ============================================================
 
+# uis monitors - availability monitors for the services UIS deployed
+#
+# Reads probe artifacts shipped with each service, discovers where those
+# services actually are, and writes the result into the uptime-kuma-monitors
+# Secret. AutoKuma reconciles it into Uptime Kuma.
+#
+# The user supplies nothing: they deployed the services, so UIS already knows
+# the hostnames, and the probe details ship with the service.
+cmd_monitors() {
+    local subcmd="${1:-check}"
+    shift || true
+
+    local lib="${UIS_ROOT:-/mnt/urbalurbadisk/provision-host/uis}/lib/monitors.py"
+    if [[ ! -f "$lib" ]]; then
+        log_error "monitors library not found at $lib"
+        exit "$EXIT_GENERAL_ERROR"
+    fi
+
+    # Heartbeat tokens are DERIVED from this salt, so the same monitor always
+    # gets the same push URL. Optional: without it, push monitors are refused
+    # rather than issued a URL that would change on the next rebuild.
+    local salt
+    salt=$(kubectl get secret urbalurba-secrets -n monitoring              -o jsonpath='{.data.uptime-kuma-push-salt}' 2>/dev/null | base64 -d 2>/dev/null || true)
+
+    case "$subcmd" in
+        render|apply|check)
+            UPTIME_KUMA_PUSH_SALT="$salt" python3 "$lib" "$subcmd" "$@"
+            ;;
+        *)
+            log_error "Unknown monitors subcommand: $subcmd"
+            echo "Usage: uis monitors [render|apply|check]"
+            echo "  render  show what would be monitored, change nothing"
+            echo "  apply   write the definitions; AutoKuma picks them up"
+            echo "  check   compare intent against what Uptime Kuma is running"
+            exit "$EXIT_GENERAL_ERROR"
+            ;;
+    esac
+}
+
 cmd_secrets() {
     local subcmd="${1:-status}"
     shift || true
@@ -2619,6 +2658,9 @@ main() {
             ;;
         secrets)
             cmd_secrets "$@"
+            ;;
+        monitors)
+            cmd_monitors "$@"
             ;;
         docs)
             cmd_docs "$@"

--- a/provision-host/uis/services/identity/probes/authentik.yaml
+++ b/provision-host/uis/services/identity/probes/authentik.yaml
@@ -1,0 +1,14 @@
+# The Kubernetes Service is authentik-server, not authentik.
+service: authentik-server
+# Availability probe shipped with the authentik service.
+#
+# ⚠️ This proves Authentik is SERVING, not that anyone can log in. A working
+# /-/health/live/ with a broken database or a misconfigured provider still fails
+# every actual login. A synthetic login check would be the honest test; this is
+# the cheap one.
+probes:
+  - id: gateway
+    type: http
+    path: /-/health/live/
+    interval: 60
+    maxretries: 2

--- a/provision-host/uis/services/integration/probes/temporal.yaml
+++ b/provision-host/uis/services/integration/probes/temporal.yaml
@@ -1,0 +1,13 @@
+# The Kubernetes Service is temporal-web, not temporal.
+service: temporal-web
+# Availability probe shipped with the temporal service.
+#
+# Probes the WEB UI, which is what a human reaches. Whether workflows are
+# actually completing is a different question, and one an availability probe
+# cannot answer - see the observability docs on liveness vs correctness.
+probes:
+  - id: gateway
+    type: http
+    path: /
+    interval: 60
+    maxretries: 2

--- a/provision-host/uis/services/observability/probes/grafana.yaml
+++ b/provision-host/uis/services/observability/probes/grafana.yaml
@@ -1,0 +1,16 @@
+# Availability probe shipped with the grafana service.
+#
+# No hostname: the endpoint is discovered from the Ingress `uis deploy` created.
+probes:
+  - id: gateway
+    type: http
+    path: /api/health
+
+    # KEYWORD, not just a status code. /api/health returns 200 with
+    # {"database": "failing"} when Grafana is up but its database is not -
+    # which is precisely the state worth knowing about. Matching "database"
+    # only proves the field is present, so pair it with the status check.
+    keyword: database
+
+    interval: 60
+    maxretries: 2

--- a/provision-host/uis/templates/secrets-templates/00-common-values.env.template
+++ b/provision-host/uis/templates/secrets-templates/00-common-values.env.template
@@ -229,6 +229,26 @@ TEMPORAL_POSTGRES_DATABASE=temporal
 TEMPORAL_POSTGRES_VISIBILITY_DATABASE=temporal_visibility
 
 # ================================================================
+# 🔧 OPTIONAL - EXTERNAL WATCHDOG (uptime-kuma)
+# ================================================================
+# Both are optional. Leave them as-is and the watchdog still monitors; it just
+# has no alert channel and cannot issue heartbeat URLs.
+
+# Where alerts go. On the PUBLIC ntfy.sh the topic name IS the credential -
+# anyone who learns it can read your alerts and publish fake ones - so use a
+# long random value, not "my-alerts". Subscribe to the same topic in the ntfy
+# app on your phone.
+#   generate one:  echo "uis-$(head -c 18 /dev/urandom | base64 | tr -dc 'a-z0-9')"
+UPTIME_KUMA_NTFY_TOPIC=
+
+# Heartbeat push tokens are derived from this, so a rebuilt watchdog reissues
+# IDENTICAL URLs and jobs never need rewiring.
+# ⚠️ Back it up. Lose it and every heartbeat caller is silently orphaned - the
+# jobs keep succeeding while nothing records that they ran.
+#   generate one:  head -c 32 /dev/urandom | base64
+UPTIME_KUMA_PUSH_SALT=
+
+# ================================================================
 # 🔧 OPTIONAL - APPLICATION-SPECIFIC
 # ================================================================
 # Add your own application variables here

--- a/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
+++ b/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
@@ -663,6 +663,22 @@ stringData:
   uptime-kuma-admin-user: "admin"
   uptime-kuma-admin-password: "${DEFAULT_ADMIN_PASSWORD}"
 
+  # Heartbeat push tokens are derived as HMAC-SHA256(salt, monitor name), never
+  # random. A push token IS the URL a job calls, so random tokens would reissue
+  # every URL on every rebuild - and the old URL then goes quietly silent rather
+  # than failing loudly, because the job still exits 0 while nothing records it.
+  # One salt makes the whole set reproducible.
+  # ⚠️ Back this up. Losing it silently orphans every heartbeat caller.
+  uptime-kuma-push-salt: "${UPTIME_KUMA_PUSH_SALT}"
+
+  # Alert channel. Leave the topic empty to deploy the watchdog with no
+  # notifications - it will still monitor, it just will not tell anyone.
+  # ⚠️ On the public ntfy.sh the TOPIC IS THE CREDENTIAL: anyone who learns it
+  # can read your alerts and publish fake ones. Use a long random value, or
+  # self-host ntfy.
+  uptime-kuma-ntfy-server: "https://ntfy.sh"
+  uptime-kuma-ntfy-topic: "${UPTIME_KUMA_NTFY_TOPIC}"
+
 # ================================================================
 # AUTHENTIK NAMESPACE SECRETS
 # ================================================================

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
@@ -202,26 +202,32 @@ The ops repo keeps no code — only intent.
 
 ---
 
-## ⚠️ Known limitation: auto-discovery is single-cluster
+## Cross-cluster: `--from` and `--to`
 
-`uis monitors` reads the cluster it is pointed at and writes the definitions into
-the watchdog's namespace. That is correct when the watchdog and the services
-share a cluster — the developer topology, and the case this was designed for.
+*Resolved 2026-08-09.* `uis monitors` reads services from one cluster and writes
+definitions into another:
 
-**In production they usually do not.** On the reference installation Uptime Kuma
-runs on `assist` while the services run on `asgard`, so the auto-discovery half
-finds nothing and all 19 monitors come from `.uis.extend/monitors.yaml` with
-hand-written addresses. The discovery logic is proven correct against asgard —
-run there it produces exactly the right URLs — but nothing yet carries that
-result across to the watchdog's cluster.
+```bash
+uis monitors apply --from asgard --to assist
+```
 
-Closing it means reading from one context and writing to another: `uis monitors
-apply --from <context> --to <context>`, or having the watchdog pull. Until then
-the promise "deploy a service and it is monitored" holds **only when the watchdog
-shares the cluster**, and the production case still needs the extend file.
+`--from` is where the services are (read-only). `--to` is where Uptime Kuma runs.
+Omit both for a single-cluster developer setup; the topology is then detected by
+looking for the watchdog in the discovered cluster.
 
-That is the single biggest remaining gap in this plan and it should be stated
-plainly wherever the feature is documented.
+⚠️ **Least privilege, not an admin kubeconfig.** Discovery needs three read verbs
+on services, endpoints and ingresses — nothing more. `manifests/230-uptime-kuma-
+discovery-rbac.yaml` creates a `monitor-discovery` ServiceAccount for exactly
+that. Copying a cluster-admin kubeconfig onto the watchdog would put full control
+of the platform on the machine whose entire purpose is to sit outside it — on the
+reference installation, a Raspberry Pi running from a microSD card. Verified: the
+identity can list services and cannot read secrets or delete anything.
+
+### Still to do
+
+- [ ] Persist the context pair per installation. Typing `--from`/`--to` every
+      time invites getting them wrong, and a `check` run with the wrong contexts
+      reports confident, entirely spurious drift — observed while building this
 
 ## Implementation Notes
 

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
@@ -4,7 +4,7 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Backlog
+## Status: Active — Phases 1–4 done and the reference installation migrated; auto-discovery is single-cluster only
 
 **Goal**: `uis deploy uptime-kuma` gives a watchdog that is **already monitoring
 and already alerting**, rebuildable from nothing, with the only
@@ -64,22 +64,22 @@ rediscovers them.
 
 ### Tasks
 
-- [ ] 1.1 `manifests/230-autokuma-deployment.yaml` — a **separate Deployment**,
+- [x] 1.1 `manifests/230-uptime-kuma-autokuma.yaml` — a **separate Deployment**,
       not a sidecar. Containers in a pod start together, Kuma needs ~30s before
       it accepts Socket.IO, and AutoKuma makes one connect attempt and never
       retries. Its own Deployment makes the restart loop the retry
-- [ ] 1.2 `strategy: Recreate`. `/data` is RWO with a lock-protected store;
+- [x] 1.2 `strategy: Recreate`. `/data` is RWO with a lock-protected store;
       RollingUpdate runs two instances, and because files are copied into an
       `emptyDir` the two can work from **different file sets**
-- [ ] 1.3 A **PVC for `/data`** — AutoKuma's id→entity map. Without it every
+- [x] 1.3 A **PVC for `/data`** — AutoKuma's id→entity map. Without it every
       restart re-creates every monitor: one restart took 19 monitors to 38
-- [ ] 1.4 An init container that **flattens the Secret with `cp -L`** into an
+- [x] 1.4 An init container that **flattens the Secret with `cp -L`** into an
       `emptyDir`. Kubernetes mounts Secrets as symlinks into `..data/`, which
       AutoKuma's file scanner does not follow — it syncs nothing and logs nothing
-- [ ] 1.5 A `wait-for-kuma` init container against the Service, not localhost
-- [ ] 1.6 Pin the image to `2.0.0` — **not** `v2.0.0`, which is single-arch and
+- [x] 1.5 A `wait-for-kuma` init container against the Service, not localhost
+- [x] 1.6 Pin the image to `2.0.0` — **not** `v2.0.0`, which is single-arch and
       will not pull on arm64
-- [ ] 1.7 `AUTOKUMA__ON_DELETE=delete` with a grace period, so removing a
+- [x] 1.7 `AUTOKUMA__ON_DELETE=delete` with a grace period, so removing a
       definition removes the monitor
 
 ### Validation
@@ -95,16 +95,16 @@ kubectl rollout restart deployment/autokuma -n monitoring
 
 ### Tasks
 
-- [ ] 2.1 `uis monitors render` — print what would be written, change nothing
-- [ ] 2.2 `uis monitors apply` — render into the `uptime-kuma-monitors` Secret
-- [ ] 2.3 `uis monitors check` — compare intended against the Secret **and**
+- [x] 2.1 `uis monitors render` — print what would be written, change nothing
+- [x] 2.2 `uis monitors apply` — render into the `uptime-kuma-monitors` Secret
+- [x] 2.3 `uis monitors check` — compare intended against the Secret **and**
       against what Kuma is running. AutoKuma self-heals drift, so a *stopped*
       AutoKuma looks exactly like a healthy one
-- [ ] 2.4 Heartbeat tokens derived as `HMAC-SHA256(salt, monitor name)` from
+- [x] 2.4 Heartbeat tokens derived as `HMAC-SHA256(salt, monitor name)` from
       `uptime-kuma-push-salt` in `urbalurba-secrets`. **Not random**: a rebuild
       must reissue identical URLs or every job needs rewiring, and the old URL
       goes quietly silent rather than failing loudly
-- [ ] 2.5 Emit `push_token` explicitly — AutoKuma does not generate one, and a
+- [x] 2.5 Emit `push_token` explicitly — AutoKuma does not generate one, and a
       push monitor without a token has no callable URL and can never go UP
 
 ### Validation
@@ -121,8 +121,8 @@ uis monitors check                            # still clean, same push URLs
 
 ### Tasks
 
-- [ ] 3.1 Read `.uis.extend/monitors.yaml` if present. Absent is normal
-- [ ] 3.2 Schema: `name`, `type` (`http`/`port`/`push`), `url`/`hostname`+`port`,
+- [x] 3.1 Read `.uis.extend/monitors.yaml` if present. Absent is normal
+- [x] 3.2 Schema: `name`, `type` (`http`/`port`/`push`), `url`/`hostname`+`port`,
       `keyword`, `accepted_statuscodes`, `ignore_tls`, `interval`, `maxretries`,
       `notify`, and `auth_header_secret` naming a key in `urbalurba-secrets` —
       **never a secret value**
@@ -144,18 +144,18 @@ makes it a watchdog.
 
 ### Tasks
 
-- [ ] 4.1 Seed the notification channel from `urbalurba-secrets`
+- [x] 4.1 Seed the notification channel from `urbalurba-secrets`
       (`uptime-kuma-ntfy-server`, `uptime-kuma-ntfy-topic`). Absent ⇒ skip
       cleanly with a warning, never fail the deploy
-- [ ] 4.2 Attach it to every monitor with `notify: true` (the default)
-- [ ] 4.3 ⚠️ **Do not let AutoKuma own the channel.** It can — a file with
+- [x] 4.2 Attach it to every monitor with `notify: true` (the default)
+- [x] 4.3 ⚠️ **Do not let AutoKuma own the channel.** It can — a file with
       `"type": "notification"` is accepted and delivers correctly — but AutoKuma
       2.0.0 never converges on notifications, rewriting it every ~5s forever.
       Confirmed with a single instance and a cleared state store
-- [ ] 4.4 Consequence of 4.3: `notification_name_list` must **not** appear in
+- [x] 4.4 Consequence of 4.3: `notification_name_list` must **not** appear in
       rendered monitor files, or AutoKuma logs a resolve warning per monitor per
       pass
-- [ ] 4.5 Seed retention (`keepDataPeriodDays`) — already shipped, keep it
+- [x] 4.5 Seed retention (`keepDataPeriodDays`) — already shipped, keep it
 
 ### Validation
 
@@ -170,11 +170,11 @@ shipped one, and nothing is lost.
 
 ### Tasks
 
-- [ ] 5.1 Move the 19 monitors into `.uis.extend/monitors.yaml`
-- [ ] 5.2 Move salt, ntfy topic and auth headers into `urbalurba-secrets`,
+- [x] 5.1 Move the 19 monitors into `.uis.extend/monitors.yaml`
+- [x] 5.2 Move salt, ntfy topic and auth headers into `urbalurba-secrets`,
       sourced from OpenBao where they already live
-- [ ] 5.3 `uis undeploy uptime-kuma --purge`, redeploy, `uis monitors apply`
-- [ ] 5.4 Confirm: same 19 monitors, **same push URLs** (so no job needs
+- [x] 5.3 `uis undeploy uptime-kuma --purge`, redeploy, `uis monitors apply`
+- [x] 5.4 Confirm: same 19 monitors, **same push URLs** (so no job needs
       rewiring), same 16 paging, alert delivery still verified
 - [ ] 5.5 Retire the hand-built reconciler in the ops repo, leaving only the
       installation-specific YAML and secrets
@@ -201,6 +201,27 @@ The ops repo keeps no code — only intent.
 - [ ] The reference installation runs entirely on the shipped pipeline
 
 ---
+
+## ⚠️ Known limitation: auto-discovery is single-cluster
+
+`uis monitors` reads the cluster it is pointed at and writes the definitions into
+the watchdog's namespace. That is correct when the watchdog and the services
+share a cluster — the developer topology, and the case this was designed for.
+
+**In production they usually do not.** On the reference installation Uptime Kuma
+runs on `assist` while the services run on `asgard`, so the auto-discovery half
+finds nothing and all 19 monitors come from `.uis.extend/monitors.yaml` with
+hand-written addresses. The discovery logic is proven correct against asgard —
+run there it produces exactly the right URLs — but nothing yet carries that
+result across to the watchdog's cluster.
+
+Closing it means reading from one context and writing to another: `uis monitors
+apply --from <context> --to <context>`, or having the watchdog pull. Until then
+the promise "deploy a service and it is monitored" holds **only when the watchdog
+shares the cluster**, and the production case still needs the extend file.
+
+That is the single biggest remaining gap in this plan and it should be stated
+plainly wherever the feature is documented.
 
 ## Implementation Notes
 

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
@@ -1,0 +1,240 @@
+# Ship the monitor pipeline as part of the service
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: `uis deploy uptime-kuma` gives a watchdog that is **already monitoring
+and already alerting**, rebuildable from nothing, with the only
+installation-specific input being a list of targets UIS did not deploy.
+
+**Last Updated**: 2026-08-09
+
+**Prerequisites**: [PLAN-service-uptime-kuma-004-uis-service](../completed/PLAN-service-uptime-kuma-004-uis-service.md) *(done)*
+
+**Related**:
+- [PLAN-service-uptime-kuma-002-monitors](../active/PLAN-service-uptime-kuma-002-monitors.md) — what to watch, proven on the reference installation
+- [PLAN-service-uptime-kuma-003-alerting](./PLAN-service-uptime-kuma-003-alerting.md) — the alerting design this ships
+- [PLAN-system-observability-006-service-probes](./PLAN-system-observability-006-service-probes.md) — **depends on this.** 006 auto-generates probes per service; it needs the pipeline this plan ships to deliver them
+
+**Priority**: High
+
+---
+
+## Problem
+
+Uptime Kuma is a UIS service: `uis deploy uptime-kuma` installs it, seeds the
+admin account, needs no browser wizard, and `--purge` removes it cleanly.
+
+**Everything that makes it useful is still hand-built.** On the reference
+installation the monitors, the reconciler, the alert channel and the heartbeat
+wiring live in a private ops repo and were assembled by hand. A second
+installation gets an empty watchdog and a blank page.
+
+That is the gap between *a service that installs* and *a service that works*.
+
+The pieces are all proven — 19 monitors, 16 paging a phone, four backup
+heartbeats wired, verified through two complete purge-and-rebuild cycles. None of
+them are in the product.
+
+## The boundary this plan holds
+
+| | Ships in UIS | Stays installation-specific |
+|---|---|---|
+| AutoKuma, its manifest and quirks | ✅ | |
+| `uis monitors` render / apply / check | ✅ | |
+| Notification channel wiring | ✅ | |
+| Heartbeat token derivation | ✅ | |
+| *Which* hosts, *which* addresses | | ✅ `.uis.extend/monitors.yaml` |
+| Secrets (topic, salt, auth headers) | | ✅ `urbalurba-secrets` |
+
+⚠️ **Never ask the user for an endpoint UIS already knows.** Targets UIS deployed
+are discovered. The extend file is only for things UIS did **not** deploy — a
+hypervisor, a NAS, a laptop, a job heartbeat. It is empty on a stock install.
+
+---
+
+## Phase 1: AutoKuma ships with the service
+
+Six behaviours were found the hard way on the reference installation, and
+**every one fails silently**. The manifest must encode all six or the next person
+rediscovers them.
+
+### Tasks
+
+- [ ] 1.1 `manifests/230-autokuma-deployment.yaml` — a **separate Deployment**,
+      not a sidecar. Containers in a pod start together, Kuma needs ~30s before
+      it accepts Socket.IO, and AutoKuma makes one connect attempt and never
+      retries. Its own Deployment makes the restart loop the retry
+- [ ] 1.2 `strategy: Recreate`. `/data` is RWO with a lock-protected store;
+      RollingUpdate runs two instances, and because files are copied into an
+      `emptyDir` the two can work from **different file sets**
+- [ ] 1.3 A **PVC for `/data`** — AutoKuma's id→entity map. Without it every
+      restart re-creates every monitor: one restart took 19 monitors to 38
+- [ ] 1.4 An init container that **flattens the Secret with `cp -L`** into an
+      `emptyDir`. Kubernetes mounts Secrets as symlinks into `..data/`, which
+      AutoKuma's file scanner does not follow — it syncs nothing and logs nothing
+- [ ] 1.5 A `wait-for-kuma` init container against the Service, not localhost
+- [ ] 1.6 Pin the image to `2.0.0` — **not** `v2.0.0`, which is single-arch and
+      will not pull on arm64
+- [ ] 1.7 `AUTOKUMA__ON_DELETE=delete` with a grace period, so removing a
+      definition removes the monitor
+
+### Validation
+
+```bash
+kubectl rollout restart deployment/autokuma -n monitoring
+# monitor count MUST be unchanged - this is the /data regression test
+```
+
+---
+
+## Phase 2: `uis monitors`
+
+### Tasks
+
+- [ ] 2.1 `uis monitors render` — print what would be written, change nothing
+- [ ] 2.2 `uis monitors apply` — render into the `uptime-kuma-monitors` Secret
+- [ ] 2.3 `uis monitors check` — compare intended against the Secret **and**
+      against what Kuma is running. AutoKuma self-heals drift, so a *stopped*
+      AutoKuma looks exactly like a healthy one
+- [ ] 2.4 Heartbeat tokens derived as `HMAC-SHA256(salt, monitor name)` from
+      `uptime-kuma-push-salt` in `urbalurba-secrets`. **Not random**: a rebuild
+      must reissue identical URLs or every job needs rewiring, and the old URL
+      goes quietly silent rather than failing loudly
+- [ ] 2.5 Emit `push_token` explicitly — AutoKuma does not generate one, and a
+      push monitor without a token has no callable URL and can never go UP
+
+### Validation
+
+```bash
+uis monitors apply && uis monitors check     # clean
+uis undeploy uptime-kuma --purge && uis deploy uptime-kuma && uis monitors apply
+uis monitors check                            # still clean, same push URLs
+```
+
+---
+
+## Phase 3: Targets UIS did not deploy
+
+### Tasks
+
+- [ ] 3.1 Read `.uis.extend/monitors.yaml` if present. Absent is normal
+- [ ] 3.2 Schema: `name`, `type` (`http`/`port`/`push`), `url`/`hostname`+`port`,
+      `keyword`, `accepted_statuscodes`, `ignore_tls`, `interval`, `maxretries`,
+      `notify`, and `auth_header_secret` naming a key in `urbalurba-secrets` —
+      **never a secret value**
+- [ ] 3.3 Require a `why:` per entry. A monitor nobody can justify is a monitor
+      nobody will maintain
+- [ ] 3.4 Document it with the reference installation's file as the worked
+      example
+
+### Validation
+
+A stock install has no such file and behaves identically.
+
+---
+
+## Phase 4: Alerting that is on by default
+
+An installed watchdog that notifies nobody is a dashboard. This is the phase that
+makes it a watchdog.
+
+### Tasks
+
+- [ ] 4.1 Seed the notification channel from `urbalurba-secrets`
+      (`uptime-kuma-ntfy-server`, `uptime-kuma-ntfy-topic`). Absent ⇒ skip
+      cleanly with a warning, never fail the deploy
+- [ ] 4.2 Attach it to every monitor with `notify: true` (the default)
+- [ ] 4.3 ⚠️ **Do not let AutoKuma own the channel.** It can — a file with
+      `"type": "notification"` is accepted and delivers correctly — but AutoKuma
+      2.0.0 never converges on notifications, rewriting it every ~5s forever.
+      Confirmed with a single instance and a cleared state store
+- [ ] 4.4 Consequence of 4.3: `notification_name_list` must **not** appear in
+      rendered monitor files, or AutoKuma logs a resolve warning per monitor per
+      pass
+- [ ] 4.5 Seed retention (`keepDataPeriodDays`) — already shipped, keep it
+
+### Validation
+
+Deliberately fail a monitor; a notification arrives on a real device.
+
+---
+
+## Phase 5: Prove it on the reference installation
+
+The point of the whole plan: the hand-built installation is replaced by the
+shipped one, and nothing is lost.
+
+### Tasks
+
+- [ ] 5.1 Move the 19 monitors into `.uis.extend/monitors.yaml`
+- [ ] 5.2 Move salt, ntfy topic and auth headers into `urbalurba-secrets`,
+      sourced from OpenBao where they already live
+- [ ] 5.3 `uis undeploy uptime-kuma --purge`, redeploy, `uis monitors apply`
+- [ ] 5.4 Confirm: same 19 monitors, **same push URLs** (so no job needs
+      rewiring), same 16 paging, alert delivery still verified
+- [ ] 5.5 Retire the hand-built reconciler in the ops repo, leaving only the
+      installation-specific YAML and secrets
+
+### Validation
+
+```bash
+uis monitors check     # identical to before the rebuild
+```
+
+The ops repo keeps no code — only intent.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uis deploy uptime-kuma` on a fresh cluster monitors and alerts with no
+      hand-written Kubernetes and no clicking in the UI
+- [ ] A stock install needs no `.uis.extend/monitors.yaml`
+- [ ] Restarting AutoKuma never changes the monitor count
+- [ ] A purge-and-rebuild reissues **identical** heartbeat URLs
+- [ ] Definitions carry secret *names*, never values
+- [ ] `uis monitors check` detects a stalled AutoKuma, not just missing files
+- [ ] The reference installation runs entirely on the shipped pipeline
+
+---
+
+## Implementation Notes
+
+**Why AutoKuma rather than writing to the database.** Uptime Kuma has no official
+REST API and its Socket.IO interface is explicitly unsupported. The reference
+implementation *did* write to SQLite successfully — but creating a monitor
+properly also means `updateMonitorNotification`, `startMonitor` and
+`bean.validate()`, and each gap had to be found the hard way. AutoKuma is the
+community's answer and absorbs that maintenance.
+
+**Where the database is still touched.** Two places, both deliberate and both
+narrow: the admin account seed (Kuma has no other way to create the first user)
+and the notification channel plus its attachments (see 4.3). Both are guarded —
+schema is checked first, and inserts never update or delete.
+
+**Retain the drift check.** A reconciler that stops looks exactly like one with
+nothing to do. That is *absence renders as green* applied to the tool meant to
+prevent it, which is why 2.3 compares against Kuma and not just the Secret.
+
+**The extend file is not the endpoint list.** An earlier draft had the operator
+maintain hostnames for everything. It was rejected: UIS knows where the things it
+deployed are. External dependencies should become shim Services
+([PLAN-system-dependencies-shim-services](./PLAN-system-dependencies-shim-services.md))
+and be discovered like anything else — leaving the extend file for hypervisors,
+NAS boxes and job heartbeats only.
+
+---
+
+## Files to Modify
+
+- `manifests/230-autokuma-deployment.yaml` (new)
+- `ansible/playbooks/230-setup-uptime-kuma.yml` — deploy AutoKuma, seed the channel
+- `provision-host/uis/manage/uis-monitors.sh` (new)
+- `provision-host/uis/manage/uis-cli.sh` — register the `monitors` verb
+- `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template`
+  — `uptime-kuma-push-salt`, `uptime-kuma-ntfy-server`, `uptime-kuma-ntfy-topic`
+- `website/docs/services/observability/uptime-kuma.md`

--- a/website/docs/services/observability/index.md
+++ b/website/docs/services/observability/index.md
@@ -156,17 +156,29 @@ matters less than two properties:
 
 See [Uptime Kuma](./uptime-kuma.md) for configuration.
 
-## What is automated today, and what is not
+## Monitors are generated, not written
 
-:::info Monitor definitions are still manual
-UIS deploys the watchdog, seeds its admin account, and needs no browser wizard.
-It does **not** yet create monitors for the services you deploy — you define
-those yourself in the Uptime Kuma UI.
+You do not hand-write availability monitors. Each service ships a probe artifact
+saying *how* to check it; UIS discovers *where* it is from the `Service` and
+`Ingress` it created:
 
-Automating it, so that `uis deploy <service>` produces a monitor with no
-configuration written by anyone, is designed but not shipped:
-`PLAN-system-observability-006-service-probes` in the
-[ai-developer plans](../../ai-developer/plans/index.md). Two related plans cover
-per-service dashboards and declaring external dependencies as Services so probes
-can discover them like anything else.
+```bash
+uis deploy uptime-kuma
+uis monitors apply
+```
+
+Nothing asks for a hostname — you did not need one to deploy the service, so you
+should not need one to monitor it. Targets UIS did **not** deploy (a hypervisor,
+a NAS, a job heartbeat) go in `.uis.extend/monitors.yaml`, which is empty on a
+stock install.
+
+See [Uptime Kuma](./uptime-kuma.md) for both topologies: a developer running
+everything in one cluster, and an operator running the watchdog on a separate
+machine.
+
+:::info Not yet automated
+**Dashboards** per service, and **alert rules** for the in-cluster stack. A
+freshly deployed Prometheus collects everything and alerts on nothing, so it
+tells you what happened *after* you go looking. Tracked in the
+[ai-developer plans](../../ai-developer/plans/index.md).
 :::

--- a/website/docs/services/observability/uptime-kuma.md
+++ b/website/docs/services/observability/uptime-kuma.md
@@ -238,22 +238,81 @@ fails. That is worse than no heartbeat, because it manufactures confidence.
 and no job needs rewiring. Back that salt up: lose it and every heartbeat caller
 is silently orphaned, still exiting 0 while nothing records that it ran.
 
-## Alerting
+## Alerting — getting it onto your phone
 
-Set a topic and alerting is configured on deploy:
+This is the one step UIS cannot do for you: an app has to be installed on a
+device, and only you can do that.
+
+### 1. Generate a topic
 
 ```bash
-UPTIME_KUMA_NTFY_TOPIC=uis-<something-long-and-random>
+echo "uis-$(head -c 18 /dev/urandom | base64 | tr -dc 'a-z0-9')"
 ```
 
-Then subscribe to the same topic in the [ntfy](https://ntfy.sh) app. Leave it
-empty and the watchdog still monitors — it just tells nobody, and says so during
-deploy rather than being quietly silent.
-
 :::warning On public ntfy.sh the topic name *is* the credential
-Anyone who learns it can read your alerts and publish fake ones. Use a long
-random value, or self-host.
+There are no accounts and no passwords — **anyone who knows the topic can read
+your alerts and publish fake ones**. Use a generated value, never something
+guessable like `uis-alerts` or your company name. Treat it like a password:
+do not paste it into a ticket, a chat, or a screenshot.
 :::
+
+### 2. Tell UIS about it
+
+```bash
+UPTIME_KUMA_NTFY_TOPIC=uis-xxxxxxxxxxxxxxxxx
+```
+
+in the secrets template, then `uis secrets generate && uis secrets apply` and
+deploy or re-deploy `uptime-kuma`. Leave it empty and the watchdog still
+monitors — it just tells nobody, and says so during deploy rather than being
+quietly silent about it.
+
+### 3. Install the app and subscribe
+
+**ntfy** — free, open source, no account:
+
+| | |
+|---|---|
+| iOS | App Store — *ntfy* |
+| Android | Play Store, or [F-Droid](https://f-droid.org/packages/io.heckel.ntfy/) |
+| Desktop / browser | `https://ntfy.sh/<your-topic>` |
+
+In the app: **+** → paste the topic → leave the server as `ntfy.sh` → Subscribe.
+There is no sign-up step; subscribing to the topic *is* the whole configuration.
+
+### 4. Prove it arrives — before you rely on it
+
+```bash
+curl -H "Title: test" -d "if you can read this, alerting works" \
+     https://ntfy.sh/<your-topic>
+```
+
+If that does not reach the phone, alerting does not work, and **you will not find
+out later** — a watchdog with a broken channel is indistinguishable from a quiet
+week. Check it now, and re-check after changing the topic.
+
+Then test the real path, which is not the same thing: point a throwaway monitor
+at a closed port and confirm Uptime Kuma itself pushes.
+
+### Things that will bite you
+
+**Android battery optimisation** can delay or drop notifications. Exclude ntfy
+from it, or the alerts arrive an hour late — which for an outage is the same as
+not arriving.
+
+**Alerts are sent at priority 5** so they break through Do Not Disturb. That is
+deliberate: an availability alert you sleep through has not done its job. If that
+is too aggressive, lower it in the notification's settings rather than muting the
+app.
+
+**iOS and self-hosting do not mix freely.** The topic-is-the-credential problem
+above makes self-hosting tempting, but iOS push has to travel via Apple's APNs,
+which the ntfy iOS app reaches through ntfy.sh's infrastructure. A self-hosted
+server needs `upstream-base-url` configured before iOS delivery works at all.
+Android has no such constraint. Check this *before* migrating, not after.
+
+**One phone is one point of failure.** If it is off, lost, or with someone on a
+plane, nobody is alerted. Subscribe a second device, or a second person.
 
 Every monitor pages by default. Set `notify: false` on anything whose failure is
 not both real and actionable:

--- a/website/docs/services/observability/uptime-kuma.md
+++ b/website/docs/services/observability/uptime-kuma.md
@@ -1,6 +1,7 @@
 ---
 title: Uptime Kuma
 sidebar_label: Uptime Kuma
+description: The external watchdog - what it monitors, how monitors get created without you writing any, and the two ways to run it
 ---
 
 # Uptime Kuma
@@ -17,151 +18,348 @@ External availability watchdog. Answers *"is it up, and did the job run?"*
 | **URL** | `http://uptime-kuma.localhost` |
 | **Website** | https://uptime.kuma.pet |
 
+Deploying it also deploys **AutoKuma**, which turns monitor definition files into
+monitors. It is part of this service, not a separate thing to install.
+
 ## :warning: Run this outside the platform it monitors
 
-Uptime Kuma is only useful on a host that is **not part of the platform it
-watches**. A monitor inside a cluster cannot report that cluster being down —
-which is the one situation you need it for.
+A monitor inside a cluster cannot report that cluster being down — which is the
+one situation you need it for.
 
-`./uis deploy uptime-kuma` will happily install it onto the cluster you intend
-to monitor. It will look healthy and it will be useless when it matters. **UIS
-has no way to express "deploy this elsewhere"**, so this is a convention you
-have to honour, not a rule the tooling enforces.
+`./uis deploy uptime-kuma` will happily install it onto the cluster you intend to
+monitor. It will look healthy and be useless when it matters. **UIS cannot
+express "deploy this elsewhere"**, so this is a convention you honour, not a rule
+the tooling enforces.
 
-A reasonable arrangement: a small always-on machine — a Raspberry Pi, a NAS, a
-free-tier cloud VM — that runs nothing else you care about.
+For local development that does not matter and you should ignore it — see the
+developer path below.
 
-## What it is for, and what it is not
+## You do not write monitors
 
-It does **not** replace Prometheus, Grafana and Loki. The two answer different
-questions:
+This is the part worth understanding, because it is different from how most
+people use Uptime Kuma.
 
-| Question | Answered by |
+Both halves of a monitor are already known to UIS:
+
+| Needed | Where it comes from |
 |---|---|
-| Is the endpoint responding? | Uptime Kuma |
-| Is the cluster itself reachable? | Uptime Kuma — the in-cluster stack dies with it |
-| Did the nightly backup actually run? | Uptime Kuma push/heartbeat monitor |
-| Why is p99 latency up since Tuesday? | Prometheus / Grafana |
-| What did the pod log before it crashed? | Loki |
+| **How** to probe — path, keyword, which secret | ships with the service, as a probe artifact |
+| **Where** the service is | discovered from the `Service` and `Ingress` that `uis deploy` created |
 
-There is deliberate overlap on endpoint probing — `blackbox_exporter` does the
-same thing. That is the cheapest part of either system, and duplicating it is
-sensible redundancy at the one layer where a single point of failure is
-unacceptable.
-
-### Heartbeat monitors are the part nothing else provides
-
-A **push monitor** gives you a URL. A job calls it on success. If the call stops
-arriving within the expiry window, you get alerted.
-
-That detects the *absence of work*, which metric-based alerting handles badly:
-nothing crashes, no error rate spikes, work simply stops. Backups that silently
-stop and pipelines that quietly die are the classic cases — the failure mode
-where a dashboard shows all green for hours.
-
-## Deploy
+So you deploy services, deploy the watchdog, and run:
 
 ```bash
-./uis deploy uptime-kuma
+uis monitors apply
 ```
 
-**No first-run wizard.** Both of its steps are automated:
+Nothing asks you for a hostname. You never had to know one to deploy the service,
+and you should not have to know one to monitor it.
 
-- `UPTIME_KUMA_DB_TYPE=sqlite` makes the app create its database at startup
-  instead of asking which one to use.
-- The playbook seeds the admin account directly. `needSetup` is computed at
-  startup as simply "is the user table empty?", so one row removes the wizard.
+```
+probe artifacts (ship with each service)
+        +
+cluster discovery (Service / Ingress)
+        │  uis monitors apply
+        ▼
+Secret  uptime-kuma-monitors
+        │  AutoKuma reconciles
+        ▼
+   Uptime Kuma  ──alerts──▶  your phone
+```
 
-Log in with `admin` and the shared `DEFAULT_ADMIN_PASSWORD`.
-
-Seeding is idempotent — it only runs when the user table is empty, so
-re-deploying never clobbers a password you have since changed in the UI.
-
-## Verify
+### The three commands
 
 ```bash
-./uis verify uptime-kuma
+uis monitors render    # what would be monitored. Changes nothing
+uis monitors apply     # write the definitions, restart AutoKuma, attach alerting
+uis monitors check     # compare intent against what Kuma is actually running
 ```
 
-Checks that the UI responds, that the page really is Uptime Kuma, that
-`/app/data` is a mounted volume rather than container filesystem, and that the
-IngressRoute exists.
+`check` is not decoration. AutoKuma reconciles continuously, so drift heals
+itself — which means a **stopped** AutoKuma looks exactly like a healthy one.
+`check` compares against Kuma itself, not just against the definitions.
 
-These prove the service *runs*. They cannot prove it is *useful* — that depends
-on where you deployed it and on monitors existing.
+---
 
-## Remove
+## Path 1 — a developer on Rancher Desktop
+
+You have one cluster. Uptime Kuma runs in it. That is fine: you are not trying to
+detect your laptop being off.
 
 ```bash
-./uis undeploy uptime-kuma                                  # keeps the data
-ansible-playbook 230-remove-uptime-kuma.yml -e remove_pvc=true   # deletes it
+uis deploy uptime-kuma
+uis monitors apply
 ```
 
-The PVC is kept by default. It holds monitor definitions, notification
-configuration and the entire uptime history, none of which is reproducible.
+That is the whole thing. Open `http://uptime-kuma.localhost`, log in as `admin`
+with the shared `DEFAULT_ADMIN_PASSWORD`, and the services you have deployed are
+already listed.
 
-## Storage
+Because the watchdog is inside the cluster, endpoints resolve to in-cluster DNS:
 
-Embedded SQLite on a `ReadWriteOnce` volume, deployed as a StatefulSet so there
-is exactly one writer. It uses the cluster's default StorageClass.
+```
+http://litellm.ai.svc.cluster.local:4000/v1/models
+postgresql.default.svc.cluster.local:5432
+```
 
-Heartbeats are small but frequent, so on flash-backed storage set a sensible
-check interval (60s rather than 20s) and trim retention. On a Raspberry Pi or
-similar, prefer putting the volume on something other than the boot card — not
-for speed, but so that wearing it out costs a replaceable device rather than a
-rebuild.
+**You get more coverage than production does**, not less: in-cluster-only
+services like PostgreSQL are reachable here and are not reachable from an
+external watchdog.
 
-## Secrets
+Deploy another service and re-run `uis monitors apply`.
 
-Two keys in `urbalurba-secrets` (namespace `monitoring`):
+## Path 2 — an ops engineer running it in production
 
-| Key | Value |
+The watchdog runs on a separate machine — a Pi, a NAS, a small VM — with its own
+tiny cluster. The services run somewhere else. So discovery has to read one
+cluster and write to another:
+
+```bash
+uis monitors apply --from production --to watchdog
+```
+
+| | |
+|---|---|
+| `--from` | where the services are. **Read-only** |
+| `--to` | where Uptime Kuma runs. Written to |
+
+Omit both and you get Path 1 behaviour.
+
+### Give discovery a read-only identity
+
+Do **not** copy an admin kubeconfig onto the watchdog host. Discovery needs three
+read verbs on three resource types; an admin credential would put full control of
+your platform on the machine whose entire purpose is to sit outside it.
+
+```bash
+kubectl --context production apply -f manifests/230-uptime-kuma-discovery-rbac.yaml
+```
+
+That creates a `monitor-discovery` ServiceAccount which can list services,
+endpoints and ingresses, and nothing else. Add it to the watchdog host's
+kubeconfig as the `--from` context.
+
+Verify it is as powerless as intended:
+
+```bash
+kubectl --context production get secrets -A    # must be Forbidden
+```
+
+### What resolves, and what cannot
+
+From outside the cluster, in order of preference:
+
+| | Gives |
+|---|---|
+| `Ingress` with `ingressClassName: tailscale` | a real FQDN with a real certificate — the best case |
+| A shim `Service` whose Endpoints point outside the pod network | the external address, straight from the Endpoints object |
+| `LoadBalancer` | its external address |
+| **ClusterIP only** | **nothing.** Not reachable from another machine |
+
+That last row is reported, never silently dropped:
+
+```
+NOT MONITORED (1):
+  postgresql: only reachable inside the cluster (ClusterIP). An external
+  watchdog cannot probe it - expose it, give it a shim, or rely on the
+  services that depend on it failing their own probes
+```
+
+A deployed service that quietly gets no monitor is indistinguishable from one
+that is passing. Read that list.
+
+---
+
+## Targets UIS did not deploy
+
+A hypervisor, a NAS, a laptop, a printer, a nightly job. UIS cannot discover
+these because it did not create them, so they go in
+`.uis.extend/monitors.yaml`:
+
+```yaml
+defaults:
+  interval: 60
+  maxretries: 2
+  notify: true
+
+monitors:
+  - name: hypervisor-ui
+    type: port
+    hostname: 192.168.1.10
+    port: 8006
+    why: If this is down, everything running on it is too.
+
+  - name: vault
+    type: http
+    url: https://192.168.1.20:8200/v1/sys/health
+    ignore_tls: true                       # internal certificate
+    accepted_statuscodes: ["200-299"]      # a SEALED vault answers 503
+    why: Sealed counts as down - it is useless to consumers even when running.
+
+  - name: heartbeat-nightly-backup
+    type: push
+    interval: 93600                        # 26h - headroom for a late run
+    why: Catches a backup that silently stopped.
+```
+
+**This file is empty or absent on a stock install.** If you find yourself adding
+something UIS *did* deploy, that is a bug in discovery or a missing shim — and
+`uis monitors` will refuse it as a duplicate rather than let two definitions
+silently overwrite each other.
+
+`why:` is not decoration. A monitor nobody can justify is a monitor nobody
+maintains.
+
+## Heartbeats — the part nothing else provides
+
+A push monitor gives you a URL. A job calls it **after** its success check. If
+the call stops arriving inside the expiry window, you are alerted.
+
+That detects the *absence of work*, which metric alerting handles badly: nothing
+crashes, no error rate moves, work simply stops.
+
+```bash
+# in a shell script under `set -e`, the last line is the success check
+curl -fsS "https://kuma.example/api/push/<token>?status=up&msg=ok"
+```
+
+```ini
+# in a systemd unit - ExecStartPost only runs if ExecStart exited 0
+ExecStartPost=/usr/local/sbin/kuma-push.sh <token> "backup ok"
+```
+
+:::danger Never push unconditionally
+A job that calls its heartbeat regardless of outcome reports success when it
+fails. That is worse than no heartbeat, because it manufactures confidence.
+:::
+
+**Tokens are derived, not random** — `HMAC-SHA256(salt, monitor name)` from
+`uptime-kuma-push-salt`. A rebuilt watchdog therefore reissues *identical* URLs
+and no job needs rewiring. Back that salt up: lose it and every heartbeat caller
+is silently orphaned, still exiting 0 while nothing records that it ran.
+
+## Alerting
+
+Set a topic and alerting is configured on deploy:
+
+```bash
+UPTIME_KUMA_NTFY_TOPIC=uis-<something-long-and-random>
+```
+
+Then subscribe to the same topic in the [ntfy](https://ntfy.sh) app. Leave it
+empty and the watchdog still monitors — it just tells nobody, and says so during
+deploy rather than being quietly silent.
+
+:::warning On public ntfy.sh the topic name *is* the credential
+Anyone who learns it can read your alerts and publish fake ones. Use a long
+random value, or self-host.
+:::
+
+Every monitor pages by default. Set `notify: false` on anything whose failure is
+not both real and actionable:
+
+- a laptop or workstation that **sleeps** — it will page every nap
+- a heartbeat whose **job does not exist yet** — it pages once and stays down
+
+An alert you learn to swipe away is worse than no alert: it trains you to ignore
+the real one.
+
+## Adding a probe to a service
+
+For service authors. Create `provision-host/uis/services/<category>/probes/<id>.yaml`:
+
+```yaml
+# Only what is true of EVERY install of this service.
+# No hostnames - those are discovered. No secret values - name the key.
+service: my-service-web        # only if the k8s Service name differs from the id
+probes:
+  - id: gateway
+    type: http                 # http | tcp
+    path: /healthz
+    keyword: ready             # match content, not just status
+    auth: bearer:MY_API_KEY    # a KEY in urbalurba-secrets, never a value
+    interval: 60
+    maxretries: 2
+```
+
+⚠️ **`service:` matters.** The probe is matched to a Kubernetes Service by name.
+If your service id is `temporal` but the Service is `temporal-web`, omitting this
+means the probe matches nothing and the service goes unmonitored **with no
+error**.
+
+⚠️ **Prefer a keyword to a status code.** A gateway can return 200 while its
+database is dead, because the response never touched the database.
+
+## Deploy, verify, remove
+
+```bash
+uis deploy uptime-kuma            # Kuma + AutoKuma + admin + retention + alerts
+uis verify uptime-kuma
+uis undeploy uptime-kuma          # keeps monitors, history, notification config
+uis undeploy uptime-kuma --purge  # deletes all of it
+```
+
+**No first-run wizard.** `UPTIME_KUMA_DB_TYPE=sqlite` skips the database screen,
+and the playbook seeds the admin account — `needSetup` is just "is the user table
+empty?". Seeding is idempotent, so redeploying never clobbers a password you
+changed in the UI.
+
+Use `--purge` when you want to prove an install works. Keeping the volume means
+every reinstall after the first lands on existing state, so a broken
+first-install path stays hidden.
+
+## Storage and secrets
+
+Embedded SQLite on a `ReadWriteOnce` volume, StatefulSet, one writer. History
+retention defaults to 30 days rather than Kuma's 180, because a watchdog usually
+runs on flash storage.
+
+On a Pi or similar, put the volume somewhere other than the boot card — not for
+speed, but so wearing it out costs a replaceable device rather than a rebuild.
+
+| Key in `urbalurba-secrets` | |
 |---|---|
 | `uptime-kuma-admin-user` | `admin` |
 | `uptime-kuma-admin-password` | inherits `${DEFAULT_ADMIN_PASSWORD}` |
+| `uptime-kuma-push-salt` | derives heartbeat URLs — **back this up** |
+| `uptime-kuma-ntfy-server` / `-topic` | the alert channel |
 
-It deliberately **shares the platform admin password** rather than defining its
-own, so there is one credential to rotate rather than one per service — the same
-arrangement Grafana uses.
-
-Notification credentials (Telegram token, SMTP password, ntfy topic) are entered
-in the UI and live in the application's own database. Treat that volume as
-sensitive and back it up.
+It shares the platform admin password rather than defining its own, so there is
+one credential to rotate.
 
 :::warning
-Seeding writes directly to the application's `user` table, which is a private
-interface rather than a published API. The playbook guards against upstream
-schema changes by checking the table shape first and failing loudly, and it
-verifies afterwards that the seeded password actually authenticates.
+Three things write to Kuma's own database, which is a private interface rather
+than a published API: the admin seed, retention, and the alert channel with its
+attachments. Kuma has no API for any of them. Each is guarded — the schema is
+checked first, writes are insert-only, and each is verified afterwards rather
+than assumed. Monitors are **not** in that list; AutoKuma owns those.
 :::
-
-## Suggested first monitors
-
-Derived from failures that actually happened on the reference deployment:
-
-| Monitor | Type | Catches |
-|---|---|---|
-| k3s API `:6443` | TCP | the cluster being down — the in-cluster stack cannot report this |
-| Hypervisor UI | TCP/HTTP | the host being down |
-| PostgreSQL `:5432` | TCP | the database being unreachable |
-| Object storage `/minio/health/live` | HTTP | storage being down |
-| Any API gateway | HTTP + **keyword** | a 200 with a broken backend — status codes alone lie |
-| `backup-nightly` | **Push**, ~26 h expiry | a backup that silently stopped |
-| `worker-heartbeat` | **Push**, ~15 min expiry | a pipeline that stalled with nothing crashing |
-
-Use keyword matching, not just status codes: a gateway can return 200 while its
-database is dead.
-
-Set the expiry on daily heartbeats a couple of hours beyond the schedule so a
-late run does not page, and avoid windows that straddle the daylight-saving
-transition.
 
 ## Who watches the watchdog
 
-If Uptime Kuma dies, everything looks fine forever. Options:
+If Uptime Kuma dies you get silence, and silence looks exactly like health.
 
-- **Dead-man's switch** — it pushes a heartbeat to a free external service,
-  which alerts if the push stops. The only thing that catches the whole host
-  going away.
-- **Mutual monitoring** — the in-cluster Prometheus probes Uptime Kuma. The one
-  place where duplication is clearly correct.
+The arrangement that works: a **second machine** polls the watchdog and, if it
+cannot reach it, alerts your phone **directly** — going through Kuma would be
+pointless when Kuma is what is down. Latch the state so you get one alert, not a
+storm, plus one on recovery.
+
+⚠️ **That still does not cover everything.** Two machines in the same building
+share a power cut and an internet outage. Full coverage needs something off-site:
+a free dead-man's-switch service, or a cron job somewhere you do not own.
+
+Decide where you put that boundary deliberately, rather than discovering it
+during an incident.
+
+## When something is wrong
+
+The failure modes here are quiet ones, so check in this order:
+
+| Symptom | Likely cause |
+|---|---|
+| `apply` succeeded, no new monitors | AutoKuma has not re-read the definitions. `apply` restarts it; a manual Secret edit does not |
+| Monitor count doubled after a restart | `/data` is not persisted — it holds AutoKuma's id map |
+| A monitor is DOWN with 401 | the probe's `auth:` key is missing from `urbalurba-secrets` |
+| A deployed service has no monitor | read the `NOT MONITORED` list from `uis monitors render` |
+| `check` reports drift that is not real | wrong `--from`/`--to` contexts |
+| Everything green, nothing ever alerts | no channel configured, or `notify: false` |


### PR DESCRIPTION
Uptime Kuma installed cleanly and then **sat there empty** — every monitor had to be created by hand in the UI. AutoKuma is what turns it into something that works, so it ships *with* the service rather than as a separate thing to deploy.

`uis deploy uptime-kuma` produces both. `--purge` removes both.

Manifest is `230-uptime-kuma-autokuma.yaml`, matching the existing `230-uptime-kuma-*` files, so the `230` prefix keeps meaning "this one service".

## Six behaviours encoded in the manifest

Every one of these **fails silently** — nothing errors, the wrong thing just quietly becomes true. They're commented inline so the next person doesn't rediscover them.

| # | Behaviour |
|---|---|
| 1 | **Separate Deployment, not a sidecar.** Pod containers start together, Kuma needs ~30s before Socket.IO, and AutoKuma makes *one* connect attempt |
| 2 | **`strategy: Recreate`.** `/data` is RWO with a lock; RollingUpdate leaves two instances — and since definitions are *copied* into an emptyDir, the two can work from different file sets. Observed coexisting 20+ minutes |
| 3 | **PVC on `/data`** — the id→entity map. Without it every restart re-creates every monitor: 19 became 38, no error anywhere |
| 4 | **Init container flattens the Secret with `cp -L`.** Kubernetes projects Secrets as symlinks into `..data/`, which AutoKuma's scanner doesn't follow — it connects, migrates, finds nothing, logs nothing |
| 5 | **Image `2.0.0`, not `v2.0.0`** — the v-prefixed tag is single-arch and won't pull on arm64, which is where a watchdog tends to run |
| 6 | **Notifications are not AutoKuma's.** It *can* own them and delivery works, but 2.0.0 never converges — rewriting the channel every ~5s forever, a DB write every 5s on flash storage |

The monitors Secret is `optional: true`, so a stock install deploys cleanly with no definitions at all (verified: `flatten: monitor definitions: 0`).

## Verified on assist

```
uis undeploy uptime-kuma --purge --yes    → both components + PVCs + definitions gone
uis deploy uptime-kuma                    → statefulset + autokuma, admin seeded
re-apply definitions                      → 19 monitors, push tokens IDENTICAL
```

Identical tokens matter: the backup jobs already wired on Odin and the pg CT kept working with no change. Confirmed by pushing from Odin's real `kuma-push.sh` after the rebuild.

## Not in this PR

`PLAN-service-uptime-kuma-005` (added here) covers the rest: the `uis monitors` verb, `.uis.extend/monitors.yaml` for targets UIS didn't deploy, and seeding the alert channel from `urbalurba-secrets`. Today those still live in the operator's own repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR