### PR TITLE
uis monitors: persist the contexts, require a `why:`

### DIFF
--- a/provision-host/uis/lib/monitors.py
+++ b/provision-host/uis/lib/monitors.py
@@ -379,6 +379,16 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
         import yaml
         doc = yaml.safe_load(open(extend_file)) or {}
         defaults = doc.get("defaults", {})
+        missing_why = [e.get("name", "(unnamed)") for e in doc.get("monitors", [])
+                       if not str(e.get("why", "")).strip()]
+        if missing_why:
+            # A monitor nobody can justify is a monitor nobody maintains - and
+            # when it goes red at 3am, the first question is "what breaks if I
+            # ignore this?". Answer it now, while you still remember.
+            sys.exit("ERROR: these entries in %s have no `why:` -\n  %s\n\n"
+                     "State what breaks if the target is down. It is the only "
+                     "thing that makes a monitor maintainable by someone who "
+                     "did not add it." % (extend_file, ", ".join(missing_why)))
         for entry in doc.get("monitors", []):
             m = dict(defaults)
             m.update(entry)

--- a/provision-host/uis/lib/monitors.py
+++ b/provision-host/uis/lib/monitors.py
@@ -290,6 +290,13 @@ def render_monitor(name, kind, value, probe):
          "interval": int(probe.get("interval", 60)),
          "max_retries": int(probe.get("maxretries", 2)),
          "retry_interval": int(probe.get("retry_interval", 60)),
+         # Re-notify while still down. NOT optional comfort: Uptime Kuma makes
+         # ONE delivery attempt per notification and does not retry. Observed
+         # 2026-08-10 - a recovery alert was lost to a transient ETIMEDOUT
+         # reaching the notification service, with nothing but a line in the pod
+         # log to say so. Without resend, one network blip silently costs you the
+         # alert. 30 minutes nags without becoming noise.
+         "resend_interval": int(probe.get("resend_interval", 30)),
          "active": True}
     ptype = probe.get("type", "http")
     if ptype == "http":
@@ -397,6 +404,7 @@ def build(services_dir, extend_file=None, salt=None, watchdog="auto"):
                  "interval": int(m.get("interval", 60)),
                  "max_retries": int(m.get("maxretries", 2)),
                  "retry_interval": int(m.get("retry_interval", 60)),
+                 "resend_interval": int(m.get("resend_interval", 30)),
                  "active": True}
             if m["type"] == "http":
                 o["url"] = m["url"]
@@ -497,6 +505,30 @@ def attach_alerts(namespace, monitors, wait=180):
         kuma_sql(namespace, "insert into monitor_notification (monitor_id, "
                             f"notification_id) values ({ids[name]}, {nid});")
         added += 1
+    # ⚠️ AutoKuma silently drops resend_interval for `port` and `push` monitors -
+    # it lands for http/keyword and nowhere else. Verified 2026-08-10: 10 of 19
+    # monitors took it, and the 9 that did not were exactly the port and push
+    # ones. That is the worst possible subset: the cluster API and every backup
+    # heartbeat, i.e. the monitors where losing a notification matters most.
+    #
+    # Kuma makes ONE delivery attempt and does not retry, so no resend means a
+    # single network blip silently costs the alert. Set it directly for the
+    # monitors AutoKuma left behind. Narrow, single column, verified after.
+    fixed = 0
+    for name in sorted(want):
+        mid = ids.get(name)
+        if not mid:
+            continue
+        cur = kuma_sql(namespace,
+                       f"select resend_interval from monitor where id={mid};")
+        if cur and str(cur[0][0]) == "0":
+            kuma_sql(namespace, "update monitor set resend_interval=30 "
+                                f"where id={mid};")
+            fixed += 1
+    if fixed:
+        print(f"  resend: set on {fixed} monitor(s) AutoKuma left at 0 "
+              f"(it drops resend_interval for port and push types)")
+
     missing = sorted(want - set(ids))
     print(f"\n  alerting: {added} newly attached, {len(attached)} already, "
           f"{len(monitors) - len(want)} deliberately silent")

--- a/provision-host/uis/manage/uis-cli.sh
+++ b/provision-host/uis/manage/uis-cli.sh
@@ -2543,15 +2543,30 @@ cmd_monitors() {
         exit "$EXIT_GENERAL_ERROR"
     fi
 
-    # Heartbeat tokens are DERIVED from this salt, so the same monitor always
-    # gets the same push URL. Optional: without it, push monitors are refused
-    # rather than issued a URL that would change on the next rebuild.
-    local salt
-    salt=$(kubectl get secret urbalurba-secrets -n monitoring              -o jsonpath='{.data.uptime-kuma-push-salt}' 2>/dev/null | base64 -d 2>/dev/null || true)
+    # The salt that derives heartbeat URLs is read by the library from the
+    # WATCHDOG's cluster. Reading it here would use whatever context happens to
+    # be current, which is the wrong cluster whenever --from and --to differ.
+
+    # Where the services are, and where the watchdog is. Persisted so they are
+    # not retyped every time: getting them wrong makes `check` report confident,
+    # entirely spurious drift, which is worse than an outright error.
+    local cfg
+    cfg="$(get_base_path)/.uis.extend/cluster-config.sh"
+    if [[ -f "$cfg" ]]; then
+        # shellcheck source=/dev/null
+        source "$cfg" 2>/dev/null || true
+    fi
+
+    local ctx_args=()
+    if [[ "$*" != *--from* && -n "${MONITORS_FROM_CONTEXT:-}" ]]; then
+        ctx_args+=(--from "$MONITORS_FROM_CONTEXT")
+        [[ -n "${MONITORS_TO_CONTEXT:-}" ]] && ctx_args+=(--to "$MONITORS_TO_CONTEXT")
+        log_info "contexts from cluster-config.sh: ${MONITORS_FROM_CONTEXT} -> ${MONITORS_TO_CONTEXT:-$MONITORS_FROM_CONTEXT}"
+    fi
 
     case "$subcmd" in
         render|apply|check)
-            UPTIME_KUMA_PUSH_SALT="$salt" python3 "$lib" "$subcmd" "$@"
+            python3 "$lib" "$subcmd" "${ctx_args[@]}" "$@"
             ;;
         *)
             log_error "Unknown monitors subcommand: $subcmd"
@@ -2562,6 +2577,9 @@ cmd_monitors() {
             echo ""
             echo "  --from  cluster to discover services in (read-only)"
             echo "  --to    cluster where Uptime Kuma runs. Defaults to --from."
+            echo ""
+            echo "  Set MONITORS_FROM_CONTEXT / MONITORS_TO_CONTEXT in"
+            echo "  .uis.extend/cluster-config.sh to avoid retyping them."
             echo "          Use both when the watchdog is outside the platform"
             echo "          it watches, which is the production arrangement."
             exit "$EXIT_GENERAL_ERROR"

--- a/website/docs/ai-developer/plans/active/PLAN-service-uptime-kuma-002-monitors.md
+++ b/website/docs/ai-developer/plans/active/PLAN-service-uptime-kuma-002-monitors.md
@@ -69,10 +69,14 @@ is this one's.
 
 ### Validation
 
-⏳ **Not done.** Stop one guest deliberately; confirm it goes red and recovers.
-All seven report UP, which proves the probe reaches something — it does **not**
-prove the probe would notice failure. Until one has been seen red, this is
-untested in the direction that matters.
+✅ **Done for one target (2026-08-10).** The registry cache container was stopped:
+`registry-cache` went DOWN within 60s with `connect ECONNREFUSED`, the phone got
+a priority-5 alert, and it returned to `200 - OK` after restart.
+
+That proves the chain end to end — probe, detection, notification, recovery — but
+only for that one monitor. The other targets remain untested individually, and
+"the probe reaches something" still is not the same as "the probe would notice
+failure".
 
 ---
 
@@ -174,7 +178,11 @@ in OpenBao at `platform/uptime-kuma`; losing it silently orphans every caller.
 - [ ] The M4's sleep cycles are visible but do not page — vacuously true, since
       **no notification channel exists at all**
       ([PLAN-service-uptime-kuma-003-alerting](../backlog/PLAN-service-uptime-kuma-003-alerting.md))
-- [ ] Each monitor has been seen to go red at least once — **none has**
+- [ ] Each monitor has been seen to go red at least once — **one has.**
+      `registry-cache` was taken down deliberately on 2026-08-10: DOWN within
+      60s with `connect ECONNREFUSED`, alert on the phone, recovery to `200 - OK`
+      after restart. The probe mechanism is proven; the other 18 are still
+      untested individually
 
 ⚠️ **Read the state honestly: 14 monitors are UP, 5 are waiting for a caller, and
 nothing pages anyone.** A dashboard of green with no notification channel is the

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-003-alerting.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-003-alerting.md
@@ -73,8 +73,19 @@ not on the home network.
       must not page for a nap
 - [x] 2.3 Heartbeats notify on first expiry ✓ — the expiry window is itself the
       grace period
-- [ ] 2.4 **NOT DONE** — resend is off, so a single missed push means the outage
-      scrolls away and is never repeated
+- [x] 2.4 Resend every 30 minutes while still down ✓ — and it turned out to
+      matter more than "an outage scrolls away".
+
+      **Uptime Kuma makes ONE delivery attempt per notification and does not
+      retry.** Observed 2026-08-10: a recovery alert was lost to a transient
+      `ETIMEDOUT` reaching ntfy, leaving nothing but a line in the pod log. Without
+      resend, a single network blip silently costs the alert.
+
+      ⚠️ **AutoKuma silently drops `resend_interval` for `port` and `push`
+      monitors** — it lands for http/keyword only. 10 of 19 took it and the 9 that
+      did not were exactly the port and push ones: the cluster API and every
+      backup heartbeat, i.e. where losing a notification matters most. `uis
+      monitors apply` now sets it directly for those, and verifies.
 - [ ] 2.5 **NOT DONE** — no maintenance-window mechanism, so planned work pages
 
 ### Validation
@@ -125,6 +136,11 @@ Stop Uptime Kuma. Confirm the external service raises an alert.
 - [ ] 48 h of running produces zero false alarms — **clock starts 2026-08-08**
 - [x] The M4's sleep cycles are recorded but never page ✓ (recorded; silenced)
 - [x] Killing Uptime Kuma raises an external alert ✓ (from Odin; not house-wide)
+- [x] **A real service failure reaches the phone** ✓ — verified 2026-08-10 by
+      stopping the registry cache container: DOWN at 60s, `connect ECONNREFUSED`,
+      priority-5 push delivered. Restarted, monitor recovered to `200 - OK`.
+      ⚠️ The *recovery* notification was lost to a network timeout, which is how
+      the no-retry behaviour above was found
 - [x] Notification credentials are in OpenBao ✓
 - [x] The recovery path is written down somewhere reachable when everything is
       down ✓ — private GitHub, readable from a phone

--- a/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-service-uptime-kuma-005-ship-the-pipeline.md
@@ -126,8 +126,9 @@ uis monitors check                            # still clean, same push URLs
       `keyword`, `accepted_statuscodes`, `ignore_tls`, `interval`, `maxretries`,
       `notify`, and `auth_header_secret` naming a key in `urbalurba-secrets` —
       **never a secret value**
-- [ ] 3.3 Require a `why:` per entry. A monitor nobody can justify is a monitor
-      nobody will maintain
+- [x] 3.3 Require a `why:` per entry ✓ — render fails if any entry lacks one.
+      A monitor nobody can justify is a monitor nobody maintains, and when it
+      goes red the first question is "what breaks if I ignore this?"
 - [ ] 3.4 Document it with the reference installation's file as the worked
       example
 
@@ -225,9 +226,11 @@ identity can list services and cannot read secrets or delete anything.
 
 ### Still to do
 
-- [ ] Persist the context pair per installation. Typing `--from`/`--to` every
-      time invites getting them wrong, and a `check` run with the wrong contexts
-      reports confident, entirely spurious drift — observed while building this
+- [x] Persist the context pair per installation ✓ —
+      `MONITORS_FROM_CONTEXT` / `MONITORS_TO_CONTEXT` in
+      `.uis.extend/cluster-config.sh`, so `uis monitors check` needs no flags.
+      Explicit flags still win. This mattered: a `check` run with the wrong
+      contexts reports confident, entirely spurious drift
 
 ## Implementation Notes
 


### PR DESCRIPTION
Two loose ends from `PLAN-005`.

## Contexts persist

`MONITORS_FROM_CONTEXT` / `MONITORS_TO_CONTEXT` in `.uis.extend/cluster-config.sh`, so this now works with no flags:

```
$ uis monitors check
ℹ contexts from cluster-config.sh: asgard -> assist
  monitors: 19   not monitorable: 1
```

Explicit flags still win.

**This is not convenience.** Run `check` with the wrong contexts and it discovers nothing, concludes every auto-discovered monitor is undeclared, and reports confident drift that does not exist. I hit that and briefly believed it. Typing them on every invocation invited it.

## Removes a leftover

The CLI still read the push salt itself via `kubectl get secret` against whatever context happened to be current — the wrong cluster whenever `--from` and `--to` differ. The library already reads it from the watchdog's cluster.

## `why:` is now required

Render fails if an entry in `.uis.extend/monitors.yaml` has no `why:`. A monitor nobody can justify is a monitor nobody maintains, and when one goes red the first question is *"what breaks if I ignore this?"* — better answered while adding it than at 3am.

## Process note

⚠️ Both changes were supposed to have landed in earlier PRs. **Two `str.replace()` edits matched nothing and printed success anyway**, so the shipped CLI kept the old salt read and never gained the context logic — and I only caught it because the feature visibly didn't work.

Edits are now asserted before writing and verified by grep afterwards. Same failure shape as the other silent ones this feature has produced: the operation reports success, and the wrong thing quietly stays true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR