### PR TITLE
Plan: baseline alert rules, and a receiver chosen by measurement

### DIFF
--- a/ansible/playbooks/030-setup-prometheus.yml
+++ b/ansible/playbooks/030-setup-prometheus.yml
@@ -49,6 +49,72 @@
       ansible.builtin.command: helm repo update
       changed_when: false
 
+    # ---- alerting credentials ------------------------------------------------
+    # Rules deploy regardless. Only DELIVERY depends on these, and if they are
+    # absent the deploy says so loudly rather than installing a monitoring stack
+    # that quietly notifies nobody.
+    - name: "4.1 Read alerting credentials from urbalurba-secrets"
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        namespace: "{{ namespace }}"
+        name: urbalurba-secrets
+        kubeconfig: "{{ merged_kubeconf_file | default(omit) }}"
+      register: obs_secret
+      failed_when: false
+      no_log: true
+
+    - name: "4.2 Extract the Telegram bot token and chat id"
+      ansible.builtin.set_fact:
+        _tg_token: "{{ (obs_secret.resources[0].data['alertmanager-telegram-bot-token'] | default('') | b64decode) | trim }}"
+        _tg_chat: "{{ (obs_secret.resources[0].data['alertmanager-telegram-chat-id'] | default('') | b64decode) | trim }}"
+      when: obs_secret.resources | default([]) | length > 0
+      no_log: true
+
+    - name: "4.3 Warn when alerting has no receiver"
+      ansible.builtin.debug:
+        msg:
+          - "⚠️  No Telegram credentials - alert rules will deploy but NOTHING WILL BE DELIVERED."
+          - "Set ALERTMANAGER_TELEGRAM_BOT_TOKEN and ALERTMANAGER_TELEGRAM_CHAT_ID,"
+          - "then: uis secrets generate && uis secrets apply && uis deploy prometheus"
+      when: (_tg_token | default('')) | length == 0
+
+    - name: "4.4 Create the Alertmanager token Secret"
+      # A Secret, not the values file: `alertmanager.config` is rendered into a
+      # ConfigMap, and a token that can control the bot does not belong there.
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: alertmanager-telegram
+            namespace: "{{ namespace }}"
+          type: Opaque
+          stringData:
+            token: "{{ _tg_token }}"
+        kubeconfig: "{{ merged_kubeconf_file | default(omit) }}"
+      when: (_tg_token | default('')) | length > 0
+      no_log: true
+
+    - name: "4.5 Render the chat id into the values file"
+      # chat_id cannot be read from a file by Alertmanager (only bot_token can),
+      # so it has to be substituted. Installation-specific, hence not committed.
+      ansible.builtin.command: >
+        sed -i 's/TELEGRAM_CHAT_ID_PLACEHOLDER/{{ _tg_chat }}/'
+        {{ prometheus_config_file }}
+      when: (_tg_chat | default('')) | length > 0
+      changed_when: true
+
+    - name: "4.6 Disable the receiver when unconfigured"
+      # Leaving the literal placeholder in would make Alertmanager fail to load
+      # its config, which takes ALL alerting down rather than just delivery.
+      ansible.builtin.command: >
+        sed -i 's/chat_id: TELEGRAM_CHAT_ID_PLACEHOLDER/chat_id: 0/'
+        {{ prometheus_config_file }}
+      when: (_tg_chat | default('')) | length == 0
+      changed_when: true
+
     - name: 5. Install/upgrade Prometheus via Helm
       ansible.builtin.command: >
         helm upgrade --install prometheus prometheus-community/prometheus

--- a/manifests/030-prometheus-config.yaml
+++ b/manifests/030-prometheus-config.yaml
@@ -53,11 +53,60 @@ server:
     web.enable-remote-write-receiver: ""
 
 # Alertmanager configuration
+#
+# ⚠️ THE RECEIVER MUST BE ONE ALERTMANAGER SUPPORTS NATIVELY.
+# The obvious idea - reuse the ntfy channel the external watchdog already uses -
+# does not work: this Alertmanager has no ntfy receiver, and ntfy cannot format
+# Alertmanager's webhook JSON (posting it delivers raw JSON to the phone;
+# ${...} placeholders arrive literally; {{...}} returns HTTP 400). Unifying them
+# would mean a bespoke translator sitting in the alert path, and a component
+# whose failure produces silence must not live there. Telegram is native, so
+# delivery is upstream-tested code end to end.
 alertmanager:
   enabled: true
   persistentVolume:
     enabled: true
     size: 2Gi
+
+  # The bot token as a FILE, never inline: `config` below is rendered into a
+  # ConfigMap, which is not a place for a credential that can control the bot.
+  extraSecretMounts:
+    - name: telegram-token
+      mountPath: /etc/alertmanager/telegram
+      secretName: alertmanager-telegram
+      readOnly: true
+
+  config:
+    global:
+      resolve_timeout: 5m
+
+    route:
+      receiver: telegram
+      # One notification for a broad failure, not forty. A node going away
+      # otherwise produces an alert per pod on it.
+      group_by: [alertname, namespace]
+      group_wait: 30s
+      group_interval: 5m
+      # Re-notify while unresolved. Assume a single delivery can be lost - that
+      # was observed happening to the external watchdog, which retries nothing.
+      repeat_interval: 4h
+      routes:
+        - matchers: ['severity = "critical"']
+          receiver: telegram
+          repeat_interval: 1h
+
+    receivers:
+      - name: telegram
+        telegram_configs:
+          - bot_token_file: /etc/alertmanager/telegram/token
+            chat_id: TELEGRAM_CHAT_ID_PLACEHOLDER
+            parse_mode: HTML
+            send_resolved: true
+            message: |-
+              {{ if eq .Status "firing" }}🔴{{ else }}🟢 RESOLVED:{{ end }} <b>{{ .CommonLabels.alertname }}</b>
+              {{ range .Alerts }}{{ .Annotations.summary }}
+              {{ if .Annotations.description }}<i>{{ .Annotations.description }}</i>
+              {{ end }}{{ end }}
   resources:
     requests:
       cpu: 100m
@@ -95,3 +144,153 @@ kubeStateMetrics:
 # Enables automatic scraping of services with ServiceMonitor CRDs
 serviceMonitors:
   enabled: true
+
+# ---------------------------------------------------------------------------
+# Scrape Alertmanager itself.
+#
+# ⚠️ WITHOUT THIS, THE NOTIFIER IS THE ONE COMPONENT NOBODY WATCHES.
+# alertmanager_notifications_failed_total does not exist unless Alertmanager is
+# scraped, so a notifier that silently stops delivering is invisible - which is
+# the same failure the alerts below exist to prevent, one level up. Uptime Kuma
+# was observed losing a real alert to a single failed delivery attempt with no
+# retry; assume this one can do the same and make it visible.
+# ---------------------------------------------------------------------------
+extraScrapeConfigs: |
+  - job_name: alertmanager
+    static_configs:
+      - targets:
+          - prometheus-alertmanager.monitoring.svc.cluster.local:9093
+
+# ---------------------------------------------------------------------------
+# Baseline alert rules.
+#
+# There is NO prometheus-operator here (the community chart, not
+# kube-prometheus-stack), so these are files in the prometheus-server ConfigMap,
+# not PrometheusRule CRDs. `kubectl get prometheusrule` returns 0 no matter what
+# is configured.
+#
+# DESIGN RULES, learned the hard way elsewhere in this platform:
+#  - Every alert must answer "what would I do about this?". If it cannot, it is
+#    noise, and noise teaches people to ignore alerts.
+#  - `for:` durations are the difference between alerting and noise. A pod not
+#    ready for 15 seconds is a deployment; for 15 minutes it is a problem.
+#  - Prefer forecasting to thresholds where possible. "85% full" says where you
+#    are; "full in 6 hours" says whether to care.
+#  - Deliberately NOT the ~100 rules from kube-prometheus-stack: on a single-node
+#    k3s many are meaningless or permanently firing, and a permanently-firing
+#    alert is a muted alert.
+#
+# Every metric referenced here was confirmed present on a live cluster before
+# being used, so none of these is an alert that can never fire.
+# ---------------------------------------------------------------------------
+serverFiles:
+  alerting_rules.yml:
+    groups:
+      - name: capacity
+        rules:
+          - alert: PersistentVolumeFillingUp
+            expr: |
+              kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.85
+            for: 10m
+            labels: { severity: warning }
+            annotations:
+              summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full"
+              description: "Expand the volume or delete data. Above 90% many databases stop accepting writes."
+
+          # The one that gives you a working day's notice instead of a surprise.
+          - alert: PersistentVolumeWillFillIn24h
+            expr: |
+              predict_linear(kubelet_volume_stats_available_bytes[6h], 24 * 3600) < 0
+              and kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.6
+            for: 30m
+            labels: { severity: critical }
+            annotations:
+              summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is on course to be full within 24h"
+              description: "Based on the last 6h of growth. Act now rather than at 100%."
+
+          - alert: NodeFilesystemFillingUp
+            expr: |
+              (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}
+                 / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}) > 0.85
+            for: 15m
+            labels: { severity: warning }
+            annotations:
+              summary: "{{ $labels.instance }} filesystem {{ $labels.mountpoint }} is over 85% full"
+              description: "A full root filesystem takes the kubelet with it."
+
+          - alert: NodeMemoryPressure
+            expr: |
+              node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.10
+            for: 15m
+            labels: { severity: warning }
+            annotations:
+              summary: "{{ $labels.instance }} has under 10% memory available"
+              description: "The OOM killer will start choosing for you."
+
+      - name: workloads
+        rules:
+          - alert: PodCrashLooping
+            expr: |
+              increase(kube_pod_container_status_restarts_total[30m]) > 3
+            for: 5m
+            labels: { severity: critical }
+            annotations:
+              summary: "{{ $labels.namespace }}/{{ $labels.pod }} is restarting repeatedly"
+              description: "More than 3 restarts in 30m. kubectl logs --previous."
+
+          # 15m, not 5m: long enough that an ordinary rollout does not page.
+          - alert: PodNotReady
+            expr: |
+              kube_pod_status_ready{condition="false"} == 1
+            for: 15m
+            labels: { severity: warning }
+            annotations:
+              summary: "{{ $labels.namespace }}/{{ $labels.pod }} has been not-ready for 15m"
+              description: "Too long for a deployment. kubectl describe pod."
+
+          - alert: DeploymentReplicasUnavailable
+            expr: |
+              kube_deployment_status_replicas_unavailable > 0
+            for: 15m
+            labels: { severity: warning }
+            annotations:
+              summary: "{{ $labels.namespace }}/{{ $labels.deployment }} has unavailable replicas"
+
+          - alert: NodeNotReady
+            expr: |
+              kube_node_status_condition{condition="Ready",status="true"} == 0
+            for: 5m
+            labels: { severity: critical }
+            annotations:
+              summary: "Node {{ $labels.node }} is not Ready"
+              description: "On a single-node cluster this means the platform is down."
+
+      - name: monitoring-itself
+        rules:
+          # A monitoring stack that has stopped looking must say so. This is the
+          # in-cluster version of "absence renders as green".
+          - alert: ScrapeTargetDown
+            expr: up == 0
+            for: 10m
+            labels: { severity: warning }
+            annotations:
+              summary: "Prometheus cannot scrape {{ $labels.job }} ({{ $labels.instance }})"
+              description: "Metrics from this target are missing, so alerts based on them cannot fire."
+
+          - alert: PrometheusConfigReloadFailed
+            expr: prometheus_config_last_reload_successful == 0
+            for: 5m
+            labels: { severity: critical }
+            annotations:
+              summary: "Prometheus is running with a stale config"
+              description: "The last reload failed, so any rule change since then is NOT active."
+
+          # Requires the alertmanager scrape job above.
+          - alert: AlertNotificationsFailing
+            expr: |
+              increase(alertmanager_notifications_failed_total[30m]) > 0
+            for: 5m
+            labels: { severity: critical }
+            annotations:
+              summary: "Alertmanager is failing to deliver notifications"
+              description: "Alerts are firing and not reaching anyone. Check the receiver's credentials and outbound network."

--- a/manifests/030-prometheus-config.yaml
+++ b/manifests/030-prometheus-config.yaml
@@ -161,6 +161,35 @@ extraScrapeConfigs: |
       - targets:
           - prometheus-alertmanager.monitoring.svc.cluster.local:9093
 
+  # ---------------------------------------------------------------------------
+  # Hosts and services OUTSIDE the cluster.
+  #
+  # On a production install the cluster runs on something, and that something is
+  # invisible here by default: the external watchdog says whether it answers, but
+  # nothing says whether its disk is filling. The in-cluster workloads are
+  # replaceable; the storage pool holding every volume is not.
+  #
+  # ⚠️ Addresses are installation-specific. This block belongs in
+  # `.uis.extend` for a real deployment (PLAN-004 Phase 2) - it is inline here
+  # only until that mechanism exists, and a stock install should scrape nothing
+  # extra.
+  #
+  # Scraped over the host-only backplane rather than the LAN, so monitoring
+  # traffic cannot leave the hypervisor and does not depend on anything hosted.
+  # The exporter is bound to that address too, so host metrics - a detailed
+  # inventory of filesystems, memory and processes - are not offered to the LAN.
+  #
+  # No new alert rules are needed: PLAN-002's capacity rules match on
+  # node_filesystem_* with no cluster-specific selector, so this host is covered
+  # the moment it is scraped. If adding a host had required new rules, the rules
+  # were written too narrowly.
+  - job_name: external-hosts
+    static_configs:
+      - targets:
+          - 10.10.0.1:9100        # hypervisor - ZFS pool, disks, memory
+        labels:
+          role: hypervisor
+
 # ---------------------------------------------------------------------------
 # Baseline alert rules.
 #

--- a/manifests/031-alloy-config.yaml
+++ b/manifests/031-alloy-config.yaml
@@ -1,0 +1,156 @@
+# File: manifests/031-alloy-config.yaml
+#
+# Description:
+# Helm values for Grafana Alloy — the log collection agent that ships container
+# logs into Loki. Without it Loki is deployed, healthy, and empty: it holds only
+# its own canary traffic, and Grafana's Loki datasource returns nothing useful.
+#
+# Alloy runs as a DaemonSet because logs are per-node.
+#
+# Usage:
+#   helm upgrade --install alloy grafana/alloy \
+#     -n monitoring -f manifests/031-alloy-config.yaml
+#
+# Prerequisites:
+# - the 'monitoring' namespace, with Loki already deployed
+# - Helm repository: https://grafana.github.io/helm-charts
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY ALLOY, AND NOT PROMTAIL
+# Promtail reached end-of-life on 2 March 2026. Alloy is its successor and a
+# vendor-neutral distribution of the OTel Collector.
+#
+# ⚠️ SCOPE: LOGS ONLY.
+# Alloy can also replace the standalone OTel Collector, taking the stack from
+# five components to four. That is deliberately NOT done here. The collector
+# currently carries the metrics remote-write path into Prometheus and it works;
+# replacing it in the same change that introduces log collection would put two
+# failure domains in one step and make any regression hard to attribute.
+# Consolidate later, once logs are known good.
+# ─────────────────────────────────────────────────────────────────────────────
+---
+# Pin it, like every other image.
+image:
+  tag: v1.13.1
+
+controller:
+  # Logs live on nodes, so the agent has to be on every node.
+  type: daemonset
+
+alloy:
+  # No UI needed for a log shipper; it is one less thing exposed.
+  enableReporting: false
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # Mounts /var/log and the container runtime's log directory.
+  mounts:
+    varlog: true
+
+  configMap:
+    content: |-
+      // Discover every pod in the cluster.
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      // ── Labels ──────────────────────────────────────────────────────────
+      // Labels are the whole ergonomics of Loki: they are what you filter on,
+      // and they are indexed.
+      //
+      // ⚠️ NOTHING HIGH-CARDINALITY HERE. No pod UID, no request id, no trace
+      // id. Loki indexes every label value, so a label that is unique per pod
+      // instance turns the index into the component that falls over. This is
+      // the most common way a working Loki install becomes an unusable one.
+      discovery.relabel "pods" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label  = "container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+        // The app label if the workload sets one - this is what makes
+        // "show me everything for this service" a single query.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          target_label  = "app"
+        }
+        // Blank out `instance` at the TARGET level. loki.source.kubernetes
+        // derives it as "<ns>/<pod>:<container>", which embeds the pod name and
+        // therefore mints a new label value on every deploy. stage.label_drop in
+        // the process pipeline does NOT remove it - verified - because the source
+        // sets it outside that label set. In relabel semantics an empty
+        // replacement drops the label.
+        rule {
+          target_label = "instance"
+          replacement  = ""
+        }
+        // Drop anything not actually running, so we do not tail nothing.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_phase"]
+          regex         = "Pending|Succeeded|Failed|Completed"
+          action        = "drop"
+        }
+      }
+
+      // Tail the files the kubelet writes.
+      loki.source.kubernetes "pods" {
+        targets    = discovery.relabel.pods.output
+        forward_to = [loki.process.drop_empty.receiver]
+      }
+
+      loki.process "drop_empty" {
+        // Drop blank lines. Pure cost: stored, indexed, never read.
+        stage.drop {
+          expression = "^\\s*$"
+        }
+
+        // ⚠️ REMOVE HIGH-CARDINALITY LABELS THE SOURCE ADDS BY DEFAULT.
+        // loki.source.kubernetes attaches `instance`, which looks like
+        //   ai/litellm-765b7db9dd-nvm9p:litellm
+        // - it contains the pod name, so every deploy or restart mints a new
+        // label value and the index grows without bound. Observed on the first
+        // deploy of this config, which is why the relabel rules above are not
+        // sufficient on their own: they add labels, they do not remove the
+        // ones the source supplies.
+        //
+        // namespace + pod + container already identify the stream, without the
+        // unbounded growth.
+        stage.label_drop {
+          values = ["instance", "service_name"]
+        }
+
+        forward_to = [loki.write.loki.receiver]
+      }
+
+      // Write to the Loki that is already deployed. Do NOT stand up a second one.
+      loki.write "loki" {
+        endpoint {
+          url = "http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push"
+        }
+      }
+
+# The chart's own service account needs to read pods to discover them.
+rbac:
+  create: true
+
+serviceMonitor:
+  enabled: false

--- a/provision-host/uis/templates/secrets-templates/00-common-values.env.template
+++ b/provision-host/uis/templates/secrets-templates/00-common-values.env.template
@@ -249,6 +249,21 @@ UPTIME_KUMA_NTFY_TOPIC=
 UPTIME_KUMA_PUSH_SALT=
 
 # ================================================================
+# 🔧 OPTIONAL - IN-CLUSTER ALERTING (prometheus / alertmanager)
+# ================================================================
+# Without these, alert rules still deploy and evaluate - they just reach nobody,
+# and the deploy says so. With them, Alertmanager messages you directly.
+#
+# Deliberately a different channel from the watchdog's ntfy topic, so that
+# "the platform is unreachable" cannot be swiped away with "a disk is at 86%".
+#
+# Setup: message @BotFather, /newbot, keep the token. Then send your new bot any
+# message (a bot cannot message you first) and read the chat id from:
+#   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates"
+ALERTMANAGER_TELEGRAM_BOT_TOKEN=
+ALERTMANAGER_TELEGRAM_CHAT_ID=
+
+# ================================================================
 # 🔧 OPTIONAL - APPLICATION-SPECIFIC
 # ================================================================
 # Add your own application variables here

--- a/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
+++ b/provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template
@@ -679,6 +679,15 @@ stringData:
   uptime-kuma-ntfy-server: "https://ntfy.sh"
   uptime-kuma-ntfy-topic: "${UPTIME_KUMA_NTFY_TOPIC}"
 
+  # In-cluster alerting (Alertmanager). A DIFFERENT channel from the watchdog
+  # above, on purpose: "the platform is unreachable" must not be lost among
+  # "a disk is filling". Telegram because Alertmanager supports it natively -
+  # it has no ntfy receiver, and putting a translator in the alert path would
+  # mean a component whose failure produces silence.
+  # Empty ⇒ alert rules still deploy, delivery is skipped, and the deploy warns.
+  alertmanager-telegram-bot-token: "${ALERTMANAGER_TELEGRAM_BOT_TOKEN}"
+  alertmanager-telegram-chat-id: "${ALERTMANAGER_TELEGRAM_CHAT_ID}"
+
 # ================================================================
 # AUTHENTIK NAMESPACE SECRETS
 # ================================================================

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-001-log-collection.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-001-log-collection.md
@@ -1,0 +1,181 @@
+# Ship container logs to Loki
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active — deployed and collecting; retention decision (Phase 3) outstanding
+
+**Goal**: Logs from every pod are searchable in Grafana, automatically, so that
+when an alert fires there is something to look at.
+
+**Investigation**: [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md)
+— finding **OBS-F2**, re-verified 2026-08-11 and unchanged
+
+**Related**: [PLAN-system-observability-002-alert-baseline](./PLAN-system-observability-002-alert-baseline.md)
+— shipped. Alerts now fire; this is what makes them diagnosable
+
+**Priority**: High
+
+---
+
+## Problem
+
+Loki is deployed, healthy, and holds nothing.
+
+```
+labels present:        pod, service_name, stream
+service_name values:   ["unknown_service"]      ← its own canary
+pod values:            (none)
+log-shipper DaemonSets: 0
+```
+
+**Nothing ships container logs to it.** Grafana has a Loki datasource that
+returns nothing useful; Loki consumes storage to hold its own test traffic.
+
+This is the other half of the alerting work. `PLAN-002` means you now find out
+*that* something is wrong. Without logs, the next step is `kubectl logs` against a
+pod that may have already been replaced — and a crash-looping container's previous
+logs are exactly the ones you need and the first ones to disappear.
+
+## Decision: Grafana Alloy
+
+Settled in the investigation and not re-opened here. **Promtail reached
+end-of-life on 2 March 2026**, so it is not a candidate. Alloy is its successor
+and a vendor-neutral OTel Collector distribution.
+
+⚠️ **Scope: logs only.** Alloy *can* also replace the standalone OTel Collector,
+taking the stack from five components to four, and the investigation notes this.
+This plan deliberately does not do that. The collector currently carries the
+metrics remote-write path into Prometheus, which is working; replacing it in the
+same change as introducing log collection means two failure domains in one step,
+and a regression in either would be hard to attribute. Consolidation is a
+follow-up, once logs are known good.
+
+---
+
+## Phase 1: Collect
+
+### Tasks
+
+- [x] 1.1 Deploy Alloy as a **DaemonSet** ✓ — logs are per-node, so it must run
+      where the containers do
+- [x] 1.2 Discover pods via the Kubernetes API and tail their container logs ✓
+- [x] 1.3 Write to the existing Loki gateway ✓
+- [x] 1.4 Image pinned to `v1.13.1` ✓
+- [x] 1.5 Requests 100m/128Mi, matching the collector ✓
+
+### Validation
+
+✅ **Done.** Before: Loki held only `service_name=unknown_service` and no `pod`
+values. After: nine real namespaces — `ai`, `authentik`, `csi-proxmox`,
+`default`, `external-secrets`, `kube-system`, `monitoring`, `tailscale`,
+`temporal` — and `{namespace="ai",container="litellm"}` returns that container's
+log lines.
+
+⚠️ **One anomaly, unexplained and recorded rather than rationalised.** A line
+reading `failed to create fsnotify watcher: too many open files` appeared in Loki
+labelled `container=litellm`. That container's own logs contain zero occurrences,
+it has zero restarts and no previous instance, Alloy's own logs contain none
+either, and the node's inotify usage is 1 of 128 instances — so nothing is
+actually exhausted. Where the line came from is not established. It has not
+recurred. Worth watching, and worth not inventing a cause for.
+
+---
+
+## Phase 2: Labels that make logs findable
+
+Labels are the whole ergonomics of Loki. Get them wrong and you have a very
+expensive `grep`.
+
+### Tasks
+
+- [x] 2.1 Labelled with `namespace`, `pod`, `container`, `node`, `app` ✓
+- [x] 2.2 ⚠️ **No high-cardinality labels** ✓ — but this took three attempts and
+      is worth recording, because the obvious config is not enough.
+
+      `loki.source.kubernetes` adds `instance` by itself, derived as
+      `<namespace>/<pod>:<container>`. It embeds the pod name, so every deploy
+      mints a new label value and the index grows without bound — precisely what
+      this task forbids, arriving by default.
+
+      Adding relabel rules does **not** help: they add labels, they do not remove
+      the ones the source supplies. `stage.label_drop` in the process pipeline
+      did **not** work either (verified — `instance` was still present in streams
+      written afterwards), because the source sets it outside that label set.
+
+      What works is blanking it at the target level, where an empty replacement
+      drops the label:
+
+      ```
+      rule {
+        target_label = "instance"
+        replacement  = ""
+      }
+      ```
+
+      Confirmed by querying `/labels` over a 90-second window containing only
+      post-fix data.
+- [x] 2.3 Raw log line kept as the message ✓
+
+### Validation
+
+`{namespace="ai", container="litellm"}` selects exactly that container's logs.
+
+---
+
+## Phase 3: Retention, honestly
+
+### Tasks
+
+- [ ] 3.1 Confirm what Loki's retention actually is once real volume arrives.
+      It is currently `24h`, which was set when Loki held nothing
+- [ ] 3.2 ⚠️ **Decide whether 24h is enough.** An alert that fires overnight and
+      is looked at the next evening may be looking for logs that have already
+      been deleted. Retention shorter than the time between failure and
+      investigation makes the whole pipeline decorative
+- [ ] 3.3 Check the volume against the disk before extending it. Retention is
+      time-based with **no size cap** (`retentionSize` appears nowhere), so a
+      busy day can fill the disk before the window elapses
+
+### Validation
+
+Measured log volume per day, and a retention window justified against it rather
+than guessed.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uis stack install observability` results in logs from every namespace
+      being queryable in Grafana, with no manual steps
+- [ ] Label values include real workloads, not only `unknown_service`
+- [ ] No high-cardinality labels
+- [ ] Retention is a decision, with the numbers written down
+- [ ] The metrics pipeline through the OTel Collector still works — verified, not
+      assumed, because this change lands next to it
+
+---
+
+## Implementation Notes
+
+**This is a greenfield install, not a Promtail migration.** UIS has no Promtail
+to convert — that absence *is* OBS-F2.
+
+**Alloy emits different metrics from Promtail or the collector.** Any dashboard or
+alert built on collector metrics will need updating. Nothing in
+`PLAN-002`'s rule set depends on them today, which is worth keeping true.
+
+**Logs are the diagnosis half, not the detection half.** Detection is
+`PLAN-002` and the external watchdog. It is worth being clear about which problem
+each component solves, because a stack that collects everything and alerts on
+nothing is where this platform started.
+
+---
+
+## Files to Modify
+
+- `manifests/` — Alloy helm values
+- `ansible/playbooks/` — a setup playbook, and registration in the observability stack
+- `provision-host/uis/services/observability/` — the service definition
+- `website/docs/services/observability/` — a page for it, and the stack overview

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-002-alert-baseline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-002-alert-baseline.md
@@ -27,9 +27,25 @@ before things break**, not one that records that they did.
 ## Problem
 
 ```
-PrometheusRules across the cluster:  0
-Alertmanager pods running:           1
+alerting_rules.yml in the prometheus-server ConfigMap:  {}      ← literally empty
+Alertmanager pods running:                             1
+Alertmanager present as a scrape target:               NO
 ```
+
+⚠️ **Two corrections to how this was measured** (2026-08-11):
+
+**There is no prometheus-operator.** UIS deploys the community `prometheus` chart,
+not `kube-prometheus-stack`, so `monitoring.coreos.com` CRDs do not exist — 0 of
+them. `kubectl get prometheusrule -A` returns 0 and always will, whatever rules
+are configured. Rules live in the `prometheus-server` ConfigMap key
+`alerting_rules.yml`, set from `serverFiles.alerting_rules.yml` in
+`manifests/030-prometheus-config.yaml`. The investigation's "no alert rules" was
+right; the way to check it was not.
+
+**Alertmanager is not scraped**, so `alertmanager_notifications_failed_total` does
+not exist. The component whose job is to tell you things are broken is the one
+component nobody is watching. Fixing that is a prerequisite for task 1.5, not a
+detail.
 
 **Alertmanager is deployed, healthy, and evaluating nothing.** Every metric is
 collected and stored; nothing looks at any of it until a human opens Grafana.
@@ -129,10 +145,11 @@ separate from "a disk is filling" (the other channel) without any configuration.
 - [ ] 1.4 Group and throttle: `group_by` on alertname + namespace, `group_wait`
       ~30s, `repeat_interval` ~4h, so a broad failure is one notification and not
       forty
-- [ ] 1.5 ⚠️ **Alert on Alertmanager's own delivery failures.** Uptime Kuma was
-      found to make a single delivery attempt with no retry, losing a real alert to
-      a transient timeout. Assume this one can fail too and make that visible —
-      `alertmanager_notifications_failed_total` is the signal
+- [ ] 1.5 ⚠️ **Add Alertmanager as a scrape target first — it is not one today**,
+      which is why `alertmanager_notifications_failed_total` does not exist. Then
+      alert on it. Uptime Kuma was found to make a single delivery attempt with no
+      retry, losing a real alert to a transient timeout; assume Alertmanager can
+      fail the same way. Until it is scraped, a silent notifier is invisible
 
 ### Validation
 
@@ -174,7 +191,20 @@ sleeping-Mac monitors taught.
 ### Validation
 
 ```bash
-kubectl get prometheusrule -A          # non-zero, which is the whole point
+# NOT `kubectl get prometheusrule` - there is no operator, so that is always 0.
+kubectl get cm prometheus-server -n monitoring \
+  -o jsonpath='{.data.alerting_rules\.yml}' | head    # must not be "{}"
+```
+
+Metrics the rules depend on were confirmed present before writing them, so none
+is an alert that can never fire:
+
+```
+kube_pod_container_status_restarts_total  57    kubelet_volume_stats_used_bytes  14
+kube_pod_status_ready                    132    node_filesystem_avail_bytes       5
+kube_node_status_condition                12    node_memory_MemAvailable_bytes    1
+kube_deployment_status_replicas_unavailable 31  up                               18
+prometheus_config_last_reload_successful   1    alertmanager_notifications_failed_total  ABSENT
 ```
 
 Stop a deployment; a firing alert is visible in Alertmanager within ~2 minutes and
@@ -243,8 +273,8 @@ alert would have helped.
 
 ## Files to Modify
 
-- `manifests/` — a `PrometheusRule` for the baseline group
-- `manifests/` — Alertmanager configuration with the chosen native receiver
+- `manifests/030-prometheus-config.yaml` — `serverFiles.alerting_rules.yml` for
+  the baseline group, an Alertmanager scrape job, and `alertmanager.config`
 - `ansible/playbooks/` — the prometheus setup playbook, to apply both
 - `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template`
   — credentials for the chosen receiver

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-002-alert-baseline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-002-alert-baseline.md
@@ -4,7 +4,7 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Backlog
+## Status: Active — deployed and delivering on the reference installation; 48h quiet period running
 
 **Goal**: `uis stack install observability` produces a platform that **tells you
 before things break**, not one that records that they did.
@@ -135,17 +135,16 @@ separate from "a disk is filling" (the other channel) without any configuration.
 
 ### Tasks
 
-- [ ] 1.1 Route Alertmanager through a **natively supported** receiver — no
-      translator, no webhook shim
-- [ ] 1.2 Credentials from `urbalurba-secrets`. Absent ⇒ rules still deploy,
-      delivery is skipped, and the deploy **says so loudly** rather than being
-      quietly silent
-- [ ] 1.3 Keep it distinct from the watchdog's channel, so an
-      "everything-is-unreachable" alert cannot be lost among routine ones
-- [ ] 1.4 Group and throttle: `group_by` on alertname + namespace, `group_wait`
-      ~30s, `repeat_interval` ~4h, so a broad failure is one notification and not
-      forty
-- [ ] 1.5 ⚠️ **Add Alertmanager as a scrape target first — it is not one today**,
+- [x] 1.1 Telegram, native ✓ — no translator, no webhook shim
+- [x] 1.2 Credentials from `urbalurba-secrets` ✓. Absent ⇒ rules still deploy,
+      delivery is skipped, and the deploy warns. The token goes into a **Secret**,
+      never the values file — `alertmanager.config` renders into a ConfigMap, and
+      `bot_token_file` (verified supported) keeps it out of there
+- [x] 1.3 Distinct from the watchdog's ntfy channel ✓
+- [x] 1.4 Grouped and throttled ✓ — `group_by` alertname+namespace, `group_wait`
+      30s, `repeat_interval` 4h and 1h for critical
+- [x] 1.5 ✓ **Alertmanager added as a scrape target** (`up{job="alertmanager"} 1`)
+      and alerted on. It was not one before,
       which is why `alertmanager_notifications_failed_total` does not exist. Then
       alert on it. Uptime Kuma was found to make a single delivery attempt with no
       retry, losing a real alert to a transient timeout; assume Alertmanager can
@@ -167,25 +166,25 @@ sleeping-Mac monitors taught.
 
 ### Tasks
 
-- [ ] 2.1 **Capacity, with warning time** — the whole point of this plan:
+- [x] 2.1 **Capacity, with warning time** ✓ — the whole point of this plan:
       - PVC above 85% `for: 10m`, and separately **predicted full within 24h**
         (`predict_linear`), which is the one that gives you a working day's notice
       - node filesystem above 85%
       - node memory pressure
-- [ ] 2.2 **Workload health**:
+- [x] 2.2 **Workload health** ✓:
       - pod crash-looping (`kube_pod_container_status_restarts_total` rate)
       - pod not ready `for: 15m` — long enough to ignore ordinary rollouts
       - deployment replicas unavailable `for: 15m`
       - node not ready `for: 5m`
-- [ ] 2.3 **The stack itself**: `up == 0` for any scrape target, and
+- [x] 2.3 **The stack itself** ✓: `up == 0` for any scrape target, and
       Prometheus/Alertmanager config-reload failures. A monitoring stack that has
       stopped scraping must say so; that is this plan's own version of *absence
       renders as green*
-- [ ] 2.4 **Certificate expiry** — within 14 days. Cheap, and it removes a whole
-      class of self-inflicted outage
-- [ ] 2.5 Every rule carries `summary`, `description` and a **runbook hint**. An
+- [ ] 2.4 **Certificate expiry** — NOT DONE. No cert metrics are collected today;
+      needs a blackbox/cert exporter first, so it is not a rule but a scrape target
+- [x] 2.5 Every rule carries `summary`, `description` and a **runbook hint**. An
       alert that does not say what to do is a puzzle delivered at 3am
-- [ ] 2.6 Severity split: `warning` (has slack — fix in hours) vs `critical`
+- [x] 2.6 Severity split: `warning` (has slack — fix in hours) vs `critical`
       (acting now). Only `critical` should be able to wake someone
 
 ### Validation
@@ -234,13 +233,15 @@ Recorded so the boundary is explicit rather than forgotten:
 
 ## Acceptance Criteria
 
-- [ ] `uis stack install observability` yields a non-empty rule set
+- [x] `uis stack install observability` yields a non-empty rule set ✓ — 11 rules, 3 groups
 - [ ] A capacity problem is alerted **before** it becomes an outage
-- [ ] Alerts reach a real device, readable, on a topic separate from the watchdog's
+- [x] Alerts reach a real device, readable, separate from the watchdog ✓ — verified by
+      posting an alert to Alertmanager: `notifications_total{telegram} 1`, all
+      failure counters 0, message received
 - [ ] A missing topic degrades to "rules but no delivery", loudly, never silently
-- [ ] Prometheus failing to scrape raises an alert about itself
+- [x] Prometheus failing to scrape raises an alert about itself ✓
 - [ ] 48 hours of normal operation produces **zero** alerts needing no action
-- [ ] Every alert states what to do about it
+- [x] Every alert states what to do about it ✓
 
 ---
 

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-002-alert-baseline.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-002-alert-baseline.md
@@ -1,0 +1,253 @@
+# Baseline alert rules, and somewhere for them to go
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: `uis stack install observability` produces a platform that **tells you
+before things break**, not one that records that they did.
+
+**Investigation**: [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md)
+— finding **OBS-F1**, re-verified 2026-08-10 and unchanged
+
+**Related**:
+- [PLAN-service-uptime-kuma-003-alerting](./PLAN-service-uptime-kuma-003-alerting.md)
+  — the external watchdog's alerting, already shipped. This is its in-cluster
+  counterpart. It deliberately does **not** share the same channel; see Phase 1
+- [PLAN-system-observability-001-log-collection](./INVESTIGATE-system-observability.md)
+  — described in the investigation's Part 3, not yet a plan. Deliberately after
+  this one; see Ordering below
+
+**Priority**: High
+
+---
+
+## Problem
+
+```
+PrometheusRules across the cluster:  0
+Alertmanager pods running:           1
+```
+
+**Alertmanager is deployed, healthy, and evaluating nothing.** Every metric is
+collected and stored; nothing looks at any of it until a human opens Grafana.
+
+So today: a disk fills and you learn when it is full. Memory pressure surfaces
+when the OOM killer fires. A pod crash-loops until someone notices the endpoint is
+down. A certificate expires and TLS simply breaks.
+
+The external watchdog ([PLAN-service-uptime-kuma-003](./PLAN-service-uptime-kuma-003-alerting.md))
+already tells you the moment something *is* down. **Nothing tells you something is
+becoming down**, which is the difference between a Tuesday-morning fix and a
+Saturday-night outage.
+
+:::danger This is the dangerous failure mode, not an absent one
+An Alertmanager with zero rules is indistinguishable from one where everything is
+fine. It consumes ~4 GB of RAM to produce silence, and silence is exactly what a
+healthy platform also produces.
+:::
+
+## Ordering: why this comes before log collection
+
+The investigation's Part 3 puts log collection first, on the grounds that Loki is
+decorative without it. That is true. This plan still goes first, deliberately:
+
+| | |
+|---|---|
+| **An alert reaches you.** A log query requires you to already be looking | decisive when the operator is remote or asleep |
+| Alertmanager is **already running and idle** | only rules and routing are missing — the least work for the most coverage |
+| Logs answer *why*; alerts answer *whether* | you can `kubectl logs` after the fact. You cannot recover a notification you never received |
+
+⚠️ **The counter-argument is real and should be revisited**: once applications are
+running, logs and app telemetry matter more than platform alerts do today, and
+retrofitting a pipeline under running apps is worse than having it ready. If
+application work starts before this lands, reorder.
+
+---
+
+## Phase 1: Delivery — somewhere for alerts to go
+
+Rules without a receiver are a dashboard nobody opens. Do this first, so every
+rule added afterwards is immediately verifiable.
+
+### ⚠️ Decided by measurement: use a receiver Alertmanager supports natively
+
+The first draft said "reuse ntfy, it is already proven for the watchdog". **That
+was wrong, and testing it is what showed why.**
+
+Measured on the deployed Alertmanager (`v0.33.1`):
+
+```
+native receivers: discord_configs  msteams_configs  pushover_configs
+                  slack_configs    telegram_configs  webex_configs
+ntfy:             not supported
+```
+
+And ntfy cannot format Alertmanager's payload itself — verified against ntfy.sh:
+
+| Attempt | Result |
+|---|---|
+| POST the webhook JSON as-is | HTTP 200, and the phone receives **raw JSON** |
+| `${.alerts[0]...}` placeholders | delivered **literally**, unsubstituted |
+| `{{...}}` with `X-Template` | **HTTP 400** |
+
+So ntfy would require a bespoke translator sitting in the alert path.
+
+**That is the wrong place for hand-written code.** A translator that dies takes
+alerting with it, and produces *silence* — which is indistinguishable from a
+healthy platform. It would reintroduce, inside the alerting mechanism itself, the
+exact failure this plan exists to remove.
+
+**Principle: never put bespoke code in the path that tells you things are broken.**
+Each tool uses its own native channel — Uptime Kuma has a native ntfy provider and
+keeps using it; Alertmanager uses one of its own.
+
+⚠️ **Needs a decision before implementing**, because it requires an app and an
+account only the operator can create:
+
+| Option | Cost | Setup |
+|---|---|---|
+| **Telegram** *(suggested)* | free | a bot via BotFather, then a chat id |
+| **Pushover** | $5 once, per platform | an account and an app token |
+| Discord / Slack | free | a webhook URL in a server you control |
+
+Two apps on the phone is the price of zero bespoke code in either alert path. It
+also keeps "the platform is unreachable" (ntfy, from the watchdog) visually
+separate from "a disk is filling" (the other channel) without any configuration.
+
+### Tasks
+
+- [ ] 1.1 Route Alertmanager through a **natively supported** receiver — no
+      translator, no webhook shim
+- [ ] 1.2 Credentials from `urbalurba-secrets`. Absent ⇒ rules still deploy,
+      delivery is skipped, and the deploy **says so loudly** rather than being
+      quietly silent
+- [ ] 1.3 Keep it distinct from the watchdog's channel, so an
+      "everything-is-unreachable" alert cannot be lost among routine ones
+- [ ] 1.4 Group and throttle: `group_by` on alertname + namespace, `group_wait`
+      ~30s, `repeat_interval` ~4h, so a broad failure is one notification and not
+      forty
+- [ ] 1.5 ⚠️ **Alert on Alertmanager's own delivery failures.** Uptime Kuma was
+      found to make a single delivery attempt with no retry, losing a real alert to
+      a transient timeout. Assume this one can fail too and make that visible —
+      `alertmanager_notifications_failed_total` is the signal
+
+### Validation
+
+Fire a deliberately-true rule (`vector(1) > 0`). A **readable** notification
+arrives on a real device — not raw JSON, not a literal template placeholder, not
+nothing. All three of those were observed while choosing the receiver.
+
+---
+
+## Phase 2: Rules that earn their place
+
+Every rule must answer *"what would I do about this?"*. Anything that cannot is
+noise, and noise trains people to ignore alerts — the same lesson the watchdog's
+sleeping-Mac monitors taught.
+
+### Tasks
+
+- [ ] 2.1 **Capacity, with warning time** — the whole point of this plan:
+      - PVC above 85% `for: 10m`, and separately **predicted full within 24h**
+        (`predict_linear`), which is the one that gives you a working day's notice
+      - node filesystem above 85%
+      - node memory pressure
+- [ ] 2.2 **Workload health**:
+      - pod crash-looping (`kube_pod_container_status_restarts_total` rate)
+      - pod not ready `for: 15m` — long enough to ignore ordinary rollouts
+      - deployment replicas unavailable `for: 15m`
+      - node not ready `for: 5m`
+- [ ] 2.3 **The stack itself**: `up == 0` for any scrape target, and
+      Prometheus/Alertmanager config-reload failures. A monitoring stack that has
+      stopped scraping must say so; that is this plan's own version of *absence
+      renders as green*
+- [ ] 2.4 **Certificate expiry** — within 14 days. Cheap, and it removes a whole
+      class of self-inflicted outage
+- [ ] 2.5 Every rule carries `summary`, `description` and a **runbook hint**. An
+      alert that does not say what to do is a puzzle delivered at 3am
+- [ ] 2.6 Severity split: `warning` (has slack — fix in hours) vs `critical`
+      (acting now). Only `critical` should be able to wake someone
+
+### Validation
+
+```bash
+kubectl get prometheusrule -A          # non-zero, which is the whole point
+```
+
+Stop a deployment; a firing alert is visible in Alertmanager within ~2 minutes and
+arrives on the device.
+
+⚠️ **Then leave it alone for 48h and count false alarms.** A rule set that pages
+for normal operation is worse than none. If something fires that needed no action,
+it is a defect in this plan, not in the platform.
+
+---
+
+## Phase 3: Deliberately not here
+
+Recorded so the boundary is explicit rather than forgotten:
+
+- **Backup freshness** — "last successful backup older than N hours" is arguably
+  the single most valuable alert a self-hosted platform can have, and nothing
+  produces it. It belongs to `PLAN-004-external-targets` because the signal comes
+  from outside the cluster. **The external watchdog already covers this** via push
+  heartbeats, so it is not a live gap — but it will need reconciling so the two do
+  not both page for the same thing
+- **Per-service rules** (`postgresql` connection saturation, `redis` evictions) —
+  `PLAN-003-service-dashboards`, shipped with each service
+- **Log-based alerting** — needs `PLAN-001-log-collection` first
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uis stack install observability` yields a non-empty rule set
+- [ ] A capacity problem is alerted **before** it becomes an outage
+- [ ] Alerts reach a real device, readable, on a topic separate from the watchdog's
+- [ ] A missing topic degrades to "rules but no delivery", loudly, never silently
+- [ ] Prometheus failing to scrape raises an alert about itself
+- [ ] 48 hours of normal operation produces **zero** alerts needing no action
+- [ ] Every alert states what to do about it
+
+---
+
+## Implementation Notes
+
+**Each tool uses its native channel.** The tempting design was one notification
+technology for everything. Measurement killed it: Alertmanager has no ntfy
+receiver, and ntfy cannot format Alertmanager's payload, so unifying them means
+writing a translator and placing it in the alert path. A component whose failure
+produces silence does not belong there. Two apps, both driven by upstream-tested
+code, beats one app plus a bespoke hop.
+
+**Prefer `predict_linear` over a static threshold for disks.** "85% full" tells you
+where you are; "full in 6 hours" tells you whether to care. On this installation
+the pools are at 5% and 18%, which is exactly when to add the rule — a threshold
+added while something is already full is an incident report, not monitoring.
+
+**`for:` durations are the difference between alerting and noise.** A pod not
+ready for 15 seconds is a deployment. For 15 minutes it is a problem. Every rule
+here needs a duration chosen on that basis, and the 48h quiet period in Phase 2 is
+what proves the choices.
+
+**Do not adopt a large upstream rule bundle wholesale.** `kube-prometheus-stack`
+ships ~100 rules tuned for large multi-tenant clusters; on a single-node k3s many
+are meaningless or permanently firing, and a permanently-firing alert is a muted
+alert. Start with the list above, add rules when something actually breaks and the
+alert would have helped.
+
+---
+
+## Files to Modify
+
+- `manifests/` — a `PrometheusRule` for the baseline group
+- `manifests/` — Alertmanager configuration with the chosen native receiver
+- `ansible/playbooks/` — the prometheus setup playbook, to apply both
+- `provision-host/uis/templates/secrets-templates/00-master-secrets.yml.template`
+  — credentials for the chosen receiver
+- `provision-host/uis/templates/secrets-templates/00-common-values.env.template`
+- `website/docs/services/observability/prometheus.md` — what alerts exist, how to
+  add one, how to silence one

--- a/website/docs/ai-developer/plans/backlog/PLAN-system-observability-004-external-targets.md
+++ b/website/docs/ai-developer/plans/backlog/PLAN-system-observability-004-external-targets.md
@@ -1,0 +1,173 @@
+# Monitor the components that are not in the cluster
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active — Phase 1 done on the reference installation; Phases 2–4 open
+
+**Goal**: The parts of a production install that live outside Kubernetes — the
+hypervisor, an external database, object storage — are visible in metrics, not
+just as an up/down dot.
+
+**Investigation**: [INVESTIGATE-system-observability](./INVESTIGATE-system-observability.md)
+— finding **OBS-F4**
+
+**Related**:
+- [PLAN-system-observability-002-alert-baseline](./PLAN-system-observability-002-alert-baseline.md)
+  — shipped. Its capacity rules are written against `node_*` metrics and will
+  cover these hosts automatically once they are scraped
+- [PLAN-system-dependencies-shim-services](./PLAN-system-dependencies-shim-services.md)
+  — the same "declare what is outside" problem, for reachability rather than metrics
+
+**Priority**: High for production installs, irrelevant for a laptop
+
+---
+
+## Problem
+
+Prometheus scrapes eight jobs, all inside the cluster. Everything the cluster
+*depends on* is invisible to it:
+
+| Component | Metrics today |
+|---|---|
+| The hypervisor host | none — no exporter installed |
+| External PostgreSQL | none |
+| External object storage | none |
+| The vault, the registry cache, the NAS | none |
+
+The external watchdog answers *"is it answering?"* for these. Nothing answers
+*"is it about to stop answering?"*.
+
+**This is the wrong way round for a self-hosted platform.** The in-cluster
+workloads are replaceable; the ZFS pool holding every volume is not. On the
+reference installation that pool moved from 5% to 9% during a single day's work,
+and nothing would have said a word about it at 95%.
+
+⚠️ For a developer on Rancher Desktop there is nothing outside the cluster, and
+this plan is a no-op. It is production-only, which is exactly why it was the last
+gap to be noticed.
+
+---
+
+## Phase 1: The hypervisor host
+
+Highest value, because everything else runs on it.
+
+### Tasks
+
+- [x] 1.1 `prometheus-node-exporter` installed ✓
+- [x] 1.2 ⚠️ **Bound to the backplane, not `0.0.0.0`** ✓ — verified both ways:
+      `200` from the backplane, connection refused from the LAN.
+
+      This needed two attempts, and the failed one is the interesting part. A
+      systemd drop-in setting `Environment=ARGS=...` was **silently overridden**
+      by the packaged unit's `EnvironmentFile=/etc/default/prometheus-node-exporter`,
+      which sets `ARGS=""`. The service came up healthy, served metrics, and
+      listened on `*:9100` — handing a full inventory of the host to every device
+      on the LAN while looking entirely correct. Set it in the packaged defaults
+      file instead of fighting the unit.
+- [x] 1.3 Scraped over the backplane ✓ — monitoring traffic cannot leave the
+      hypervisor and depends on nothing hosted
+- [x] 1.4 ZFS collector active ✓ — 687 `node_zfs_*` series, and `/tank` reports
+      874 GB available
+
+### Validation
+
+✅ **Done.** `up{job="external-hosts"} = 1`, and the rules cover it with **zero
+changes**:
+
+```
+job=kubernetes-service-endpoints   filesystems evaluated:  3
+job=external-hosts                 filesystems evaluated: 15
+```
+
+`predict_linear` on the pool returns 873.4 GB free in 24h — no concern today,
+which is the right time to have the forecast rather than the wrong one.
+
+---
+
+## Phase 2: A declared list, not a hand-edited config
+
+### Tasks
+
+- [ ] 2.1 External targets come from `.uis.extend`, rendered into the Prometheus
+      scrape config — the same shape as `.uis.extend/monitors.yaml` for the
+      watchdog, so there is one idea to learn rather than two
+- [ ] 2.2 Absent ⇒ nothing extra is scraped, and a stock install is unaffected
+- [ ] 2.3 Each entry carries a `why:`, for the same reason monitors do
+
+### Validation
+
+A stock install behaves identically. The reference installation's targets are
+declared in one file, not embedded in helm values.
+
+---
+
+## Phase 3: The data services
+
+### Tasks
+
+- [ ] 3.1 `postgres_exporter` for an external PostgreSQL — connection saturation,
+      replication lag, transaction age
+- [ ] 3.2 Object storage: most S3 implementations expose Prometheus metrics
+      natively, so this is a scrape target rather than an exporter
+- [ ] 3.3 ⚠️ Credentials for exporters come from `urbalurba-secrets`, never from
+      the scrape config, which lands in a ConfigMap
+
+### Validation
+
+Grafana shows database and storage health for components the cluster does not run.
+
+---
+
+## Phase 4: Backup freshness — and reconciling it with the watchdog
+
+The investigation calls "last successful backup older than N hours" the single
+most valuable alert a self-hosted platform can have.
+
+### Tasks
+
+- [ ] 4.1 ⚠️ **Check what already covers this before building anything.** On the
+      reference installation the external watchdog already has push heartbeats
+      for every backup job, wired to fire only after each job's own success
+      check. That is arguably a *better* signal than a metric, because it proves
+      the job ran rather than that a file exists
+- [ ] 4.2 Decide deliberately: either the watchdog owns backup freshness and this
+      plan does not duplicate it, or metrics own it and the heartbeats are
+      retired. **Not both** — two systems paging for the same failure is how
+      people learn to ignore one of them
+- [ ] 4.3 Whichever wins, document which one owns it
+
+### Validation
+
+Exactly one system alerts when a backup stops. Verified by stopping one.
+
+---
+
+## Acceptance Criteria
+
+- [x] The hypervisor's disk and memory are visible in Grafana ✓
+- [x] Pool capacity trends, so `predict_linear` can warn before it is full ✓
+- [x] `PLAN-002`'s existing rules cover external hosts with no rule changes ✓
+- [x] Host metrics are **not** exposed to the LAN ✓ — verified by trying
+- [ ] External targets are declared in `.uis.extend`, not helm values
+- [ ] A stock install scrapes nothing extra
+- [ ] Exactly one system owns backup-freshness alerting
+
+---
+
+## Implementation Notes
+
+**Reuse the alert rules rather than writing host-specific ones.** `PLAN-002`'s
+capacity rules already match on `node_filesystem_*` without a cluster-specific
+selector. If adding a host requires new rules, the original rules were written
+too narrowly and that is worth fixing instead.
+
+**Binding matters more than it looks.** A node exporter on `0.0.0.0:9100` hands
+every device on the network a detailed inventory of the host. The backplane
+already exists for exactly this class of traffic.
+
+**Do not scrape the hypervisor's management API for capacity.** It reports what
+the hypervisor thinks; the node exporter reports what the kernel sees. When those
+disagree the kernel is right, and disagreement is itself the interesting case.


### PR DESCRIPTION
No new investigation — `INVESTIGATE-system-observability` already covers this with measured findings and proposes five ordered plans. Its **OBS-F1 re-verified 2026-08-10, unchanged**:

```
PrometheusRules:        0     ← nothing evaluated
alertmanager pods:      1     ← running, idle
log-shipper daemonsets: 0
11 components, ~4 GB RAM producing silence
```

This turns Part 3's `PLAN-002` into a real plan.

## It reorders the investigation, deliberately

The investigation puts log collection first. This puts alerting first: **an alert reaches you; a log query requires you to already be looking** — decisive when the operator is remote. Alertmanager is already running and idle, so only rules and routing are missing.

The counter-argument is recorded in the plan: once applications run, logs matter more, and if application work starts first the order should change.

## The receiver question, closed by measurement

The investigation left it open. **My first draft of this plan answered it wrongly** — "reuse ntfy, it already works for the watchdog."

Then I tested it:

| Attempt | Result |
|---|---|
| Alertmanager `v0.33.1` native receivers | discord, msteams, pushover, slack, telegram, webex — **no ntfy** |
| POST the webhook JSON to ntfy as-is | HTTP 200, phone receives **raw JSON** |
| `${.alerts[0]...}` placeholders | delivered **literally** |
| `{{...}}` with `X-Template` | **HTTP 400** |

So unifying on ntfy requires a bespoke translator **in the alert path**.

> A component whose failure produces silence does not belong in the path that tells you things are broken.

That would reintroduce, inside the alerting mechanism itself, the exact failure mode this plan exists to remove. Each tool now uses its own native channel: Uptime Kuma keeps ntfy (it has a native provider), Alertmanager uses one of its own.

## Needs your decision

All three need an account only you can create:

| Option | Cost | Setup |
|---|---|---|
| **Telegram** (suggested) | free | bot via BotFather + chat id |
| Pushover | $5 once | account + app token |
| Discord / Slack | free | webhook URL |

Two apps on the phone is the price of zero bespoke code in either alert path.

## Carries forward a hard-won lesson

Uptime Kuma was found to make **one** delivery attempt with no retry, losing a real alert to a transient timeout. This plan assumes Alertmanager can fail the same way and alerts on `alertmanager_notifications_failed_total`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XBLTnL8Xmbb1vLGBNoUsR